### PR TITLE
Add `by-row` and `by-column` properties

### DIFF
--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -143,6 +143,16 @@
   applicability: mtr
   effect: indicates that the row continues an equation wrapped from the row above
 
+- property: by-row
+  type: table
+  applicability: mtable
+  effect: indicates that the table should be read row by row
+
+- property: by-column
+  type: table
+  applicability: mtable
+  effect: indicates that the table should be read column by column
+
 
 - property: number-set
   type: mathematical-category

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -64,6 +64,8 @@ defaultfixity:
          characters: [×]
        - concept: defined-as
          characters: ["≝", "=", "≔"]
+       - concept: dimensional-product
+         characters: [×]
        - concept: divided-by
          characters: [/, ÷, ":"]
        - concept: divides
@@ -1005,6 +1007,14 @@ concepts:
       default: false
       en: "transpose of $1"
       fr: "transposée de $1"
+
+    - concept: dimensional-product
+      arity: "*"
+      property: infix
+      default: false
+      en: "$1 by $2"
+      comment: "This is typically used with the `×` operator and can be placed on that character as a 0-arity concept name.
+                A common use would be describe the size of a matrix. For example <math><mi>m</mi><mo>×</mo><mi>n</mi></math>."
 
 
     ## ====================== 4.4.10 Constants and Sets ======================


### PR DESCRIPTION
Add `by-row` and `by-column` properties per Math WG meeting 16 May.

Add `dimensional-product` per Math WG meeting 16 May. 
@davidcarlisle: I added this to both the character list and linear algebra sections. It would be good to be able to link the character list name to the linear algebra entry. If that's possible, can you add it?