### PR TITLE
Unify format of core and open concept lists

### DIFF
--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6101,7 +6101,7 @@ concepts:
       property: indexed fenced
       area: "classical mechanics"
       comments:
-       - "<math><msub><mrow><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi></mrow><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
+       - "<math><msub><mrow><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi><mo>]</mo></mrow><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeBracket.html"
        - "https://en.wikipedia.org/wiki/Lagrange_bracket"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6096,7 +6096,7 @@ concepts:
       property: indexed fenced
       area: "classical mechanics"
       comments:
-       - "<math><msub><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi><mo></msub><mrow><mi>p</mi>,</mo><mi>q</mi></mrow></msub></math>"
+       - "<math><msub><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi></msub><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeBracket.html"
        - "https://en.wikipedia.org/wiki/Lagrange_bracket"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9133,10 +9133,12 @@ concepts:
     
     - concept: scalar-triple-product
       arity: 3
-      en: scalar triple product  of $1, $2 and $3
+      en: scalar-triple product  of $1, $2 and $3
       property: mixfix<br/>fenced
       area: "vector algebra"
-      notation: "mrow $1 ⋅ ( $2 × $3 )<br/>mrow [ $1 , $2 , $3 ]"
+      comments:
+       - "<math><mi>A</mi><mo>&cdot;</mo>(mrow><mo>(</mo><mi>B</mi><mo>&cdot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
+       - "<math>mo>[</mo><mi>A</mi><mo>,</mo>(mrow><mi>B</mi><mo>,</mo><mi>C</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ScalarTripleProduct.html"
        - "https://en.wikipedia.org/wiki/Triple_product"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9136,7 +9136,7 @@ concepts:
       en: scalar-triple product  of $1, $2 and $3
       property: mixfix<br/>fenced
       area: "vector algebra"
-      comments:
+      comment:
        - "<math><mi>A</mi><mo>&cdot;</mo>(mrow><mo>(</mo><mi>B</mi><mo>&cdot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
        - "<math>mo>[</mo><mi>A</mi><mo>,</mo>(mrow><mi>B</mi><mo>,</mo><mi>C</mi><mo>]</mo></math>"
       urls: 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -74,7 +74,10 @@ concepts:
       notation: "mo -"
       urls: 
        - "https://en.wikipedia.org/wiki/Additive_inverse"
-      alias: "opposite, sign-change, negation"
+      alias:
+       - opposite
+       - sign-change
+       - negation
     
     - concept: adiabatic-invariant-first
       arity: 0
@@ -131,7 +134,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
        - "https://ncatlab.org/nlab/show/adjoint+action"
        - "https://www.encyclopediaofmath.org/index.php/Adjoint_action"
-      alias: adjoint-endomorphism
+      alias:
+       - adjoint-endomorphism
     
     - concept: adjoint-representation
       arity: 1
@@ -282,7 +286,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/%E2%88%A8"
        - "https://en.wikipedia.org/wiki/Logical_disjunction"
        - "https://www.encyclopediaofmath.org/index.php/Alternation"
-      alias: "disjunction, or"
+      alias:
+       - disjunction
+       - or
     
     - concept: alternative-denial
       arity: 2
@@ -293,7 +299,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/AlternativeDenial.html"
        - "https://en.wikipedia.org/wiki/Sheffer_stroke"
-      alias: "sheffer-stroke, nand"
+      alias:
+       - sheffer-stroke
+       - nand
     
     - concept: amalgam
       arity: 1
@@ -315,7 +323,9 @@ concepts:
        - "https://math.stackexchange.com/questions/828828/amalgamated-product"
        - "https://en.wikipedia.org/wiki/Free_product"
        - "http//home.iiserb.ac.in/~kashyap/Group/thesis_abhay.pdf"
-      alias: "amalgamated-free-product<br/>free-product-with-amalgamation"
+      alias:
+       - amalgamated-free-product
+       - free-product-with-amalgamation
     
     - concept: analytic-manifold
       arity: 0
@@ -414,7 +424,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Antimatter"
        - "https://en.wikipedia.org/wiki/Antiparticle"
-      alias: antimatter
+      alias:
+       - antimatter
     
     - concept: apartness-relation
       arity: 2
@@ -449,7 +460,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/Minute_of_arc"
        - "https://en.wikipedia.org/wiki/Arcsecond"
        - "https://en.wikipedia.org/wiki/Second_(angle)"
-      alias: "minute-arc, minute-of-arc"
+      alias:
+       - minute-arc
+       - minute-of-arc
     
     - concept: arcsecond
       arity: 1
@@ -745,7 +758,8 @@ concepts:
        - "https://dlmf.nist.gov/5.12"
        - "https://dlmf.nist.gov/5.12#E1"
        - "https://ncatlab.org/nlab/show/beta+function"
-      alias: euler-integral-of-the-first-kind
+      alias:
+       - euler-integral-of-the-first-kind
     
     - concept: betti-number
       arity: 1
@@ -768,7 +782,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Biconditional.html"
        - "https://ncatlab.org/nlab/show/biconditional"
-      alias: "iff, if-and-only-if"
+      alias:
+       - iff
+       - if-and-only-if
     
     - concept: big-O
       arity: 1
@@ -820,7 +836,8 @@ concepts:
        - "https://dlmf.nist.gov/1.2#E1"
        - "https://dlmf.nist.gov/26.3#SS1.p1"
        - "https://www.encyclopediaofmath.org/index.php/Binomial_coefficients"
-      alias: combination
+      alias:
+       - combination
     
     - concept: binomial-distribution
       arity: 1
@@ -904,7 +921,9 @@ concepts:
       urls: 
        - "https://ncatlab.org/nlab/show/bottom"
        - "https://en.wikipedia.org/wiki/Bottom_type"
-      alias: "empty-type, bottom"
+      alias:
+       - empty-type
+       - bottom
     
     - concept: bottom-element
       arity: 0
@@ -914,7 +933,9 @@ concepts:
       notation: "mi ⊥"
       urls: 
        - "https://en.wikipedia.org/wiki/Greatest_element_and_least_element"
-      alias: "bottom, least-element"
+      alias:
+       - bottom
+       - least-element
     
     - concept: boundary
       arity: 1
@@ -927,7 +948,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Boundary_(topology)"
        - "https://ncatlab.org/nlab/show/boundary"
        - "https://www.encyclopediaofmath.org/index.php/Boundary"
-      alias: frontier
+      alias:
+       - frontier
     
     - concept: bounded-variation
       arity: 1
@@ -947,7 +969,8 @@ concepts:
       notation: "mo ☐"
       urls: 
        - "https://en.wikipedia.org/wiki/Cartesian_product_of_graphs"
-      alias: cartesian-product
+      alias:
+       - cartesian-product
     
     - concept: brauer-group
       arity: 1
@@ -1028,7 +1051,8 @@ concepts:
        - "https://mathworld.wolfram.com/Cardinality.html"
        - "https://en.wikipedia.org/wiki/Cardinality"
        - "https://www.encyclopediaofmath.org/index.php/Cardinality"
-      alias: size
+      alias:
+       - size
     
     - concept: carmichael-function
       arity: 1
@@ -1175,7 +1199,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Center_(group_theory)"
        - "https://en.wikipedia.org/wiki/Center_(algebra)"
        - "https://ncatlab.org/nlab/show/center"
-      alias: centre
+      alias:
+       - centre
     
     - concept: centralizer
       arity: 1
@@ -1248,7 +1273,8 @@ concepts:
        - "https://ncatlab.org/nlab/show/characteristic+function"
        - "https://www.encyclopediaofmath.org/index.php/Characteristic_function"
        - "https://en.wikipedia.org/wiki/Expected_value#Interchanging_limits_and_expectation"
-      alias: indicator-function
+      alias:
+       - indicator-function
     
     - concept: characteristic-subgroup
       arity: 2
@@ -1282,7 +1308,8 @@ concepts:
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
        - "https://dlmf.nist.gov/18.3#T1.t1.r8"
-      alias: first-chebyshev-function
+      alias:
+       - first-chebyshev-function
     
     - concept: chebyshev-polynomial-of-second-kind
       arity: 1
@@ -1294,7 +1321,8 @@ concepts:
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
        - "https://dlmf.nist.gov/18.3#T1.t1.r11"
-      alias: second-chebyshev-function
+      alias:
+       - second-chebyshev-function
     
     - concept: cheeger-constant
       arity: 1
@@ -1313,7 +1341,9 @@ concepts:
       notation: "mi h"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant_(graph_theory)"
-      alias: "cheeger-constant, isoperimetric-number"
+      alias:
+       - cheeger-constant
+       - isoperimetric-number
     
     - concept: chemical-equilibrium
       arity: 2
@@ -1323,7 +1353,8 @@ concepts:
       notation: "mo ⇌"
       urls: 
        - "https://en.wikipedia.org/wiki/Chemical_equilibrium"
-      alias: equilibrium
+      alias:
+       - equilibrium
     
     - concept: chi-squared-distribution
       arity: 0
@@ -1449,7 +1480,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
        - "https://en.wikipedia.org/wiki/Ball_(mathematics)"
-      alias: closed-metric-ball
+      alias:
+       - closed-metric-ball
     
     - concept: closed-interval
       arity: 2
@@ -1514,7 +1546,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/CofiniteFilter.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_filter"
-      alias: frechet-filter
+      alias:
+       - frechet-filter
     
     - concept: coherence
       arity: 1
@@ -1591,7 +1624,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Derived_series"
        - "https://ncatlab.org/nlab/show/commutator+subgroup"
        - "https://www.encyclopediaofmath.org/index.php/Commutator_subgroup"
-      alias: derived-subgroup
+      alias:
+       - derived-subgroup
     
     - concept: companion-lehmer-number
       arity: 1
@@ -1612,7 +1646,8 @@ concepts:
       notation: "munderover = > <"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
-      alias: comparable
+      alias:
+       - comparable
     
     - concept: complement-of-interval
       arity: 2
@@ -1642,7 +1677,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/CompleteGraph.html"
        - "https://en.wikipedia.org/wiki/Complete_graph"
-      alias: "Also complete bipartite graph: K_{n,m}"
+      alias:
+       - Also complete bipartite graph: K_{n
+       - m}
     
     - concept: complex-conjugate
       arity: 1
@@ -1678,7 +1715,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Complexification"
        - "https://ncatlab.org/nlab/show/complexification"
        - "https://www.encyclopediaofmath.org/index.php/Complexification_of_a_vector_space"
-      alias: complexification-of-vector-space
+      alias:
+       - complexification-of-vector-space
     
     - concept: composition
       arity: 2
@@ -1690,7 +1728,8 @@ concepts:
        - "https://mathworld.wolfram.com/Composition.html"
        - "https://ncatlab.org/nlab/show/composition"
        - "https://www.encyclopediaofmath.org/index.php/Composition"
-      alias: compose
+      alias:
+       - compose
     
     
     
@@ -1771,7 +1810,8 @@ concepts:
       notation: "D ( $1 | $2)"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(statistics)"
-      alias: divergence
+      alias:
+       - divergence
     
     - concept: configuration
       arity: 4
@@ -1798,7 +1838,10 @@ concepts:
        - "https://en.wikipedia.org/wiki/Congruence_(geometry)"
        - "https://ncatlab.org/nlab/show/congruence"
        - "https://www.encyclopediaofmath.org/index.php/Congruence"
-      alias: "congruence,<br/>congruent"
+      alias:
+       - congruence
+       - 
+       - congruent
     
     - concept: conjugacy-class
       arity: 1
@@ -1863,7 +1906,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Encompassment_ordering"
        - "https://en.wikipedia.org/wiki/Subset"
        - "https://en.wikipedia.org/wiki/%E2%8A%83"
-      alias: encompassment
+      alias:
+       - encompassment
     
     - concept: contingency-table
       arity: 1
@@ -1874,7 +1918,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/ContingencyTable.html"
        - "https://en.wikipedia.org/wiki/Contingency_table"
-      alias: two-way-frequency-table
+      alias:
+       - two-way-frequency-table
     
     - concept: continued-fraction
       arity: 1
@@ -1888,7 +1933,10 @@ concepts:
        - "https://dlmf.nist.gov/1.12#i"
        - "https://ncatlab.org/nlab/show/continued+fraction"
        - "https://www.encyclopediaofmath.org/index.php/Continued_fraction"
-      alias: "anthyphairetic-ratio,<br/>chain-fraction"
+      alias:
+       - anthyphairetic-ratio
+       - 
+       - chain-fraction
     
     - concept: continuum
       arity: 0
@@ -1924,7 +1972,8 @@ concepts:
       notation: "mo ↓"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
-      alias: convergence
+      alias:
+       - convergence
     
     - concept: converse
       arity: 1
@@ -1934,7 +1983,8 @@ concepts:
       notation: "msup $1 ˘"
       urls: 
        - "https://en.wikipedia.org/wiki/Relation_algebra"
-      alias: reciprocal
+      alias:
+       - reciprocal
     
     - concept: converse-graph
       arity: 1
@@ -1944,7 +1994,9 @@ concepts:
       notation: "msup $1 '<br/>msup $1 T<br/>msup $1 R"
       urls: 
        - "https://en.wikipedia.org/wiki/Transpose_graph"
-      alias: "transpose-graph, reverse-graph"
+      alias:
+       - transpose-graph
+       - reverse-graph
     
     - concept: convolution
       arity: 2
@@ -1957,7 +2009,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/List_of_convolutions_of_probability_distributions"
        - "https://en.wikipedia.org/wiki/Convolution_(computer_science)"
        - "https://en.wikipedia.org/wiki/Convolution"
-      alias: convolve
+      alias:
+       - convolve
     
     - concept: conway-group
       arity: 0
@@ -1981,7 +2034,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Coprime.html"
        - "https://en.wikipedia.org/wiki/Coprime_integers"
-      alias: "relatively-prime, mutually-prime"
+      alias:
+       - relatively-prime
+       - mutually-prime
     
     - concept: coproduct
       arity: 1
@@ -2036,7 +2091,9 @@ concepts:
       notation: "mi g"
       urls: 
        - "https://en.wikipedia.org/wiki/Coupling_constant"
-      alias: "gauge-coupling-parameter, coupling"
+      alias:
+       - gauge-coupling-parameter
+       - coupling
     
     - concept: covariance
       arity: 1
@@ -2071,7 +2128,8 @@ concepts:
       notation: "msub mrow [ $1, $2 ] /mrow $3"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_variation"
-      alias: cross-variance
+      alias:
+       - cross-variance
     
     - concept: covering-relation
       arity: 2
@@ -2094,7 +2152,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Cross_product"
        - "https://ncatlab.org/nlab/show/cross+product"
        - "https://www.encyclopediaofmath.org/index.php/Cross_product"
-      alias: vector-product
+      alias:
+       - vector-product
     
     - concept: cross-ratio
       arity: 4
@@ -2105,7 +2164,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
-      alias: double-ratio
+      alias:
+       - double-ratio
     
     - concept: crossing-number
       arity: 1
@@ -2150,7 +2210,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/CumulativeDistributionFunction.html"
        - "https://en.wikipedia.org/wiki/Cumulative_distribution_function"
-      alias: "cdf, distribution-function"
+      alias:
+       - cdf
+       - distribution-function
     
     - concept: cup-product
       arity: 2
@@ -2250,7 +2312,10 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/D%27Alembert_operator"
        - "https://www.encyclopediaofmath.org/index.php/D'Alembert_operator"
-      alias: "dalembertian, wave-operator, box-operator"
+      alias:
+       - dalembertian
+       - wave-operator
+       - box-operator
     
     - concept: davenport-constant
       arity: 1
@@ -2274,7 +2339,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Dawson_function"
        - "https://dlmf.nist.gov/7.2#ii"
        - "https://dlmf.nist.gov/7.2#E5"
-      alias: dawson-integral
+      alias:
+       - dawson-integral
     
     - concept: decrease
       arity: 1
@@ -2333,7 +2399,9 @@ concepts:
       urls: 
        - "https://math.stackexchange.com/questions/522864/what-is-the-symbol-triangleq"
        - "https://drive.google.com/file/d/1z_dcQ6lsOA_0CsH55fwcg4hQF_w22olM/view"
-      alias: "defined-to-be-equal-to<br/>equal-to-by-definition"
+      alias:
+       - defined-to-be-equal-to
+       - equal-to-by-definition
     
     - concept: degree
       arity: 1
@@ -2356,7 +2424,9 @@ concepts:
       notation: "mi deg"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
-      alias: "valency, degree"
+      alias:
+       - valency
+       - degree
     
     - concept: degree-of-freedom
       arity: 0
@@ -2376,7 +2446,8 @@ concepts:
       notation: "mi deg"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_continuous_mapping"
-      alias: degree
+      alias:
+       - degree
     
     - concept: degree-of-polynomial
       arity: 1
@@ -2386,7 +2457,8 @@ concepts:
       notation: "mi deg"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_polynomial"
-      alias: degree
+      alias:
+       - degree
     
     - concept: dependence-relation
       arity: 2
@@ -2473,7 +2545,8 @@ concepts:
        - "https://mathworld.wolfram.com/DickmanFunction.html"
        - "https://en.wikipedia.org/wiki/Dickman_function"
        - "https://www.encyclopediaofmath.org/index.php/Dickman_function"
-      alias: dickman-de-bruijn-function
+      alias:
+       - dickman-de-bruijn-function
     
     - concept: different-ideal
       arity: 1
@@ -2483,7 +2556,8 @@ concepts:
       notation: "msub δ $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Different_ideal"
-      alias: different
+      alias:
+       - different
     
     - concept: differential-entropy
       arity: 1
@@ -2495,7 +2569,8 @@ concepts:
        - "https://mathworld.wolfram.com/DifferentialEntropy.html"
        - "https://en.wikipedia.org/wiki/Differential_entropy"
        - "https://www.encyclopediaofmath.org/index.php/Differential_entropy"
-      alias: continuous-entropy
+      alias:
+       - continuous-entropy
     
     - concept: differential-operator
       arity: 1
@@ -2508,7 +2583,10 @@ concepts:
        - "https://en.wikipedia.org/wiki/Differential_operator"
        - "https://ncatlab.org/nlab/show/differential+operator"
        - "https://www.encyclopediaofmath.org/index.php/Differential_operator"
-      alias: "newton-leibniz-operator, differential, diff"
+      alias:
+       - newton-leibniz-operator
+       - differential
+       - diff
     
     - concept: digamma-function
       arity: 0
@@ -2551,7 +2629,8 @@ concepts:
        - "https://dlmf.nist.gov/25.12#E1"
        - "https://ncatlab.org/nlab/show/dilogarithm"
        - "https://ncatlab.org/nlab/show/dilogarithm"
-      alias: spence-function
+      alias:
+       - spence-function
     
     - concept: dimension
       arity: 1
@@ -2584,7 +2663,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/DiracDeltaFunction.html"
        - "https://en.wikipedia.org/wiki/Dirac_delta_function"
-      alias: delta-function
+      alias:
+       - delta-function
     
     - concept: dirac-matrix
       arity: 0
@@ -2596,7 +2676,8 @@ concepts:
        - "https://mathworld.wolfram.com/DiracMatrices.html"
        - "https://en.wikipedia.org/wiki/Gamma_matrices"
        - "https://www.encyclopediaofmath.org/index.php/Dirac_matrices"
-      alias: gamma-matrix
+      alias:
+       - gamma-matrix
     
     - concept: dirac-measure
       arity: 1
@@ -2733,7 +2814,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/DirichletL-Function.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_L-function"
-      alias: dirichlet-l-series
+      alias:
+       - dirichlet-l-series
     
     - concept: discrete-valuation
       arity: 1
@@ -2787,7 +2869,8 @@ concepts:
       notation: "mo ↑"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
-      alias: divergence
+      alias:
+       - divergence
     
     - concept: divergence
       arity: 1
@@ -2825,7 +2908,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Divisor"
        - "https://ru.wikipedia.org/wiki/%D0%94%D0%B5%D0%BB%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D1%8C"
        - "https://youtu.be/a3wyG2mkmxc?t=32"
-      alias: divides
+      alias:
+       - divides
     
     
     - concept: divisor-function
@@ -2859,7 +2943,8 @@ concepts:
       notation: "mi 𝔻"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_discourse"
-      alias: universe-of-discourse
+      alias:
+       - universe-of-discourse
     
     - concept: domination-number
       arity: 1
@@ -2884,7 +2969,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/DotProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
-      alias: scalar-product
+      alias:
+       - scalar-product
     
     - concept: double-bond
       arity: 2
@@ -2914,7 +3000,8 @@ concepts:
        - "https://mathworld.wolfram.com/DoubleFactorial.html"
        - "https://en.wikipedia.org/wiki/Double_factorial"
        - "https://arxiv.org/pdf/0806.2334.pdf"
-      alias: semifactorial
+      alias:
+       - semifactorial
     
     - concept: double-mersenne-number
       arity: 0
@@ -2936,7 +3023,8 @@ concepts:
       notation: "mi 𝒵"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(category_theory)"
-      alias: center
+      alias:
+       - center
     
     - concept: dual-basis
       arity: 1
@@ -2949,7 +3037,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/Dual_basis"
        - "https://ncatlab.org/nlab/show/dual+basis"
        - "https://www.encyclopediaofmath.org/index.php/Dual_basis"
-      alias: "dual-set<br/>reciprocal-basis"
+      alias:
+       - dual-set
+       - reciprocal-basis
     
     - concept: dual-bundle
       arity: 1
@@ -2961,7 +3051,8 @@ concepts:
        - "https://mathworld.wolfram.com/DualBundle.html"
        - "https://en.wikipedia.org/wiki/Dual_bundle"
        - "https://www.encyclopediaofmath.org/index.php/Dual_bundle"
-      alias: dual
+      alias:
+       - dual
     
     - concept: dual-space
       arity: 1
@@ -2973,7 +3064,8 @@ concepts:
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
        - "https://ncatlab.org/nlab/show/dual+space"
-      alias: dual
+      alias:
+       - dual
     
     - concept: duodecimal
       arity: 1
@@ -2984,7 +3076,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Duodecimal.html"
        - "https://en.wikipedia.org/wiki/Duodecimal#Base_notation"
-      alias: "base-twelve<br/>dozenal"
+      alias:
+       - base-twelve
+       - dozenal
     
     - concept: e-function
       arity: 1
@@ -3145,7 +3239,9 @@ concepts:
        - "https://mathworld.wolfram.com/Equalizer.html"
        - "https://en.wikipedia.org/wiki/Equaliser_(mathematics)"
        - "https://ncatlab.org/nlab/show/equalizer"
-      alias: "difference-kernel, equaliser"
+      alias:
+       - difference-kernel
+       - equaliser
     
     - concept: equivalence-class
       arity: 1
@@ -3171,7 +3267,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Equivalence_relation"
        - "https://ncatlab.org/nlab/show/equivalence+relation"
        - "https://www.encyclopediaofmath.org/index.php/Equivalence_relation"
-      alias: equivalence
+      alias:
+       - equivalence
     
     - concept: equivariant-cohomology
       arity: 2
@@ -3214,7 +3311,9 @@ concepts:
       notation: "msub ⊆ e<br/>mo ⊴<br/>mo ⊂"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
-      alias: "essential-submodule, large-submodule"
+      alias:
+       - essential-submodule
+       - large-submodule
     
     - concept: essential-infimum
       arity: 1
@@ -3246,7 +3345,9 @@ concepts:
       notation: "mi ℮"
       urls: 
        - "https://en.wikipedia.org/wiki/Estimation"
-      alias: "estimated-sign, e-mark"
+      alias:
+       - estimated-sign
+       - e-mark
     
     - concept: etale-cohomology
       arity: 1
@@ -3277,7 +3378,8 @@ concepts:
       notation: "mi d<br/>msub d $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Euclidean_distance"
-      alias: euclidean-metric
+      alias:
+       - euclidean-metric
     
     - concept: euclidean-plane
       arity: 0
@@ -3287,7 +3389,8 @@ concepts:
       notation: "msup ℝ 2"
       urls: 
        - "https://mathworld.wolfram.com/EuclideanPlane.html"
-      alias: euclidean-space
+      alias:
+       - euclidean-space
     
     - concept: euler-characteristic
       arity: 1
@@ -3324,7 +3427,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant"
        - "https://dlmf.nist.gov/5.2#E3"
        - "https://www.encyclopediaofmath.org/index.php/Euler_constant"
-      alias: euler-mascheroni-constant
+      alias:
+       - euler-mascheroni-constant
     
     - concept: euler-number
       arity: 0
@@ -3340,7 +3444,8 @@ concepts:
        - "https://dlmf.nist.gov/24.2#ii"
        - "https://ncatlab.org/nlab/show/Euler+number"
        - "https://www.encyclopediaofmath.org/index.php/Euler_numbers"
-      alias: napier-constant
+      alias:
+       - napier-constant
     
     - concept: euler-polynomial
       arity: 1
@@ -3363,7 +3468,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/EulerTotientFunction.html"
        - "https://en.wikipedia.org/wiki/Euler%27s_totient_function"
-      alias: totient-function
+      alias:
+       - totient-function
     
     - concept: euler-mascheroni-constant
       arity: 0
@@ -3398,7 +3504,9 @@ concepts:
        - "https://ncatlab.org/nlab/show/exclusive+disjunction"
        - "https://www.encyclopediaofmath.org/index.php/Exclusive_disjunction"
        - "https://en.wikipedia.org/wiki/Exclusive_or"
-      alias: "exclusive-disjunction, xor"
+      alias:
+       - exclusive-disjunction
+       - xor
     
     - concept: expectation-value
       arity: 1
@@ -3419,7 +3527,12 @@ concepts:
       notation: "mi E<br/>mi M<br/>msub μ $1<br/>"
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
-      alias: "mathematical-expectation, expectation, mean, average, first-moment"
+      alias:
+       - mathematical-expectation
+       - expectation
+       - mean
+       - average
+       - first-moment
     
     - concept: exponential-factorial
       arity: 1
@@ -3443,7 +3556,8 @@ concepts:
        - "https://dlmf.nist.gov/6.2#i"
        - "https://dlmf.nist.gov/6.2#E1"
        - "https://dlmf.nist.gov/6.2#SS1.p3"
-      alias: ei
+      alias:
+       - ei
     
     - concept: exterior
       arity: 1
@@ -3483,7 +3597,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/ExteriorProduct.html"
        - "https://www.encyclopediaofmath.org/index.php/Exterior_product"
-      alias: wedge-product
+      alias:
+       - wedge-product
     
     - concept: f-distribution
       arity: 1
@@ -3516,7 +3631,11 @@ concepts:
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/FallingFactorial.html"
        - "https://dlmf.nist.gov/26.1#P1.p1"
-      alias: "descending-factorial, falling-sequential-product, lower-factorial, pochhammer-symbol"
+      alias:
+       - descending-factorial
+       - falling-sequential-product
+       - lower-factorial
+       - pochhammer-symbol
     
     - concept: fatou-set
       arity: 1
@@ -3585,7 +3704,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Fermi%E2%80%93Dirac_distribution"
        - "https://en.wikipedia.org/wiki/Fermi%E2%80%93Dirac_distribution>s"
-      alias: f-d-distribution
+      alias:
+       - f-d-distribution
     
     - concept: feynman-slash
       arity: 1
@@ -3629,7 +3749,10 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Pullback_(category_theory)"
        - "https://www.encyclopediaofmath.org/index.php/Fibre_product"
-      alias: "pullback, fiber-product, cartesian-square"
+      alias:
+       - pullback
+       - fiber-product
+       - cartesian-square
     
     - concept: field-extension
       arity: 2
@@ -3671,7 +3794,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/FisherInformation.html"
        - "https://en.wikipedia.org/wiki/Fisher_information"
-      alias: information
+      alias:
+       - information
     
     - concept: flattening
       arity: 0
@@ -3682,7 +3806,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Flattening.html"
        - "https://en.wikipedia.org/wiki/Flattening"
-      alias: "ellipticity, oblateness"
+      alias:
+       - ellipticity
+       - oblateness
     
     - concept: floor
       arity: 1
@@ -3771,7 +3897,8 @@ concepts:
       notation: "mmultiscripts Ψ q none mprescripts p none"
       urls: 
        - "https://en.wikipedia.org/wiki/Fox%E2%80%93Wright_function"
-      alias: wright-function
+      alias:
+       - wright-function
     
     - concept: fractional-derivative
       arity: 1
@@ -3805,7 +3932,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Fractional_part"
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
        - "https://en.wikipedia.org/wiki/Phase_(waves)"
-      alias: decimal-part
+      alias:
+       - decimal-part
     
     - concept: franel-number
       arity: 1
@@ -3847,7 +3975,9 @@ concepts:
       notation: "msub T 1"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
-      alias: "tikhonov-space, accessible-space"
+      alias:
+       - tikhonov-space
+       - accessible-space
     
     - concept: fredholm-determinant
       arity: 1
@@ -3929,7 +4059,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/FrobeniusNorm.html"
        - "https://www.encyclopediaofmath.org/index.php/Frobenius_matrix_norm"
-      alias: "euclidean-norm, frobenius-matrix-norm"
+      alias:
+       - euclidean-norm
+       - frobenius-matrix-norm
     
     - concept: frolicher-nijenhuis-bracket
       arity: 2
@@ -3949,7 +4081,8 @@ concepts:
       notation: "mrow $1 ≡ $2 (mod $3"
       urls: 
        - "https://mathworld.wolfram.com/FunctionalCongruence.html"
-      alias: identical-congruence
+      alias:
+       - identical-congruence
     
     - concept: functor-category
       arity: 2
@@ -3979,7 +4112,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/G-Function.html"
        - "https://en.wikipedia.org/wiki/Meijer_G-function"
-      alias: meijer-g-function
+      alias:
+       - meijer-g-function
     
     - concept: gabor-transform
       arity: 1
@@ -4024,7 +4158,8 @@ concepts:
        - "https://mathworld.wolfram.com/GaloisField.html"
        - "https://en.wikipedia.org/wiki/Finite_field"
        - "https://www.encyclopediaofmath.org/index.php/Galois_field"
-      alias: finite-field
+      alias:
+       - finite-field
     
     - concept: galois-group
       arity: 1
@@ -4061,7 +4196,8 @@ concepts:
        - "https://dlmf.nist.gov/5#PT2"
        - "https://dlmf.nist.gov/5.2#E1"
        - "https://ncatlab.org/nlab/show/Gamma+function"
-      alias: euler-integral-of-the-second-kind
+      alias:
+       - euler-integral-of-the-second-kind
     
     - concept: gateaux-derivative
       arity: 3
@@ -4074,7 +4210,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/G%C3%A2teaux_derivative"
        - "https://www.encyclopediaofmath.org/index.php/Gateaux_derivative"
        - "https://www.encyclopediaofmath.org/index.php/GÃ¢teaux_derivative"
-      alias: gateaux-differential
+      alias:
+       - gateaux-differential
     
     - concept: gauss
       arity: 1
@@ -4093,7 +4230,10 @@ concepts:
       notation: "mi 𝒩"
       urls: 
        - "https://en.wikipedia.org/wiki/Normal_distribution"
-      alias: "normal-distribution, gauss-distribution, laplace-gauss-distribution"
+      alias:
+       - normal-distribution
+       - gauss-distribution
+       - laplace-gauss-distribution
     
     - concept: gaussian-curvature
       arity: 1
@@ -4211,7 +4351,9 @@ concepts:
        - "https://mathworld.wolfram.com/GeneralizedMean.html"
        - "https://en.wikipedia.org/wiki/Generalized_mean"
        - "https://en.wikipedia.org/wiki/Power_mean"
-      alias: "hoelder-mean, power-mean"
+      alias:
+       - hoelder-mean
+       - power-mean
     
     - concept: genocchi-number
       arity: 0
@@ -4247,7 +4389,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Diameter_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Radius_(graph_theory)"
        - "https://www.encyclopediaofmath.org/index.php/Geodesic_distance"
-      alias: distance
+      alias:
+       - distance
     
     - concept: geometric-genus
       arity: 1
@@ -4310,7 +4453,8 @@ concepts:
        - "https://mathworld.wolfram.com/GlaisherConstant.html"
        - "https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant"
        - "https://dlmf.nist.gov/5.17#E6"
-      alias: glaisher-kinkelin-constant
+      alias:
+       - glaisher-kinkelin-constant
     
     - concept: global-dimension
       arity: 1
@@ -4320,7 +4464,9 @@ concepts:
       notation: "mi gl dim"
       urls: 
        - "https://en.wikipedia.org/wiki/Global_dimension"
-      alias: "global-homological-dimension, homological-dimension"
+      alias:
+       - global-homological-dimension
+       - homological-dimension
     
     - concept: golden-ratio
       arity: 0
@@ -4333,7 +4479,16 @@ concepts:
        - "https://en.wikipedia.org/wiki/Golden_ratio"
        - "https://en.wikipedia.org/wiki/List_of_works_designed_with_the_golden_ratio"
        - "https://www.encyclopediaofmath.org/index.php/Golden_ratio"
-      alias: "golden-number, golden-mean, golden-section, medial-section, divine-proportion, divine-section, golden-proportion, golden-cut,"
+      alias:
+       - golden-number
+       - golden-mean
+       - golden-section
+       - medial-section
+       - divine-proportion
+       - divine-section
+       - golden-proportion
+       - golden-cut
+       - 
     
     - concept: graham-number
       arity: 0
@@ -4365,7 +4520,9 @@ concepts:
        - "https://mathworld.wolfram.com/GramMatrix.html"
        - "https://en.wikipedia.org/wiki/Gramian_matrix"
        - "https://www.encyclopediaofmath.org/index.php/Gram_matrix"
-      alias: "gramian-matrix, gramian"
+      alias:
+       - gramian-matrix
+       - gramian
     
     - concept: grassmannian
       arity: 1
@@ -4444,7 +4601,8 @@ concepts:
        - "https://mathworld.wolfram.com/GudermannianFunction.html"
        - "https://en.wikipedia.org/wiki/Gudermannian_function"
        - "https://dlmf.nist.gov/4.23#E39"
-      alias: gudermannian
+      alias:
+       - gudermannian
     
     - concept: hadamard-product
       arity: 2
@@ -4455,7 +4613,11 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/HadamardProduct.html"
        - "https://en.wikipedia.org/wiki/Hadamard_product_(matrices)"
-      alias: "elementwise-product, entrywise-product,<br/>schur-product"
+      alias:
+       - elementwise-product
+       - entrywise-product
+       - 
+       - schur-product
     
     - concept: hahn-polynomial
       arity: 1
@@ -4501,7 +4663,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy_space"
        - "https://www.encyclopediaofmath.org/index.php/Hardy_classes"
-      alias: hardy-space
+      alias:
+       - hardy-space
     
     - concept: hardy-space
       arity: 1
@@ -4522,7 +4685,8 @@ concepts:
       notation: "mi M"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function"
-      alias: hardy-littlewood-maximal-function
+      alias:
+       - hardy-littlewood-maximal-function
     
     - concept: harmonic-mean
       arity: 1
@@ -4534,7 +4698,8 @@ concepts:
        - "https://mathworld.wolfram.com/HarmonicMean.html"
        - "https://en.wikipedia.org/wiki/Harmonic_mean"
        - "https://en.wikipedia.org/wiki/Subcontrary_mean"
-      alias: subcontrary-mean
+      alias:
+       - subcontrary-mean
     
     - concept: hausdorff-measure
       arity: 1
@@ -4564,7 +4729,8 @@ concepts:
       notation: "msub T 2"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
-      alias: separated-space
+      alias:
+       - separated-space
     
     - concept: hazard-function
       arity: 1
@@ -4574,7 +4740,8 @@ concepts:
       notation: "mi h"
       urls: 
        - "https://mathworld.wolfram.com/HazardFunction.html"
-      alias: failure-rate
+      alias:
+       - failure-rate
     
     - concept: heaviside-function
       arity: 1
@@ -4585,7 +4752,10 @@ concepts:
       urls: 
        - "https://dlmf.nist.gov/1.16#E13)[https://en.wikipedia.org/wiki/Heaviside_step_function"
        - "https://en.wikipedia.org/wiki/Heaviside_step_function"
-      alias: "heaviside-step-function,<br/>unit-step-function"
+      alias:
+       - heaviside-step-function
+       - 
+       - unit-step-function
     
     - concept: heawood-number
       arity: 1
@@ -4632,7 +4802,10 @@ concepts:
       notation: "mi ht"
       urls: 
        - "https://en.wikipedia.org/wiki/Krull_dimension#height"
-      alias: "codimension-of-prime-ideal, rank-of-prime-ideal, altitude-of-prime-ideal"
+      alias:
+       - codimension-of-prime-ideal
+       - rank-of-prime-ideal
+       - altitude-of-prime-ideal
     
     - concept: heisenberg-group
       arity: 0
@@ -4666,7 +4839,8 @@ concepts:
       notation: "msup †,<br/>msup *"
       urls: 
        - "https://en.wikipedia.org/wiki/Hermitian_adjoint"
-      alias: adjoint-operator
+      alias:
+       - adjoint-operator
     
     - concept: hermitian-conjugate
       arity: 1
@@ -4677,7 +4851,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/HermitianConjugate.html"
        - "https://en.wikipedia.org/wiki/Conjugate_transpose"
-      alias: adjoint-matrix
+      alias:
+       - adjoint-matrix
     
     - concept: heronian-mean
       arity: 1
@@ -4699,7 +4874,8 @@ concepts:
        - "https://mathworld.wolfram.com/Hessian.html"
        - "https://en.wikipedia.org/wiki/Hessian_matrix"
        - "https://ncatlab.org/nlab/show/Hessian"
-      alias: hessian-matrix
+      alias:
+       - hessian-matrix
     
     - concept: heun-function
       arity: 1
@@ -4753,7 +4929,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Hilbert-SchmidtNorm.html"
        - "https://en.wikipedia.org/wiki/Hilbert%E2%80%93Schmidt_operator"
-      alias: 
+      alias:
+       - 
     
     - concept: hit-or-miss-transform
       arity: 2
@@ -4842,7 +5019,8 @@ concepts:
       notation: "mi hp"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
-      alias: horsepower
+      alias:
+       - horsepower
     
     - concept: horsepower-metric
       arity: 1
@@ -4852,7 +5030,8 @@ concepts:
       notation: "mi PS<br/>mi cv<br/>mi hk<br/>mi pk<br/>mi ks<br/>mi ch"
       urls: 
        - "https://en.wikipedia.org/wiki/Metric_horsepower"
-      alias: horsepower
+      alias:
+       - horsepower
     
     - concept: hurwitz-zeta-function
       arity: 1
@@ -4959,7 +5138,9 @@ concepts:
       notation: "msupT$1"
       urls: 
        - "https://en.wikipedia.org/wiki/Torus#n-dimensional_torus"
-      alias: "n-torus, n-dimensional-torus"
+      alias:
+       - n-torus
+       - n-dimensional-torus
     
     - concept: identity-element
       arity: 0
@@ -4971,7 +5152,9 @@ concepts:
        - "https://mathworld.wolfram.com/IdentityElement.html"
        - "https://en.wikipedia.org/wiki/Identity_element"
        - "https://ncatlab.org/nlab/show/identity+element"
-      alias: "identity, two-sided-identity"
+      alias:
+       - identity
+       - two-sided-identity
     
     - concept: identity-function
       arity: 1
@@ -4983,7 +5166,10 @@ concepts:
        - "https://mathworld.wolfram.com/IdentityFunction.html"
        - "https://en.wikipedia.org/wiki/Identity_function"
        - "https://ncatlab.org/nlab/show/identity+function"
-      alias: "identity-map, identity-relation, identity-transformation"
+      alias:
+       - identity-map
+       - identity-relation
+       - identity-transformation
     
     - concept: identity-functor
       arity: 1
@@ -5004,7 +5190,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/IdentityMatrix.html"
        - "https://en.wikipedia.org/wiki/Identity_matrix"
-      alias: unit-matrix
+      alias:
+       - unit-matrix
     
     - concept: image
       arity: 2
@@ -5060,7 +5247,10 @@ concepts:
       notation: "mi ι"
       urls: 
        - "https://en.wikipedia.org/wiki/Inclusion_map"
-      alias: "inclusion-function, insertion, canonical-injection"
+      alias:
+       - inclusion-function
+       - insertion
+       - canonical-injection
     
     - concept: incomparability
       arity: 2
@@ -5070,7 +5260,8 @@ concepts:
       notation: "menclose notation='updiagonalstrike' munderover = > <"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
-      alias: incomparable
+      alias:
+       - incomparable
     
     - concept: incomplete-beta-function
       arity: 1
@@ -5178,7 +5369,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
        - "https://en.wikipedia.org/wiki/Infimum_and_supremum"
-      alias: "meet, greatest-lower-bound"
+      alias:
+       - meet
+       - greatest-lower-bound
     
     - concept: infimum-limit
       arity: 1
@@ -5189,7 +5382,13 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/InfimumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
-      alias: "limit-inferior, limit-infimum, liminf, inferior-limit, lower-limit, inner-limit"
+      alias:
+       - limit-inferior
+       - limit-infimum
+       - liminf
+       - inferior-limit
+       - lower-limit
+       - inner-limit
     
     - concept: infinite-product
       arity: 1
@@ -5231,7 +5430,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Inner_automorphism"
        - "https://ncatlab.org/nlab/show/inner+automorphism"
        - "https://www.encyclopediaofmath.org/index.php/Inner_automorphism"
-      alias: inner-automorphism
+      alias:
+       - inner-automorphism
     
     - concept: inner-jordan-measure
       arity: 1
@@ -5316,7 +5516,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Image_(mathematics)"
        - "https://ncatlab.org/nlab/show/inverse+image"
-      alias: preimage
+      alias:
+       - preimage
     
     - concept: inverse-limit
       arity: 1
@@ -5328,7 +5529,8 @@ concepts:
        - "https://mathworld.wolfram.com/InverseLimit.html"
        - "https://en.wikipedia.org/wiki/Inverse_limit"
        - "https://ncatlab.org/nlab/show/inverse+limit"
-      alias: projective limit
+      alias:
+       - projective limit
     
     - concept: inverse-moment-of-function
       arity: 2
@@ -5338,7 +5540,8 @@ concepts:
       notation: "msub μ mrow - $1 /mrow<br/>mrow E [ msup $1 mrow - $2 /mrow ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
-      alias: inverse-moment
+      alias:
+       - inverse-moment
     
     - concept: inverse-tangent-integral
       arity: 1
@@ -5390,7 +5593,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Isomorphism"
        - "https://ncatlab.org/nlab/show/isomorphism"
        - "https://www.encyclopediaofmath.org/index.php/Isomorphism"
-      alias: natural-isomorphism
+      alias:
+       - natural-isomorphism
     
     - concept: isotropy-group
       arity: 2
@@ -5401,7 +5605,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/IsotropyGroup.html"
        - "https://www.encyclopediaofmath.org/index.php/Isotropy_group"
-      alias: "little-group, stabilizer-subgroup"
+      alias:
+       - little-group
+       - stabilizer-subgroup
     
     - concept: iverson-bracket
       arity: 1
@@ -5431,7 +5637,8 @@ concepts:
        - "https://mathworld.wolfram.com/JacobiMatrix.html"
        - "https://en.wikipedia.org/wiki/Jacobi_operator"
        - "https://www.encyclopediaofmath.org/index.php/Jacobi_matrix"
-      alias: jacobi-operator
+      alias:
+       - jacobi-operator
     
     - concept: jacobi-polynomial
       arity: 1
@@ -5571,7 +5778,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/JordanBlock.html"
        - "https://en.wikipedia.org/wiki/Jordan_matrix"
-      alias: jordan-matrix
+      alias:
+       - jordan-matrix
     
     - concept: jordan-measure
       arity: 1
@@ -5613,7 +5821,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/KaprekarConstant.html"
        - "https://en.wikipedia.org/wiki/6174_(number)"
-      alias: kaprekar-number
+      alias:
+       - kaprekar-number
     
     - concept: kauffman-bracket
       arity: 1
@@ -5623,7 +5832,8 @@ concepts:
       notation: "mrow ⟨ $1 ⟩"
       urls: 
        - "https://en.wikipedia.org/wiki/Bracket_polynomial"
-      alias: bracket-polynomial
+      alias:
+       - bracket-polynomial
     
     - concept: kelvin-function
       arity: 1
@@ -5657,7 +5867,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/Kernel_(statistics)"
        - "https://en.wikipedia.org/wiki/Covariance_function"
        - "https://ncatlab.org/nlab/show/kernel"
-      alias: "nullspace, null-space"
+      alias:
+       - nullspace
+       - null-space
     
     - concept: khinchin-constant
       arity: 0
@@ -5836,7 +6048,8 @@ concepts:
        - "https://mathworld.wolfram.com/KroneckerSymbol.html"
        - "https://en.wikipedia.org/wiki/Kronecker_symbol"
        - "https://www.encyclopediaofmath.org/index.php/Kronecker_symbol"
-      alias: 
+      alias:
+       - 
     
     - concept: krull-dimension
       arity: 1
@@ -5867,7 +6080,11 @@ concepts:
       urls: 
        - "http://users.monash.edu/~lloyd/tildeMML/KL/"
        - "https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence"
-      alias: "kl-distance, kl-divergence, kullback-leibler-divergence, relative-entropy"
+      alias:
+       - kl-distance
+       - kl-divergence
+       - kullback-leibler-divergence
+       - relative-entropy
     
     - concept: lagrange-bracket
       arity: 4
@@ -5891,7 +6108,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Lagrange_multiplier"
        - "https://ncatlab.org/nlab/show/Lagrange+multiplier"
        - "https://www.encyclopediaofmath.org/index.php/Lagrange_multipliers"
-      alias: lagrangian
+      alias:
+       - lagrangian
     
     - concept: lagrange-point
       arity: 0
@@ -5901,7 +6119,10 @@ concepts:
       notation: "msub L 1<br/>msub L 2<br/>msub L 3<br/>msub L 4<br/>msub L 5"
       urls: 
        - "https://en.wikipedia.org/wiki/Lagrange_point"
-      alias: "lagrangian-point, l-point, libration-point"
+      alias:
+       - lagrangian-point
+       - l-point
+       - libration-point
     
     - concept: laguerre-polynomial
       arity: 1
@@ -6043,7 +6264,8 @@ concepts:
       notation: "mo ;"
       urls: 
        - "https://en.wikipedia.org/wiki/Composition_of_relations"
-      alias: left-compose
+      alias:
+       - left-compose
     
     - concept: left-derivative
       arity: 1
@@ -6087,7 +6309,8 @@ concepts:
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
        - "https://dlmf.nist.gov/27.9"
-      alias: 
+      alias:
+       - 
     
     - concept: lehmer-mean
       arity: 1
@@ -6131,7 +6354,8 @@ concepts:
        - "https://mathworld.wolfram.com/Levi-CivitaSymbol.html"
        - "https://en.wikipedia.org/wiki/Levi-Civita_symbol"
        - "https://dlmf.nist.gov/1.6#E14"
-      alias: permutation-symbol
+      alias:
+       - permutation-symbol
     
     - concept: levy-prokhorov-metric
       arity: 1
@@ -6151,7 +6375,8 @@ concepts:
       notation: "mo ∙<br/>$1 [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Lexicographic_product_of_graphs"
-      alias: graph-composition
+      alias:
+       - graph-composition
     
     - concept: lexicographic-order
       arity: 2
@@ -6163,7 +6388,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Lexicographic_order"
        - "https://mathworld.wolfram.com/LexicographicOrder.html"
        - "https://ncatlab.org/nlab/show/lexicographic+order"
-      alias: dictionary-order
+      alias:
+       - dictionary-order
     
     - concept: lie-derivative
       arity: 1
@@ -6184,7 +6410,8 @@ concepts:
       notation: "mrow [ $1 , $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Lie_superalgebra"
-      alias: supercommutator
+      alias:
+       - supercommutator
     
     - concept: like-charge
       arity: 2
@@ -6215,7 +6442,11 @@ concepts:
        - "https://mathworld.wolfram.com/LineIntegral.html"
        - "https://en.wikipedia.org/wiki/Line_integral"
        - "https://ncatlab.org/nlab/show/line+integral"
-      alias: "curve-integral, path-integral, curvilinear-integral, contour-integral"
+      alias:
+       - curve-integral
+       - path-integral
+       - curvilinear-integral
+       - contour-integral
     
     - concept: linear-span
       arity: 1
@@ -6226,7 +6457,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/LinearSpan.html"
        - "https://en.wikipedia.org/wiki/Linear_span"
-      alias: "span, linear-hull"
+      alias:
+       - span
+       - linear-hull
     
     - concept: link
       arity: 1
@@ -6254,7 +6487,8 @@ concepts:
       notation: "mi L"
       urls: 
        - "https://mathworld.wolfram.com/LiouvillesConstant.html"
-      alias: liouville-number
+      alias:
+       - liouville-number
     
     - concept: liouville-function
       arity: 1
@@ -6299,7 +6533,8 @@ concepts:
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
-      alias: logarithmic-moment
+      alias:
+       - logarithmic-moment
     
     - concept: logit
       arity: 1
@@ -6383,7 +6618,8 @@ concepts:
       notation: "mi 𝜕<br/>msub 𝜕 -"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
-      alias: shadow
+      alias:
+       - shadow
     
     - concept: lucas-number
       arity: 1
@@ -6416,7 +6652,8 @@ concepts:
        - "https://mathworld.wolfram.com/LyapunovFunction.html"
        - "https://en.wikipedia.org/wiki/Lyapunov_function"
        - "https://www.encyclopediaofmath.org/index.php/Lyapunov_function"
-      alias: lyapunov-function
+      alias:
+       - lyapunov-function
     
     - concept: macdonald-polynomial
       arity: 1
@@ -6449,7 +6686,8 @@ concepts:
        - "https://mathworld.wolfram.com/MangoldtFunction.html"
        - "https://dlmf.nist.gov/27.2#E14"
        - "https://www.encyclopediaofmath.org/index.php/Mangoldt_function"
-      alias: von-mangoldt-function
+      alias:
+       - von-mangoldt-function
     
     - concept: mapping-class-group
       arity: 1
@@ -6471,7 +6709,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Mapping_cone_(topology)"
        - "https://en.wikipedia.org/wiki/Mapping_cone_(homological_algebra)"
        - "https://ncatlab.org/nlab/show/mapping+cone"
-      alias: homotopy-cofiber
+      alias:
+       - homotopy-cofiber
     
     - concept: matching-polynomial
       arity: 1
@@ -6501,7 +6740,9 @@ concepts:
        - "https://dlmf.nist.gov/28.12#SS2.p2"
        - "https://dlmf.nist.gov/28.2#SS6.p1"
        - "https://www.encyclopediaofmath.org/index.php/Mathieu_functions"
-      alias: "angular-mathieu-function, mathieu-function"
+      alias:
+       - angular-mathieu-function
+       - mathieu-function
     
     - concept: mathieu-function-of-second-kind
       arity: 1
@@ -6522,7 +6763,9 @@ concepts:
        - "https://dlmf.nist.gov/28.12#SS2.p2"
        - "https://dlmf.nist.gov/28.2#SS6.p1"
        - "https://www.encyclopediaofmath.org/index.php/Mathieu_functions"
-      alias: "angular-mathieu-function, mathieu-function"
+      alias:
+       - angular-mathieu-function
+       - mathieu-function
     
     - concept: mathieu-group
       arity: 1
@@ -6735,7 +6978,8 @@ concepts:
       notation: "mo -"
       urls: 
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
-      alias: geometric-difference
+      alias:
+       - geometric-difference
     
     - concept: minkowski-sum
       arity: 2
@@ -6746,7 +6990,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/MinkowskiSum.html"
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
-      alias: dilation
+      alias:
+       - dilation
     
     - concept: mittag-leffler-function
       arity: 1
@@ -6858,7 +7103,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Modulo_(jargon)"
        - "https://en.wikipedia.org/wiki/Modulo_operation"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p2.t1.r10"
-      alias: mod
+      alias:
+       - mod
     
     - concept: moebius-function
       arity: 1
@@ -6878,7 +7124,8 @@ concepts:
       notation: "msub μ $1<br/>mrow E [ msup $1 $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
-      alias: moment
+      alias:
+       - moment
     
     - concept: moment
       arity: 0
@@ -6903,7 +7150,10 @@ concepts:
        - "https://mathworld.wolfram.com/MomentofInertia.html"
        - "https://en.wikipedia.org/wiki/Moment_of_inertia"
        - "https://ncatlab.org/nlab/show/moment+of+inertia"
-      alias: "mass-moment-of-inertia, angular-mass, rotational-inertia"
+      alias:
+       - mass-moment-of-inertia
+       - angular-mass
+       - rotational-inertia
     
     - concept: momentum
       arity: 0
@@ -6914,7 +7164,9 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Momentum"
        - "https://ncatlab.org/nlab/show/momentum"
-      alias: "linear-momentum, translational-momentum"
+      alias:
+       - linear-momentum
+       - translational-momentum
     
     - concept: monster-group
       arity: 0
@@ -6926,7 +7178,8 @@ concepts:
        - "https://mathworld.wolfram.com/MonsterGroup.html"
        - "https://en.wikipedia.org/wiki/Monster_group"
        - "https://ncatlab.org/nlab/show/Monster+group"
-      alias: friendly-giant
+      alias:
+       - friendly-giant
     
     - concept: moore-penrose-inverse
       arity: 1
@@ -6936,7 +7189,8 @@ concepts:
       notation: "msup $1 +"
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse"
-      alias: moore-penrose-pseudoinverse
+      alias:
+       - moore-penrose-pseudoinverse
     
     - concept: moore-smith-sequence
       arity: 1
@@ -6947,7 +7201,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Smith_limit"
        - "https://en.wikipedia.org/wiki/Net_(mathematics)"
-      alias: net
+      alias:
+       - net
     
     - concept: motzkin-number
       arity: 1
@@ -6986,7 +7241,8 @@ concepts:
        - "https://ncatlab.org/nlab/show/inverse"
        - "https://mathworld.wolfram.com/MultiplicativeInverse.html"
        - "https://en.wikipedia.org/wiki/Multiplicative_inverse"
-      alias: inverse
+      alias:
+       - inverse
     
     - concept: multiplicative-order
       arity: 1
@@ -7026,7 +7282,8 @@ concepts:
       notation: "mrow ( ( mfrac $1 $2 )"
       urls: 
        - "https://en.wikipedia.org/wiki/Multiset"
-      alias: multiset-number
+      alias:
+       - multiset-number
     
     - concept: multivariate-gaussian-distribution
       arity: 0
@@ -7036,7 +7293,9 @@ concepts:
       notation: "msub 𝒩 $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Multivariate_normal_distribution"
-      alias: "multivariate-normal-distribution, joint-normal-distribution"
+      alias:
+       - multivariate-normal-distribution
+       - joint-normal-distribution
     
     - concept: mutation
       arity: 2
@@ -7051,7 +7310,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Hua%27s_identity_(Jordan_algebra)"
        - "https://en.wikipedia.org/wiki/Mutation_(algebra)"
        - "https://en.wikipedia.org/wiki/Mutation_(genetic_algorithm)"
-      alias: homotope
+      alias:
+       - homotope
     
     - concept: mutual-information
       arity: 1
@@ -7084,7 +7344,10 @@ concepts:
        - "https://mathworld.wolfram.com/DenjoyIntegral.html"
        - "https://en.wikipedia.org/wiki/Henstock%E2%80%93Kurzweil_integral"
        - "https://www.encyclopediaofmath.org/index.php/Denjoy_integral"
-      alias: "henstock-kurzweil-integral, luzin-integral, perron-integral"
+      alias:
+       - henstock-kurzweil-integral
+       - luzin-integral
+       - perron-integral
     
     - concept: negative-binomial-distribution
       arity: 0
@@ -7115,7 +7378,8 @@ concepts:
       notation: "msub N $1 ( $2 )<br/>mrow N ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_(graph_theory)"
-      alias: open-neighbourhood
+      alias:
+       - open-neighbourhood
     
     - concept: neighbourhood-filter
       arity: 1
@@ -7125,7 +7389,9 @@ concepts:
       notation: "mi 𝒩"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_system"
-      alias: "neighbourhood-system, complete-system-of-neighbourhoods"
+      alias:
+       - neighbourhood-system
+       - complete-system-of-neighbourhoods
     
     - concept: neron-severi-group
       arity: 1
@@ -7145,7 +7411,8 @@ concepts:
       notation: "mover h ^"
       urls: 
        - "https://en.wikipedia.org/wiki/N%C3%A9ron%E2%80%93Tate_height"
-      alias: canonical-height
+      alias:
+       - canonical-height
     
     - concept: nerve
       arity: 1
@@ -7177,7 +7444,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Orientation_(vector_space)"
        - "https://en.wikipedia.org/wiki/Euclidean_space#Angle"
-      alias: angle
+      alias:
+       - angle
     
     - concept: nor
       arity: 2
@@ -7188,7 +7456,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Nor.html"
        - "https://mathworld.wolfram.com/NOR.html"
-      alias: joint-denial
+      alias:
+       - joint-denial
     
     - concept: norm
       arity: 1
@@ -7233,7 +7502,8 @@ concepts:
        - "https://mathworld.wolfram.com/NullGraph.html"
        - "https://en.wikipedia.org/wiki/Null_graph"
        - "https://en.wikipedia.org/wiki/Order-zero_graph"
-      alias: edgeless-graph
+      alias:
+       - edgeless-graph
     
     - concept: numerical-part
       arity: 1
@@ -7278,7 +7548,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Octonion"
        - "https://ncatlab.org/nlab/show/octonion"
        - "https://www.encyclopediaofmath.org/index.php/Octonion"
-      alias: cayley-numbers
+      alias:
+       - cayley-numbers
     
     - concept: odds-ratio
       arity: 0
@@ -7309,7 +7580,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
        - "https://en.wikipedia.org/wiki/Ball_(mathematics)"
-      alias: open-metric-ball
+      alias:
+       - open-metric-ball
     
     - concept: open-interval
       arity: 2
@@ -7341,7 +7613,8 @@ concepts:
        - "https://ncatlab.org/nlab/show/opposite+category"
        - "https://en.wikipedia.org/wiki/Opposite_group"
        - "https://en.wikipedia.org/wiki/Opposite_ring"
-      alias: dual
+      alias:
+       - dual
     
     - concept: opposite-charge
       arity: 2
@@ -7360,7 +7633,9 @@ concepts:
       notation: "mo *"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
-      alias: "disjunctive-product, co-normal-product"
+      alias:
+       - disjunctive-product
+       - co-normal-product
     
     - concept: order-of-group
       arity: 1
@@ -7393,7 +7668,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Orthogonality"
        - "https://ncatlab.org/nlab/show/orthogonality"
        - "https://www.encyclopediaofmath.org/index.php/Orthogonality"
-      alias: perpendicular
+      alias:
+       - perpendicular
     
     - concept: orthogonal-group
       arity: 1
@@ -7417,7 +7693,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/OuterAutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Outer_automorphism_group"
-      alias: outer-automorphism
+      alias:
+       - outer-automorphism
     
     - concept: outer-jordan-measure
       arity: 1
@@ -7514,7 +7791,8 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Partial_charge"
        - "https://chem.libretexts.org/Bookshelves/General_Chemistry/Map%3A_Chemistry_-_The_Central_Science_(Brown_et_al.)/08._Basic_Concepts_of_Chemical_Bonding/8.S%3A_Basic_Concepts_of_Chemical_Bonding_(Summary)"
-      alias: delta-sign
+      alias:
+       - delta-sign
     
     - concept: partition
       arity: 2
@@ -7673,7 +7951,9 @@ concepts:
       notation: "mi pH"
       urls: 
        - "https://en.wikipedia.org/wiki/PH"
-      alias: "potential-of-hydrogen, power-of-hydrogen"
+      alias:
+       - potential-of-hydrogen
+       - power-of-hydrogen
     
     - concept: phase
       arity: 1
@@ -7695,7 +7975,8 @@ concepts:
       notation: "mi φ<br/>msub r φ"
       urls: 
        - "https://en.wikipedia.org/wiki/Phi_coefficient"
-      alias: mean-square-contingency-coefficient
+      alias:
+       - mean-square-contingency-coefficient
     
     - concept: picard-group
       arity: 1
@@ -7729,7 +8010,13 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/PlasticConstant.html"
        - "https://en.wikipedia.org/wiki/Plastic_number"
-      alias: "plastic-number, platin-number, minimal-pisot-number, plastic-ratio, siegel-number, le-nombre-radiant"
+      alias:
+       - plastic-number
+       - platin-number
+       - minimal-pisot-number
+       - plastic-ratio
+       - siegel-number
+       - le-nombre-radiant
     
     - concept: playing-card-suit
       arity: 1
@@ -7840,7 +8127,8 @@ concepts:
       notation: "mrow $1 [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Polynomial_ring#Definition_(univariate_case)"
-      alias: polynomial-algebra
+      alias:
+       - polynomial-algebra
     
     - concept: polylogarithm
       arity: 1
@@ -8005,7 +8293,8 @@ concepts:
       notation: "mi plim"
       urls: 
        - "https://en.wikipedia.org/wiki/Convergence_of_random_variables#Convergence_in_probability"
-      alias: convergence-in-probability
+      alias:
+       - convergence-in-probability
     
     - concept: product-integral
       arity: 1
@@ -8050,7 +8339,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Projective_space"
        - "https://ncatlab.org/nlab/show/projective+space"
        - "https://www.encyclopediaofmath.org/index.php/Projective_space"
-      alias: real-projective-space
+      alias:
+       - real-projective-space
     
     - concept: proper-subgroup
       arity: 2
@@ -8071,7 +8361,8 @@ concepts:
        - "https://mathworld.wolfram.com/Proportional.html"
        - "https://en.wikipedia.org/wiki/Proportionality_(mathematics)"
        - "https://en.wikipedia.org/wiki/Proportional_(fair_division)"
-      alias: directly-proportional
+      alias:
+       - directly-proportional
     
     - concept: prouhet-thue-morse-constant
       arity: 0
@@ -8090,7 +8381,8 @@ concepts:
       notation: "mrow Z ( msup $1 ∞ /msup"
       urls: 
        - "https://en.wikipedia.org/wiki/Pr%C3%BCfer_group"
-      alias: quasicyclic-group
+      alias:
+       - quasicyclic-group
     
     - concept: pseudovector
       arity: 2
@@ -8101,7 +8393,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Pseudovector.html"
        - "https://en.wikipedia.org/wiki/Pseudovector"
-      alias: axial-vector
+      alias:
+       - axial-vector
     
     - concept: pseudo-inner-product
       arity: 2
@@ -8142,7 +8435,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Sqrt(2)"
        - "https://en.wikipedia.org/wiki/%E2%88%9A2"
        - "https://en.wikipedia.org/wiki/Square_root_of_2"
-      alias: pythagoras-number
+      alias:
+       - pythagoras-number
     
     - concept: pythagorean-triple
       arity: 3
@@ -8171,7 +8465,9 @@ concepts:
       notation: "mo □<br/>mo ∎"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
-      alias: "end-of-proof, quod-erat-demonstrandum"
+      alias:
+       - end-of-proof
+       - quod-erat-demonstrandum
     
     - concept: quadratic-differential
       arity: 1
@@ -8203,7 +8499,8 @@ concepts:
        - "https://mathworld.wolfram.com/Quadrangle.html"
        - "https://en.wikipedia.org/wiki/Quadrilateral"
        - "https://www.encyclopediaofmath.org/index.php/Quadrangle"
-      alias: quadrangle
+      alias:
+       - quadrangle
     
     - concept: quotient-group
       arity: 2
@@ -8228,7 +8525,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Quotient_space_(linear_algebra)"
        - "https://ncatlab.org/nlab/show/quotient+space"
        - "https://www.encyclopediaofmath.org/index.php/Quotient_space"
-      alias: quotient-set
+      alias:
+       - quotient-set
     
     - concept: r-complexity-class
       arity: 0
@@ -8287,7 +8585,10 @@ concepts:
        - "https://mathworld.wolfram.com/RadiusVector.html"
        - "https://en.wikipedia.org/wiki/Position_(vector)"
        - "https://www.encyclopediaofmath.org/index.php/Radius_vector"
-      alias: "location-vector, position-vector, position"
+      alias:
+       - location-vector
+       - position-vector
+       - position
     
     - concept: ramanujan-sum
       arity: 1
@@ -8321,7 +8622,8 @@ concepts:
        - "https://mathworld.wolfram.com/Ramanujan-SoldnerConstant.html"
        - "https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant"
        - "https://mathworld.wolfram.com/SoldnersConstant.html"
-      alias: soldner-constant
+      alias:
+       - soldner-constant
     
     - concept: ramification-index
       arity: 1
@@ -8419,7 +8721,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/ReciprocalPolynomial.html"
        - "https://en.wikipedia.org/wiki/Reciprocal_polynomial"
-      alias: reflected-polynomial
+      alias:
+       - reflected-polynomial
     
     - concept: rectification
       arity: 1
@@ -8540,7 +8843,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Resultant"
        - "https://ncatlab.org/nlab/show/resultant"
        - "https://www.encyclopediaofmath.org/index.php/Resultant"
-      alias: eliminant
+      alias:
+       - eliminant
     
     - concept: rewrite-rule
       arity: 2
@@ -8550,7 +8854,8 @@ concepts:
       notation: "mo →"
       urls: 
        - "https://en.wikipedia.org/wiki/Semi-Thue_system"
-      alias: rewrite-relation
+      alias:
+       - rewrite-relation
     
     - concept: reynolds-number
       arity: 0
@@ -8570,7 +8875,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/RicciScalar.html"
        - "https://en.wikipedia.org/wiki/Scalar_curvature"
-      alias: scalar-curvature
+      alias:
+       - scalar-curvature
     
     - concept: ricci-tensor
       arity: 1
@@ -8608,7 +8914,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/Riemann_sphere"
        - "https://ncatlab.org/nlab/show/Riemann+sphere"
        - "https://www.encyclopediaofmath.org/index.php/Riemann_sphere"
-      alias: "extended-complex-numbers, extended-complex-plane"
+      alias:
+       - extended-complex-numbers
+       - extended-complex-plane
     
     - concept: riemann-theta-function
       arity: 1
@@ -8633,7 +8941,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Riemann_zeta_function"
        - "https://dlmf.nist.gov/25.1"
        - "https://dlmf.nist.gov/25.2#E1"
-      alias: euler-riemann-zeta-function
+      alias:
+       - euler-riemann-zeta-function
     
     - concept: riemann-christoffel-tensor
       arity: 1
@@ -8646,7 +8955,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Riemann_curvature_tensor"
        - "https://www.encyclopediaofmath.org/index.php/Riemann-Christoffel_tensor"
        - "https://www.encyclopediaofmath.org/index.php/RiemannâXXXXChristoffel_tensor"
-      alias: riemann-curvature-tensor
+      alias:
+       - riemann-curvature-tensor
     
     - concept: riemann-stieltje-integral
       arity: 1
@@ -8661,7 +8971,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Riemann%E2%80%93Stieltjes_integral"
        - "https://www.encyclopediaofmath.org/index.php/Riemann-Stieltjes_integral"
        - "https://www.encyclopediaofmath.org/index.php/RiemannâXXXXStieltjes_integral"
-      alias: stieltje-integral
+      alias:
+       - stieltje-integral
     
     - concept: right-angle
       arity: 1
@@ -8710,7 +9021,12 @@ concepts:
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/RisingFactorial.html"
        - "https://dlmf.nist.gov/26.1#P1.p1"
-      alias: "pochhammer-function, pochhammer-polynomial, ascending-factorial, rising-sequential-product, upper-factorial"
+      alias:
+       - pochhammer-function
+       - pochhammer-polynomial
+       - ascending-factorial
+       - rising-sequential-product
+       - upper-factorial
     
     - concept: roman-numeral
       arity: 0
@@ -8732,7 +9048,9 @@ concepts:
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
-      alias: "span, correspondence"
+      alias:
+       - span
+       - correspondence
     
     - concept: root-of-unity
       arity: 0
@@ -8753,7 +9071,9 @@ concepts:
       notation: "msub $1 RMS"
       urls: 
        - "https://mathworld.wolfram.com/Root-Mean-Square.html"
-      alias: "rms, quadratic-mean"
+      alias:
+       - rms
+       - quadratic-mean
     
     - concept: rooted-product-of-graphs
       arity: 2
@@ -8863,7 +9183,8 @@ concepts:
        - "https://mathworld.wolfram.com/SchurMultiplier.html"
        - "https://en.wikipedia.org/wiki/Schur_multiplier"
        - "https://en.wikipedia.org/wiki/Schur_cover"
-      alias: schur-multiplicator
+      alias:
+       - schur-multiplicator
     
     - concept: schwartz-space
       arity: 0
@@ -8937,7 +9258,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/Seminorm.html"
        - "https://en.wikipedia.org/wiki/Norm_(mathematics)"
-      alias: pseudonorm
+      alias:
+       - pseudonorm
     
     - concept: set-of-invertible-maps
       arity: 1
@@ -8959,7 +9281,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Entropy_(information_theory)"
        - "https://ncatlab.org/nlab/show/entropy"
        - "https://www.encyclopediaofmath.org/index.php/Entropy"
-      alias: entropy
+      alias:
+       - entropy
     
     - concept: shift-operator
       arity: 1
@@ -8971,7 +9294,9 @@ concepts:
        - "https://mathworld.wolfram.com/ShiftOperator.html"
        - "https://en.wikipedia.org/wiki/Shift_operator"
        - "https://www.encyclopediaofmath.org/index.php/Shift_operator"
-      alias: "translation-operator, lag-operator"
+      alias:
+       - translation-operator
+       - lag-operator
     
     - concept: shimura-variety
       arity: 1
@@ -9015,7 +9340,8 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/SidonSequence.html"
        - "https://en.wikipedia.org/wiki/Sidon_sequence"
-      alias: sidon-set
+      alias:
+       - sidon-set
     
     - concept: sign-function
       arity: 1
@@ -9025,7 +9351,8 @@ concepts:
       notation: "mi sgn"
       urls: 
        - "https://en.wikipedia.org/wiki/Sign_function"
-      alias: signum-function
+      alias:
+       - signum-function
     
     - concept: signature-of-permutation
       arity: 1
@@ -9035,7 +9362,8 @@ concepts:
       notation: "mi sign"
       urls: 
        - "https://ncatlab.org/nlab/show/signature+of+a+permutation"
-      alias: sign-of-permutation
+      alias:
+       - sign-of-permutation
     
     - concept: silver-ratio
       arity: 0
@@ -9164,7 +9492,8 @@ concepts:
       area: "complexity theory"
       notation: "mi Õ"
       urls: 
-      alias: Extensions_to_the_Bachmann–Landau_notations
+      alias:
+       - Extensions_to_the_Bachmann–Landau_notations
     
     - concept: solid-angle
       arity: 0
@@ -9376,7 +9705,9 @@ concepts:
       notation: "msub 𝒜 ($1"
       urls: 
        - "https://en.wikipedia.org/wiki/Matricization"
-      alias: "matricization, unfolding"
+      alias:
+       - matricization
+       - unfolding
     
     - concept: stanley-reisner-ring
       arity: 2
@@ -9388,7 +9719,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/Stanley-Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/StanleyâXXXXReisner_ring"
-      alias: face-ring
+      alias:
+       - face-ring
     
     - concept: stanley-reisner-ideal
       arity: 1
@@ -9400,7 +9732,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/Stanley-Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/StanleyâXXXXReisner_ring"
-      alias: face-ideal
+      alias:
+       - face-ideal
     
     - concept: star
       arity: 0
@@ -9496,7 +9829,8 @@ concepts:
       notation: "mi σ"
       urls: 
        - "https://en.wikipedia.org/wiki/Strength_of_a_graph"
-      alias: strength
+      alias:
+       - strength
     
     - concept: string-concatenation
       arity: 2
@@ -9516,7 +9850,9 @@ concepts:
       notation: "mo ⊠"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
-      alias: "normal-product, and-product"
+      alias:
+       - normal-product
+       - and-product
     
     - concept: struve-function
       arity: 1
@@ -9548,7 +9884,9 @@ concepts:
       notation: "mo !"
       urls: 
        - "https://en.wikipedia.org/wiki/Derangement"
-      alias: "derangement-number<br/>de-montmort-number"
+      alias:
+       - derangement-number
+       - de-montmort-number
     
     - concept: subgroup
       arity: 2
@@ -9620,7 +9958,8 @@ concepts:
       notation: "msub ⊆ s<br/>mo ≪"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
-      alias: small-submodule
+      alias:
+       - small-submodule
     
     - concept: support
       arity: 1
@@ -9634,7 +9973,9 @@ concepts:
        - "https://en.wikipedia.org/wiki/Support_of_a_module"
        - "https://en.wikipedia.org/wiki/Support_(measure_theory)"
        - "https://ncatlab.org/nlab/show/support"
-      alias: "spectrum, topological-support"
+      alias:
+       - spectrum
+       - topological-support
     
     - concept: supremum
       arity: 1
@@ -9644,7 +9985,9 @@ concepts:
       notation: "mi sup<br/>mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
-      alias: "join, least-upper-bound"
+      alias:
+       - join
+       - least-upper-bound
     
     - concept: supremum-limit
       arity: 1
@@ -9655,7 +9998,13 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/SupremumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
-      alias: "limit-superior, limit-supremum, limsup, superior-limit, upper-limit, outer-limit"
+      alias:
+       - limit-superior
+       - limit-supremum
+       - limsup
+       - superior-limit
+       - upper-limit
+       - outer-limit
     
     - concept: surface-integral
       arity: 1
@@ -9883,7 +10232,9 @@ concepts:
       notation: "mo ×"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_product_of_graphs"
-      alias: "kronecker-product-of-graphs, categorical-product"
+      alias:
+       - kronecker-product-of-graphs
+       - categorical-product
     
     - concept: therefore-sign
       arity: 1
@@ -10033,7 +10384,8 @@ concepts:
        - "https://mathworld.wolfram.com/TotalDerivative.html"
        - "https://en.wikipedia.org/wiki/Total_derivative"
        - "https://www.encyclopediaofmath.org/index.php/Total_derivative"
-      alias: total-differential
+      alias:
+       - total-differential
     
     - concept: total-variation
       arity: 1
@@ -10087,7 +10439,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/TriangleFunction.html"
        - "https://en.wikipedia.org/wiki/Triangular_function"
-      alias: "hat-function, tent-function"
+      alias:
+       - hat-function
+       - tent-function
     
     - concept: triangular-number
       arity: 1
@@ -10118,7 +10472,8 @@ concepts:
       notation: "mi TM"
       urls: 
        - "https://en.wikipedia.org/wiki/Trimean"
-      alias: tukey-trimean
+      alias:
+       - tukey-trimean
     
     - concept: triple-bond
       arity: 2
@@ -10137,7 +10492,8 @@ concepts:
       notation: "mrow [$1, $2, $3]"
       urls: 
        - "https://mathworld.wolfram.com/TripleScalarProduct.html"
-      alias: scalar-triple-product
+      alias:
+       - scalar-triple-product
     
     - concept: triple-torus
       arity: 1
@@ -10200,7 +10556,10 @@ concepts:
       notation: "mi cyc<br/>mi rev<br/>mi tr<br/>mi pla"
       urls: 
        - "https://en.wikipedia.org/wiki/Turn_(geometry)"
-      alias: "cycle, revolution, plenus angulus"
+      alias:
+       - cycle
+       - revolution
+       - plenus angulus
     
     - concept: twisted-tensor-product
       arity: 2
@@ -10313,7 +10672,10 @@ concepts:
       notation: "mi R<br/>mover R -"
       urls: 
        - "https://en.wikipedia.org/wiki/Gas_constant"
-      alias: "gas-constant, molar-gas-constant, ideal-gas-constant"
+      alias:
+       - gas-constant
+       - molar-gas-constant
+       - ideal-gas-constant
     
     - concept: universal-parabolic-constant
       arity: 0
@@ -10335,7 +10697,8 @@ concepts:
        - "https://mathworld.wolfram.com/UniversalSet.html"
        - "https://en.wikipedia.org/wiki/Universal_set"
        - "https://www.encyclopediaofmath.org/index.php/Universal_set"
-      alias: universe
+      alias:
+       - universe
     
     - concept: unique-existential
       arity: 1
@@ -10426,7 +10789,8 @@ concepts:
       notation: "mi Var"
       urls: 
        - "https://en.wikipedia.org/wiki/Variance"
-      alias: dispersion
+      alias:
+       - dispersion
     
     - concept: vect
       arity: 1
@@ -10455,7 +10819,9 @@ concepts:
       notation: "mi proj"
       urls: 
        - "https://en.wikipedia.org/wiki/Vector_projection"
-      alias: "vector-component, vector-resolution"
+      alias:
+       - vector-component
+       - vector-resolution
     
     - concept: vectorization
       arity: 1
@@ -10555,7 +10921,8 @@ concepts:
        - "https://mathworld.wolfram.com/WaveletTransform.html"
        - "https://en.wikipedia.org/wiki/Wavelet_transform"
        - "https://en.wikipedia.org/wiki/Embedded_Zerotrees_of_Wavelet_transforms"
-      alias: integral-wavelet-transform
+      alias:
+       - integral-wavelet-transform
     
     - concept: way-below
       arity: 2
@@ -10566,7 +10933,9 @@ concepts:
       urls: 
        - "http://mizar.org/fm/1997-6/pdf6-1/waybel_3.pdf"
        - "https://en.wikipedia.org/wiki/Domain_theory"
-      alias: "way-inside, order-of-approximation"
+      alias:
+       - way-inside
+       - order-of-approximation
     
     - concept: weak-convergence
       arity: 2
@@ -10656,7 +11025,9 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/WeightedMean.html"
        - "https://en.wikipedia.org/wiki/Weighted_arithmetic_mean"
-      alias: "weighted-arithmetic-mean, weighted-average"
+      alias:
+       - weighted-arithmetic-mean
+       - weighted-average
     
     - concept: wheel-graph
       arity: 1
@@ -10850,7 +11221,8 @@ concepts:
       notation: "mi ω"
       urls: 
        - "https://en.wikipedia.org/wiki/Wright_Omega_function"
-      alias: wright-function
+      alias:
+       - wright-function
     
     - concept: writhe
       arity: 1

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1121,7 +1121,8 @@ concepts:
       en: canonical commutation relation
       property: fenced
       area: "quantum mechanics"
-      notation: "mrow [ $1 , $2 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Canonical_commutation_relation"
     
@@ -1143,7 +1144,7 @@ concepts:
       area: "set theory"
       notation: "mrow | mo #"
       notationb: "mi card"
-      notationa: "mi n"
+      notationa: "<math><mi>n</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cardinality.html"
        - "https://en.wikipedia.org/wiki/Cardinality"
@@ -1633,7 +1634,8 @@ concepts:
       en: closed interval
       property: fenced
       area: "calculus"
-      notation: "mrow [ $1, $2 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ClosedInterval.html"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p1.t1.r29"
@@ -1752,7 +1754,8 @@ concepts:
       en: comma category $1 $2
       property: mixfix
       area: "category theory"
-      notation: "mrow ( $1 ↓ $2"
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>↓</mo><mi>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Comma_category"
     
@@ -5048,7 +5051,7 @@ concepts:
       comments:
        - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
        - "<math><msup><mi>X</mi><mo>×</mo></msup></math>"
-      notationa: "mi U"
+      notationa: "<math><mi>U</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5420,7 +5423,8 @@ concepts:
       en: hilbert symbol
       property: fenced
       area: "quadratic forms"
-      notation: "mrow ( $1, $2"
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HilbertSymbol.html"
        - "https://en.wikipedia.org/wiki/Hilbert_symbol"
@@ -5901,9 +5905,10 @@ concepts:
       en: index of subgroup
       property: fenced
       area: "group theory"
-      notation: "mrow [ $1 : $2 ]"
-      notationb: "mrow ( $1 : $2 )"
-      notationa: "mrow |$1 : $2 |"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>:</mo><mi>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>:</mo><mi>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow><mo>|</mo><mi>x</mi><mo>:</mo><mi>y</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_subgroup"
     
@@ -6013,7 +6018,7 @@ concepts:
       property: infix, fenced
       area: "linear algebra"
       notation: "mo ⋅"
-      notationa: "mrow [ $1, $2 ]"
+      notationa: "<math><mrow><mo>[</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -6238,7 +6243,8 @@ concepts:
       en: jacobi symbol
       property: mixfix$1 $2
       area: "number theory"
-      notation: "mrow ( $1 | $2"
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>|</mo><mi>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiSymbol.html"
        - "https://en.wikipedia.org/wiki/Jacobi_symbol"
@@ -6623,7 +6629,8 @@ concepts:
       en: kripke frame
       property: fenced
       area: "modal logic"
-      notation: "mrow ⟨ $1, $2 ⟩"
+      comments:
+       - "<math><mrow><mo>⟨</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Kripke+frame"
     
@@ -6658,7 +6665,8 @@ concepts:
       en: kronecker symbol
       property: fenced, fenced stacked
       area: "number theory"
-      notation: "mrow ( $1 | $2 )"
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>|</mo><mi>y</mi><mo>)</mo></mrow></math>"
       notationa: "( mfrac $1 $2 )"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerSymbol.html"
@@ -6785,7 +6793,7 @@ concepts:
       area: "differential operators"
       notation: "msup ∇ 2"
       notationb: "mrow ∇ · ∇"
-      notationa: "mi Δ"
+      notationa: "<math><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Laplace_operator"
        - "https://ncatlab.org/nlab/show/Laplace+operator"
@@ -7058,7 +7066,8 @@ concepts:
       en: lie superbracket
       property: fenced
       area: "lie algebra"
-      notation: "mrow [ $1 , $2 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lie_superalgebra"
       alias:
@@ -7939,7 +7948,7 @@ concepts:
       area: "combinatorial analysis"
       comments:
        - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
-      notationa: "mi M"
+      notationa: "<math><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
        - "https://en.wikipedia.org/wiki/Motzkin_number"
@@ -8344,8 +8353,9 @@ concepts:
       en: open interval
       property: fenced
       area: "algebra"
-      notation: "mrow ( $1, $2 )"
-      notationa: "mrow ] $1 , $2 ["
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow><mo>]</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>[</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OpenInterval.html"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p1.t1.r28"
@@ -8551,7 +8561,7 @@ concepts:
       property: embellished infix
       area: "category theory"
       notation: "<munderover>"
-      notationd: "<mrow/>"
+      notationd: "<math><mrow/>"
       notationc: "<munder><mo>⟶</mo> $1</munder>"
       notationb: "<mover><mo>⟶</mo> $2</mover>"
       notationa: "</munderover>"
@@ -8871,7 +8881,8 @@ concepts:
       en: poisson bracket
       property: fenced
       area: "classical mechanics"
-      notation: "mrow { $1, $2 }"
+      comments:
+       - "<math><mrow><mo>{</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PoissonBracket.html"
        - "https://en.wikipedia.org/wiki/Poisson_bracket"
@@ -9237,7 +9248,8 @@ concepts:
       en: pseudo inner product
       property: fenced
       area: "lie algebra"
-      notation: "mrow ( $1, $2"
+      comments:
+       - "<math><mrow><mo>(</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://youtu.be/mJ8ZDdA10GY?t=870"
     
@@ -9430,9 +9442,10 @@ concepts:
       en: radius vector
       property: symbol
       area: "geometry"
-      notation: "mix"
-      notationb: "mir"
-      notationa: "mis"
+      comments:
+       - "<math><mi>x</mi></math>"
+      notationb: "<math><mi>r</mi></math>"
+      notationa: "<math><mi>s</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RadiusVector.html"
        - "https://en.wikipedia.org/wiki/Position_(vector)"
@@ -10011,7 +10024,8 @@ concepts:
       en: s set theory
       property: constant
       area: "set theory"
-      notation: "miS"
+      comments:
+       - "<math><mi>S</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/S_(set_theory)"
     
@@ -10020,7 +10034,7 @@ concepts:
       en: s5 modal logic
       property: constant
       area: "logic"
-      notation: "miS5"
+      notation: "mi S5"
       urls: 
        - "https://en.wikipedia.org/wiki/S5_(modal_logic)"
     
@@ -10127,7 +10141,8 @@ concepts:
       en: schwarzian derivative $1 $2
       property: fenced, mixfix
       area: "complex analysis"
-      notation: "mrow { $1, $2 }"
+      comments:
+       - "<math><mrow><mo>{</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>}</mo></mrow></math>"
       notationa: "mrow ( S $1 ) ($2"
       urls: 
        - "https://mathworld.wolfram.com/SchwarzianDerivative.html"
@@ -10911,8 +10926,8 @@ concepts:
       area: "number theory"
       comments:
        - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
-      notationb: "mi s"
-      notationa: "mi S"
+      notationb: "<math><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+      notationa: "<math><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Proclus"
        - "https://en.wikipedia.org/wiki/Successor_cardinal"
@@ -11670,7 +11685,8 @@ concepts:
       en: ultrapower $1 $2
       property: mixfix
       area: "abstract algebra"
-      notation: "mrow ∏ $1 / $2"
+      comments:
+       - "<math><mrow><mo>∏</mo><mi>x</mi><mo>/</mo><mi>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ultrapower.html"
        - "https://en.wikipedia.org/wiki/Ultraproduct"
@@ -11928,7 +11944,8 @@ concepts:
       en: versor of $1
       property: function
       area: "quaternions"
-      notation: "miU"
+      comments:
+       - "<math><mi>U</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Versor_(physics)"
        - "https://en.wikipedia.org/wiki/Versor"
@@ -12157,7 +12174,8 @@ concepts:
       en: whitehead bracket $1 $2
       property: fenced
       area: "lie algebra"
-      notation: "mrow [ $1, $2 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>,</mo><mi>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Whitehead_product"
        - "https://ncatlab.org/nlab/show/Whitehead+product"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -135,7 +135,8 @@ concepts:
       en: adjoint action of $1
       property: "function/msub"
       area: "lie algebra"
-      notation: "mi ad<br/>msub ad $1"
+      notation: "mi ad $1"
+      notationa: "msub ad $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjoint_representation_of_a_Lie_algebra"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -205,7 +206,8 @@ concepts:
       en: airy function of $1
       property: function
       area: "special functions"
-      notation: "mi Ai<br/>mi Bi"
+      notation: "mi Ai"
+      notationa: "mi Bi"
       urls: 
        - "https://mathworld.wolfram.com/AiryFunctions.html"
        - "https://en.wikipedia.org/wiki/Airy_function"
@@ -220,7 +222,8 @@ concepts:
       en: albanese variety of $1
       property: function
       area: "algebraic geometry"
-      notation: "mi A<br/>mi Alb"
+      notation: "mi A"
+      notationa: "mi Alb"
       urls: 
        - "https://mathworld.wolfram.com/AlbaneseVariety.html"
        - "https://en.wikipedia.org/wiki/Albanese_variety"
@@ -254,7 +257,8 @@ concepts:
       en: algebraic closure of $1
       property: mover/msup
       area: "algebra"
-      notation: "mover ¯<br/>msup alg"
+      notation: "mover ¯"
+      notationa: "msup alg"
       urls: 
        - "https://mathworld.wolfram.com/AlgebraicClosure.html"
        - "https://en.wikipedia.org/wiki/Algebraic_closure"
@@ -284,7 +288,8 @@ concepts:
       en: alternating group of $1
       property: function
       area: "group theory"
-      notation: "mi A<br/>mi Alt"
+      notation: "mi A"
+      notationa: "mi Alt"
       urls: 
        - "https://mathworld.wolfram.com/AlternatingGroup.html"
        - "https://en.wikipedia.org/wiki/Alternating_group"
@@ -311,7 +316,9 @@ concepts:
       en: $1 alternative denial $2
       property: infix, prefix
       area: "propositional calculus"
-      notation: "mo | <br/>mo ↑<br/>mrow D $1 $2"
+      notation: "mo | "
+      notationb: "mo ↑"
+      notationa: "mrow D $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/AlternativeDenial.html"
        - "https://en.wikipedia.org/wiki/Sheffer_stroke"
@@ -480,7 +487,9 @@ concepts:
       en: arcminute of $1
       property: unit
       area: "SI-mentioned units"
-      notation: "mi arcmin<br/>mi amin<br/>mo ′"
+      notation: "mi arcmin"
+      notationb: "mi amin"
+      notationa: "mo ′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
        - "https://en.wikipedia.org/wiki/Minute_of_arc"
@@ -495,7 +504,9 @@ concepts:
       en: arcsecond of $1
       property: unit
       area: "SI-mentioned units"
-      notation: "mi arcsec<br/>mi asec<br/>mo ′′"
+      notation: "mi arcsec"
+      notationb: "mi asec"
+      notationa: "mo ′′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
        - "https://en.wikipedia.org/wiki/Minute_of_arc"
@@ -541,7 +552,8 @@ concepts:
       en: arithmetic geometric mean of $1
       property: function
       area: "special functions"
-      notation: "mi agm<br/>mi AGM"
+      notation: "mi agm"
+      notationa: "mi AGM"
       urls: 
        - "https://mathworld.wolfram.com/Arithmetic-GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean"
@@ -600,7 +612,8 @@ concepts:
       en: baire space
       property: symbol
       area: "set theory"
-      notation: "msup N N<br/>msup ω ω"
+      notation: "msup N N"
+      notationa: "msup ω ω"
       urls: 
        - "https://mathworld.wolfram.com/BaireSpace.html"
        - "https://en.wikipedia.org/wiki/Baire_space"
@@ -771,7 +784,10 @@ concepts:
       en: beta distribution of $1
       property: function
       area: "probability theory"
-      notation: "mi B<br/>mi Beta<br/>mi 𝓑𝓮<br/>mi β"
+      notation: "mi B"
+      notationc: "mi Beta"
+      notationb: "mi 𝓑𝓮"
+      notationa: "mi β"
       urls: 
        - "https://mathworld.wolfram.com/BetaDistribution.html"
        - "https://en.wikipedia.org/wiki/Beta_distribution"
@@ -781,7 +797,8 @@ concepts:
       en: beta function of $1
       property: function
       area: "special functions"
-      notation: "mi B<br/>mi β"
+      notation: "mi B"
+      notationa: "mi β"
       urls: 
        - "https://mathworld.wolfram.com/BetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%92(x,_y)"
@@ -810,7 +827,9 @@ concepts:
       en: $1 biconditional $2
       property: infix
       area: "logic"
-      notation: "mo ⇔<br/>mo ≡<br/>mo iff"
+      notation: "mo ⇔"
+      notationb: "mo ≡"
+      notationa: "mo iff"
       urls: 
        - "https://mathworld.wolfram.com/Biconditional.html"
        - "https://ncatlab.org/nlab/show/biconditional"
@@ -823,7 +842,8 @@ concepts:
       en: big O of $1
       property: prefix
       area: "complexity"
-      notation: "mi O<br/>"
+      notation: "mi O"
+      notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
        - "https://mathworld.wolfram.com/O.html"
@@ -888,7 +908,8 @@ concepts:
       en: bit
       property: symbol
       area: "computer science"
-      notation: "mn 0<br/>mn 1"
+      notation: "mn 0"
+      notationa: "mn 1"
       urls: 
        - "https://mathworld.wolfram.com/Bit.html"
        - "https://en.wikipedia.org/wiki/Bit"
@@ -980,7 +1001,9 @@ concepts:
       en: boundary of $1
       property: function
       area: "topology"
-      notation: "mi bd<br/>mi fr<br/>mi ∂"
+      notation: "mi bd"
+      notationb: "mi fr"
+      notationa: "mi ∂"
       urls: 
        - "https://mathworld.wolfram.com/Boundary.html"
        - "https://en.wikipedia.org/wiki/Boundary_(topology)"
@@ -1091,7 +1114,9 @@ concepts:
       en: cardinality of $1
       property: many
       area: "set theory"
-      notation: "mrow | mo #<br/>mi card<br/>mi n"
+      notation: "mrow | mo #"
+      notationb: "mi card"
+      notationa: "mi n"
       urls: 
        - "https://mathworld.wolfram.com/Cardinality.html"
        - "https://en.wikipedia.org/wiki/Cardinality"
@@ -1236,7 +1261,10 @@ concepts:
       en: ceiling of $1
       property: fenced, function
       area: "number theory"
-      notation: "⌈ $1 ⌉<br/>〛 $1 〚<br/>] $1 [<br/>ceil ($1"
+      notation: "⌈ $1 ⌉"
+      notationc: "〛 $1 〚"
+      notationb: "] $1 ["
+      notationa: "ceil ($1"
       urls: 
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -1281,7 +1309,8 @@ concepts:
       en: champernowne constant
       property: constant
       area: "number theory"
-      notation: "mi C<br/>msub C 10"
+      notation: "mi C"
+      notationa: "msub C 10"
       urls: 
        - "https://mathworld.wolfram.com/ChampernowneConstant.html"
        - "https://en.wikipedia.org/wiki/Champernowne_constant"
@@ -1319,7 +1348,8 @@ concepts:
       en: characteristic function of $1
       property: "indexed function, function"
       area: "probability theory"
-      notation: "msub 𝟏 $1<br/>mrow 𝟏 { $1 }"
+      notation: "msub 𝟏 $1"
+      notationa: "mrow 𝟏 { $1 }"
       urls: 
        - "https://mathworld.wolfram.com/CharacteristicFunction.html"
        - "https://en.wikipedia.org/wiki/Characteristic_function_(probability_theory)"
@@ -1359,7 +1389,9 @@ concepts:
       en: chebyshev polynomial of first kind of $1
       property: function
       area: "number theory"
-      notation: "mi θ<br/>mi ϑ<br/>mi T"
+      notation: "mi θ"
+      notationb: "mi ϑ"
+      notationa: "mi T"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1372,7 +1404,8 @@ concepts:
       en: chebyshev polynomial of second kind of $1
       property: function
       area: "number theory"
-      notation: "mi ψ<br/>mi U"
+      notation: "mi ψ"
+      notationa: "mi U"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1467,7 +1500,9 @@ concepts:
       en: chromatic polynomial of $1
       property: function
       area: "graph theory"
-      notation: "msub P $1<br/>msub π $1<br/>msub χ $1"
+      notation: "msub P $1"
+      notationb: "msub π $1"
+      notationa: "msub χ $1"
       urls: 
        - "https://mathworld.wolfram.com/ChromaticPolynomial.html"
        - "https://en.wikipedia.org/wiki/Chromatic_polynomial"
@@ -1477,7 +1512,8 @@ concepts:
       en: classifying space of $1
       property: function
       area: "group theory"
-      notation: "mi B<br/>mi ℬ"
+      notation: "mi B"
+      notationa: "mi ℬ"
       urls: 
        - "https://en.wikipedia.org/wiki/Classifying_space"
        - "https://ncatlab.org/nlab/show/classifying+space"
@@ -1497,7 +1533,8 @@ concepts:
       en: clebsch gordan coefficient
       property: fenced
       area: "special functions"
-      notation: "mrow ( $1 $2 $3 $4 | $5 $6 $7 $8 )<br/>mrow ⟨ $1 $2 $3 $4 |  $5 $6 $7 $8 ⟩"
+      notation: "mrow ( $1 $2 $3 $4 | $5 $6 $7 $8 )"
+      notationa: "mrow ⟨ $1 $2 $3 $4 |  $5 $6 $7 $8 ⟩"
       urls: 
        - "https://mathworld.wolfram.com/Clebsch-GordanCoefficient.html"
        - "https://en.wikipedia.org/wiki/Clebsch%E2%80%93Gordan_coefficients"
@@ -1563,7 +1600,8 @@ concepts:
       en: closed neighbourhood
       property: "indexed function, function"
       area: "graph theory"
-      notation: "msub N $1 [ $2 ]<br/>mrow N [ $1 ]"
+      notation: "msub N $1 [ $2 ]"
+      notationa: "mrow N [ $1 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_(graph_theory)"
     
@@ -1572,7 +1610,9 @@ concepts:
       en: closure of $1
       property: "function, msup"
       area: "abstract algebra,, topology"
-      notation: "mi cl<br/>mi Cl<br/>msup $1 −"
+      notation: "mi cl"
+      notationb: "mi Cl"
+      notationa: "msup $1 −"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
        - "https://en.wikipedia.org/wiki/Congruence_closure"
@@ -1622,7 +1662,8 @@ concepts:
       en: coherence of $1
       property: "indexed function"
       area: "signal processing, quantum physics"
-      notation: "mi C<br/>mi γ"
+      notation: "mi C"
+      notationa: "mi γ"
       urls: 
        - "https://en.wikipedia.org/wiki/Coherence_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Coherence_(physics)"
@@ -1687,7 +1728,9 @@ concepts:
       en: commutator subgroup of $1
       property: msup, fenced
       area: "abstract algebra"
-      notation: "msup $1 '<br/>msup $1 (1)<br/>mrow [ $1, $1 ]"
+      notation: "msup $1 '"
+      notationb: "msup $1 (1)"
+      notationa: "mrow [ $1, $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/CommutatorSubgroup.html"
        - "https://en.wikipedia.org/wiki/Commutator_subgroup"
@@ -1755,7 +1798,8 @@ concepts:
       en: complex conjugate of $1
       property: msup
       area: "complex analysis"
-      notation: "msup $1 *<br/>mover $1 ¯"
+      notation: "msup $1 *"
+      notationa: "mover $1 ¯"
       urls: 
        - "https://mathworld.wolfram.com/ComplexConjugate.html"
        - "https://en.wikipedia.org/wiki/Complex_conjugate"
@@ -1779,7 +1823,8 @@ concepts:
       en: complexification of $1
       property: msup
       area: "complex manifolds"
-      notation: "msup $1 ℂ<br/>msup $1 C"
+      notation: "msup $1 ℂ"
+      notationa: "msup $1 C"
       urls: 
        - "https://en.wikipedia.org/wiki/Complexification"
        - "https://ncatlab.org/nlab/show/complexification"
@@ -1903,7 +1948,8 @@ concepts:
       en: $1 congruence relation $2
       property: infix
       area: "algebra, geometry"
-      notation: "mo ≡<br/>mo ≅"
+      notation: "mo ≡"
+      notationa: "mo ≅"
       urls: 
        - "https://en.wikipedia.org/wiki/Congruence_relation"
        - "https://mathworld.wolfram.com/Congruence.html"
@@ -1934,7 +1980,8 @@ concepts:
       en: conjugate transpose of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 H<br/>msup $1 *"
+      notation: "msup $1 H"
+      notationa: "msup $1 *"
       urls: 
        - "https://mathworld.wolfram.com/ConjugateTranspose.html"
        - "https://en.wikipedia.org/wiki/Conjugate_transpose"
@@ -2072,7 +2119,9 @@ concepts:
       en: converse graph of $1
       property: msup
       area: "graph theory"
-      notation: "msup $1 '<br/>msup $1 T<br/>msup $1 R"
+      notation: "msup $1 '"
+      notationb: "msup $1 T"
+      notationa: "msup $1 R"
       urls: 
        - "https://en.wikipedia.org/wiki/Transpose_graph"
       alias:
@@ -2099,7 +2148,10 @@ concepts:
       en: conway group
       property: symbol
       area: "group theory"
-      notation: "msub Co 0<br/>msub Co 1<br/>msub Co 2<br/>msub Co 3"
+      notation: "msub Co 0"
+      notationc: "msub Co 1"
+      notationb: "msub Co 2"
+      notationa: "msub Co 3"
       urls: 
        - "https://mathworld.wolfram.com/ConwayGroups.html"
        - "https://en.wikipedia.org/wiki/Conway_group"
@@ -2225,7 +2277,8 @@ concepts:
       en: $1 covering relation $2
       property: infix
       area: "order theory"
-      notation: "mo ⋖<br/>mo <: "
+      notation: "mo ⋖"
+      notationa: "mo <: "
       urls: 
        - "https://en.wikipedia.org/wiki/Partially_ordered_set"
        - "https://en.wikipedia.org/wiki/Covering_relation"
@@ -2322,7 +2375,9 @@ concepts:
       en: curl of $1
       property: function
       area: "vector calculus"
-      notation: "mi curl<br/>mi rot<br/>mrow ∇ × $1"
+      notation: "mi curl"
+      notationb: "mi rot"
+      notationa: "mrow ∇ × $1"
       urls: 
        - "https://mathworld.wolfram.com/Curl.html"
        - "https://en.wikipedia.org/wiki/Curl_(mathematics)"
@@ -2334,7 +2389,8 @@ concepts:
       en: current of $1
       property: fenced
       area: "differential topology"
-      notation: "mrow [[ $1 ]]<br/>mrow [ $1 ]"
+      notation: "mrow [[ $1 ]]"
+      notationa: "mrow [ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/Current.html"
        - "https://en.wikipedia.org/wiki/Current_(mathematics)"
@@ -2380,7 +2436,8 @@ concepts:
       en: cyclotomic field of $1
       property: embellished symbol
       area: "number theory"
-      notation: "mrow Q( ζ )<br/>mrow Q( msub ζ $1"
+      notation: "mrow Q( ζ )"
+      notationa: "mrow Q( msub ζ $1"
       urls: 
        - "https://mathworld.wolfram.com/CyclotomicField.html"
        - "https://en.wikipedia.org/wiki/Cyclotomic_field"
@@ -2429,7 +2486,10 @@ concepts:
       en: dawson function of $1
       property: function
       area: "special-functions"
-      notation: "mi F<br/>mi D<br/>mi sub D -<br/>mi sub D +"
+      notation: "mi F"
+      notationc: "mi D"
+      notationb: "mi sub D -"
+      notationa: "mi sub D +"
       urls: 
        - "https://mathworld.wolfram.com/DawsonsIntegral.html"
        - "https://en.wikipedia.org/wiki/Dawson_function"
@@ -2485,7 +2545,8 @@ concepts:
       en: deductive closure of $1
       property: function
       area: "logic"
-      notation: "mi Ded<br/>mi Th"
+      notation: "mi Ded"
+      notationa: "mi Th"
       urls: 
        - "https://en.wikipedia.org/wiki/Deductive_closure"
     
@@ -2494,7 +2555,11 @@ concepts:
       en: $1 defined as $2
       property: infix
       area: "general"
-      notation: "mo ≜<br/>mo ≡<br/>mo : =<br/>mover = def<br/>mo : "
+      notation: "mo ≜"
+      notationd: "mo ≡"
+      notationc: "mo : ="
+      notationb: "mover = def"
+      notationa: "mo : "
       urls: 
        - "https://math.stackexchange.com/questions/522864/what-is-the-symbol-triangleq"
        - "https://drive.google.com/file/d/1z_dcQ6lsOA_0CsH55fwcg4hQF_w22olM/view"
@@ -2639,7 +2704,10 @@ concepts:
       en: diameter of $1
       property: symbol, prefix unit
       area: "geometry"
-      notation: "mi d<br/>mo ⌀<br/>mi DIA<br/>mi dia"
+      notation: "mi d"
+      notationc: "mo ⌀"
+      notationb: "mi DIA"
+      notationa: "mi dia"
       urls: 
        - "https://en.wikipedia.org/wiki/Diameter#Symbol"
     
@@ -2687,7 +2755,9 @@ concepts:
       en: differential operator of $1
       property: prefix
       area: "calculus"
-      notation: "mi D<br/>mo ∂<br/>mfrac d mrow d $1"
+      notation: "mi D"
+      notationb: "mo ∂"
+      notationa: "mfrac d mrow d $1"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialOperator.html"
        - "https://en.wikipedia.org/wiki/Differential_operator"
@@ -2703,7 +2773,9 @@ concepts:
       en: digamma function
       property: symbol
       area: "special functions"
-      notation: "msub ψ 0<br/>msup ψ (0)<br/>mi Ϝ"
+      notation: "msub ψ 0"
+      notationb: "msup ψ (0)"
+      notationa: "mi Ϝ"
       urls: 
        - "https://mathworld.wolfram.com/DigammaFunction.html"
        - "https://en.wikipedia.org/wiki/Digamma_function"
@@ -2713,7 +2785,9 @@ concepts:
       en: dihedral group
       property: symbol
       area: "group theory"
-      notation: "msub D $1<br/>msub Dih $1<br/>msub D 2$1"
+      notation: "msub D $1"
+      notationb: "msub Dih $1"
+      notationa: "msub D 2$1"
       urls: 
        - "https://mathworld.wolfram.com/DihedralGroup.html"
        - "https://en.wikipedia.org/wiki/Dihedral_group"
@@ -2748,7 +2822,8 @@ concepts:
       en: dimension of $1
       property: "function, fenced"
       area: "linear algebra, graph theory"
-      notation: "mi dim<br/>mrow [ $1 ]"
+      notation: "mi dim"
+      notationa: "mrow [ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
        - "https://en.wikipedia.org/wiki/Dimension_(mathematics_and_physics)"
@@ -2783,7 +2858,10 @@ concepts:
       en: dirac matrix
       property: constant
       area: "mathematical physics"
-      notation: "msup γ 0<br/>msup γ 1<br/>msup γ 2<br/>msup γ 3"
+      notation: "msup γ 0"
+      notationc: "msup γ 1"
+      notationb: "msup γ 2"
+      notationa: "msup γ 3"
       urls: 
        - "https://mathworld.wolfram.com/DiracMatrices.html"
        - "https://en.wikipedia.org/wiki/Gamma_matrices"
@@ -2860,7 +2938,9 @@ concepts:
       en: directional derivative of $1
       property: "function, mixfix"
       area: "differential calculus"
-      notation: "msub ∇ v<br/>msub D v<br/>mrow v ⋅ ∇ $1"
+      notation: "msub ∇ v"
+      notationb: "msub D v"
+      notationa: "mrow v ⋅ ∇ $1"
       urls: 
        - "https://mathworld.wolfram.com/DirectionalDerivative.html"
        - "https://en.wikipedia.org/wiki/Directional_derivative"
@@ -2954,7 +3034,9 @@ concepts:
       en: discriminant of $1
       property: function
       area: "polynomials"
-      notation: "mi Disc<br/>mi D<br/>mi Δ"
+      notation: "mi Disc"
+      notationb: "mi D"
+      notationa: "mi Δ"
       urls: 
        - "https://mathworld.wolfram.com/Discriminant.html"
        - "https://en.wikipedia.org/wiki/Discriminant"
@@ -2966,7 +3048,8 @@ concepts:
       en: disjoint union of $1
       property: indexed
       area: "set theory"
-      notation: "msup ∪ *<br/>mo ⊔"
+      notation: "msup ∪ *"
+      notationa: "mo ⊔"
       urls: 
        - "https://mathworld.wolfram.com/DisjointUnion.html"
        - "https://en.wikipedia.org/wiki/Disjoint_union"
@@ -2999,7 +3082,8 @@ concepts:
       en: divergence of $1
       property: "function, mixfix"
       area: "vector calculus"
-      notation: "mi div<br/>mrow ∇ ⋅ $1"
+      notation: "mi div"
+      notationa: "mrow ∇ ⋅ $1"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3013,7 +3097,9 @@ concepts:
       en: divided difference of $1
       property: "fenced, mixfix"
       area: "special functions"
-      notation: "mrow [ $1, ... $n ]<br/>mrow #f [$1, ..., $n ]<br/>mrow D [ $1, ... $n ] #f"
+      notation: "mrow [ $1, ... $n ]"
+      notationb: "mrow #f [$1, ..., $n ]"
+      notationa: "mrow D [ $1, ... $n ] #f"
       urls: 
        - "https://mathworld.wolfram.com/DividedDifference.html"
        - "https://en.wikipedia.org/wiki/Divided_differences"
@@ -3024,7 +3110,9 @@ concepts:
       en: $1 divisible by $2
       property: infix
       area: "number theory"
-      notation: "$1 | $2<br/>$2 ⋮ $1<br/>$2 / $1"
+      notation: "$1 | $2"
+      notationb: "$2 ⋮ $1"
+      notationa: "$2 / $1"
       urls: 
        - "https://youtu.be/9dyK_op-Ocw?t=251"
        - "https://en.wikipedia.org/wiki/Divisor"
@@ -3188,7 +3276,9 @@ concepts:
       en: dual space of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 *<br/>msup $1 $1<br/>msup $1 '"
+      notation: "msup $1 *"
+      notationb: "msup $1 $1"
+      notationa: "msup $1 '"
       urls: 
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
@@ -3201,7 +3291,9 @@ concepts:
       en: duodecimal of $1
       property: unit
       area: "arithmetic"
-      notation: "msub $1 z<br/>msub $1 12<br/>mi doz"
+      notation: "msub $1 z"
+      notationb: "msub $1 12"
+      notationa: "mi doz"
       urls: 
        - "https://mathworld.wolfram.com/Duodecimal.html"
        - "https://en.wikipedia.org/wiki/Duodecimal#Base_notation"
@@ -3227,7 +3319,8 @@ concepts:
       en: eccentricity
       property: symbol
       area: "analytic geometry, graph theory"
-      notation: "mi e<br/>mi ϵ"
+      notation: "mi e"
+      notationa: "mi ϵ"
       urls: 
        - "https://mathworld.wolfram.com/Eccentricity.html"
        - "https://en.wikipedia.org/wiki/Eccentricity_(mathematics)"
@@ -3283,7 +3376,9 @@ concepts:
       en: elliptic function of $1
       property: function
       area: "special functions"
-      notation: "mi cn<br/>mi sn<br/>mi dn"
+      notation: "mi cn"
+      notationb: "mi sn"
+      notationa: "mi dn"
       urls: 
        - "https://mathworld.wolfram.com/EllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Elliptic_function"
@@ -3439,7 +3534,9 @@ concepts:
       en: error function of $1
       property: function
       area: "special functions"
-      notation: "mi erf<br/>mi erfc<br/>mi w"
+      notation: "mi erf"
+      notationb: "mi erfc"
+      notationa: "mi w"
       urls: 
        - "https://mathworld.wolfram.com/ErrorFunction.html"
        - "https://en.wikipedia.org/wiki/Error_function"
@@ -3451,7 +3548,9 @@ concepts:
       en: $1 essential extension $2
       property: infix
       area: "abstract algebra"
-      notation: "msub ⊆ e<br/>mo ⊴<br/>mo ⊂"
+      notation: "msub ⊆ e"
+      notationb: "mo ⊴"
+      notationa: "mo ⊂"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -3519,7 +3618,8 @@ concepts:
       en: euclidean distance of $1
       property: function
       area: "geometry"
-      notation: "mi d<br/>msub d $1"
+      notation: "mi d"
+      notationa: "msub d $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Euclidean_distance"
       alias:
@@ -3566,7 +3666,8 @@ concepts:
       en: euler constant
       property: symbol
       area: "analysis"
-      notation: "mi γ<br/>mi 𝛾"
+      notation: "mi γ"
+      notationa: "mi 𝛾"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3581,7 +3682,9 @@ concepts:
       en: euler number
       property: symbol
       area: "physics"
-      notation: "mi Eu<br/>mi e<br/>mi 𝑒"
+      notation: "mi Eu"
+      notationb: "mi e"
+      notationa: "mi 𝑒"
       urls: 
        - "https://mathworld.wolfram.com/EulerNumber.html"
        - "https://en.wikipedia.org/wiki/Euler_number"
@@ -3610,7 +3713,8 @@ concepts:
       en: euler totient function of $1
       property: function
       area: "number theory"
-      notation: "mi φ<br/>mi ϕ"
+      notation: "mi φ"
+      notationa: "mi ϕ"
       urls: 
        - "https://mathworld.wolfram.com/EulerTotientFunction.html"
        - "https://en.wikipedia.org/wiki/Euler%27s_totient_function"
@@ -3646,7 +3750,11 @@ concepts:
       en: $1 exclusive or $2
       property: infix
       area: "logic"
-      notation: "mo ⊻<br/>mo ⊕<br/>mo ↮<br/>mo ≢<br/>mi XOR"
+      notation: "mo ⊻"
+      notationd: "mo ⊕"
+      notationc: "mo ↮"
+      notationb: "mo ≢"
+      notationa: "mi XOR"
       urls: 
        - "https://mathworld.wolfram.com/ExclusiveDisjunction.html"
        - "https://ncatlab.org/nlab/show/exclusive+disjunction"
@@ -3672,7 +3780,10 @@ concepts:
       en: expected value of $1
       property: function
       area: "probability theory"
-      notation: "mi E<br/>mi M<br/>msub μ $1<br/>"
+      notation: "mi E"
+      notationc: "mi M"
+      notationb: "msub μ $1"
+      notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
       alias:
@@ -3713,7 +3824,8 @@ concepts:
       en: exterior of $1
       property: "function, msup"
       area: "topology"
-      notation: "mi ext<br/>msup $1 e"
+      notation: "mi ext"
+      notationa: "msup $1 e"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
        - "https://en.wikipedia.org/wiki/Exterior_(topology)"
@@ -3778,7 +3890,9 @@ concepts:
       en: falling factorial $1 $2
       property: mixfix
       area: "combinatorics"
-      notation: "msup $1 mover $2 ¯<br/>msup $1 munder $2 ¯<br/>msub mrow ( $1 ) /mrow $2"
+      notation: "msup $1 mover $2 ¯"
+      notationb: "msup $1 munder $2 ¯"
+      notationa: "msub mrow ( $1 ) /mrow $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/FallingFactorial.html"
@@ -3973,7 +4087,10 @@ concepts:
       en: floor of $1
       property: fenced, function
       area: "number theory"
-      notation: "⌊ $1 ⌋<br/>〚 $1 〛<br/>[ $1 ]<br/>floor ($1"
+      notation: "⌊ $1 ⌋"
+      notationc: "〚 $1 〛"
+      notationb: "[ $1 ]"
+      notationa: "floor ($1"
       urls: 
        - "https://youtu.be/RxNs4SwP6lk"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -4086,7 +4203,9 @@ concepts:
       en: fractional part of $1
       property: "function, fenced"
       area: "arithmetic"
-      notation: "mi frac<br/>mrow ⟦ $1 ⟧<br/>mrow { $1 }"
+      notation: "mi frac"
+      notationb: "mrow ⟦ $1 ⟧"
+      notationa: "mrow { $1 }"
       urls: 
        - "https://mathworld.wolfram.com/FractionalPart.html"
        - "https://en.wikipedia.org/wiki/Fractional_part"
@@ -4110,7 +4229,8 @@ concepts:
       en: frattini subgroup of $1
       property: function
       area: "group theory"
-      notation: "mi φ<br/>mi ϕ"
+      notation: "mi φ"
+      notationa: "mi ϕ"
       urls: 
        - "https://mathworld.wolfram.com/FrattiniSubgroup.html"
        - "https://en.wikipedia.org/wiki/Frattini_subgroup"
@@ -4169,7 +4289,8 @@ concepts:
       en: free module $1 $2
       property: mixfix, msup
       area: "module theory"
-      notation: "mrow $1 { $2 }<br/>msup $1 ($2"
+      notation: "mrow $1 { $2 }"
+      notationa: "msup $1 ($2"
       urls: 
        - "https://mathworld.wolfram.com/FreeModule.html"
        - "https://en.wikipedia.org/wiki/Free_module"
@@ -4204,7 +4325,9 @@ concepts:
       en: fresnel integral of $1
       property: operator
       area: "special functions"
-      notation: "mi ℱ<br/>mi C<br/>mi S"
+      notation: "mi ℱ"
+      notationb: "mi C"
+      notationa: "mi S"
       urls: 
        - "https://mathworld.wolfram.com/FresnelIntegrals.html"
        - "https://en.wikipedia.org/wiki/Fresnel_integral"
@@ -4254,7 +4377,8 @@ concepts:
       en: functor category
       property: msup, fenced
       area: "category theory"
-      notation: "msup $1 $2<br/>mrow [$1, $2]"
+      notation: "msup $1 $2"
+      notationa: "mrow [$1, $2]"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -4323,7 +4447,9 @@ concepts:
       en: galois field of $1
       property: function
       area: "finite fields"
-      notation: "mrow GF ($1)<br/>msub F $1<br/>msub 𝔽 $1"
+      notation: "mrow GF ($1)"
+      notationb: "msub F $1"
+      notationa: "msub 𝔽 $1"
       urls: 
        - "https://mathworld.wolfram.com/GaloisField.html"
        - "https://en.wikipedia.org/wiki/Finite_field"
@@ -4491,7 +4617,8 @@ concepts:
       en: general linear group of $1
       property: function
       area: "group theory"
-      notation: "mi GL<br/>mi Aut"
+      notation: "mi GL"
+      notationa: "mi Aut"
       urls: 
        - "https://mathworld.wolfram.com/GeneralLinearGroup.html"
        - "https://en.wikipedia.org/wiki/General_linear_group"
@@ -4653,7 +4780,8 @@ concepts:
       en: golden ratio
       property: constant
       area: "geometry"
-      notation: "mi φ<br/>mi ϕ"
+      notation: "mi φ"
+      notationa: "mi ϕ"
       urls: 
        - "https://mathworld.wolfram.com/GoldenRatio.html"
        - "https://en.wikipedia.org/wiki/Golden_ratio"
@@ -4685,7 +4813,8 @@ concepts:
       en: gram determinant of $1
       property: function
       area: "linear algebra"
-      notation: "mi G<br/>mi Γ"
+      notation: "mi G"
+      notationa: "mi Γ"
       urls: 
        - "https://mathworld.wolfram.com/GramDeterminant.html"
        - "https://www.encyclopediaofmath.org/index.php/Gram_determinant"
@@ -4748,7 +4877,8 @@ concepts:
       en: group algebra $1 $2
       property: mixfix
       area: "ring theory"
-      notation: "mrow $1[$2]<br/>mrow $1$2"
+      notation: "mrow $1[$2]"
+      notationa: "mrow $1$2"
       urls: 
        - "https://mathworld.wolfram.com/GroupAlgebra.html"
        - "https://en.wikipedia.org/wiki/Group_algebra"
@@ -4760,7 +4890,9 @@ concepts:
       en: group of units of $1
       property: msup, function
       area: "ring theory"
-      notation: "msup $1 *<br/>msup $1 ×<br/>mi U"
+      notation: "msup $1 *"
+      notationb: "msup $1 ×"
+      notationa: "mi U"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -4770,7 +4902,8 @@ concepts:
       en: group ring $1 $2
       property: mixfix, infix
       area: "ring theory"
-      notation: "mrow $1 [ $2 ]<br/>mrow $1 $2"
+      notation: "mrow $1 [ $2 ]"
+      notationa: "mrow $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/GroupRing.html"
        - "https://en.wikipedia.org/wiki/Group_ring"
@@ -4794,7 +4927,8 @@ concepts:
       en: $1 hadamard product $2
       property: infix
       area: "algebra"
-      notation: "mo ∘<br/>mo ⊙"
+      notation: "mo ∘"
+      notationa: "mo ⊙"
       urls: 
        - "https://mathworld.wolfram.com/HadamardProduct.html"
        - "https://en.wikipedia.org/wiki/Hadamard_product_(matrices)"
@@ -4820,7 +4954,10 @@ concepts:
       en: hamiltonian of $1
       property: operator
       area: "quantum mechanics"
-      notation: "mi H<br/>mover H ˇ<br/>mover H ^<br/>mrow < H >"
+      notation: "mi H"
+      notationc: "mover H ˇ"
+      notationb: "mover H ^"
+      notationa: "mrow < H >"
       urls: 
        - "https://en.wikipedia.org/wiki/Hamiltonian_(quantum_mechanics)"
        - "https://en.wikipedia.org/wiki/Hamiltonian_vector_field"
@@ -4972,7 +5109,8 @@ concepts:
       en: height function of $1
       property: function
       area: "algebra"
-      notation: "mi H<br/>mi h"
+      notation: "mi H"
+      notationa: "mi h"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_of_a_polynomial"
     
@@ -5016,7 +5154,8 @@ concepts:
       en: hermite polynomial of $1
       property: function
       area: "special functions"
-      notation: "mi H<br/>mi He"
+      notation: "mi H"
+      notationa: "mi He"
       urls: 
        - "https://mathworld.wolfram.com/HermitePolynomial.html"
        - "https://en.wikipedia.org/wiki/Hermite_polynomials"
@@ -5029,7 +5168,8 @@ concepts:
       en: hermitian adjoint of $1
       property: msup
       area: "functional analysis"
-      notation: "msup †,<br/>msup *"
+      notation: "msup †,"
+      notationa: "msup *"
       urls: 
        - "https://en.wikipedia.org/wiki/Hermitian_adjoint"
       alias:
@@ -5077,7 +5217,8 @@ concepts:
       en: heun function of $1
       property: function
       area: "special functions"
-      notation: "mi Hf<br/>mi H⁢ℓ"
+      notation: "mi Hf"
+      notationa: "mi H⁢ℓ"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.1"
@@ -5101,7 +5242,9 @@ concepts:
       en: hexadecimal of $1
       property: unit
       area: "arithmetic"
-      notation: "mi hex<br/>msub $1 hex<br/>msub $1 16"
+      notation: "mi hex"
+      notationb: "msub $1 hex"
+      notationa: "msub $1 16"
       urls: 
        - "https://mathworld.wolfram.com/Hexadecimal.html"
        - "https://en.wikipedia.org/wiki/Hexadecimal"
@@ -5230,7 +5373,12 @@ concepts:
       en: horsepower metric of $1
       property: unit
       area: "metric unit"
-      notation: "mi PS<br/>mi cv<br/>mi hk<br/>mi pk<br/>mi ks<br/>mi ch"
+      notation: "mi PS"
+      notatione: "mi cv"
+      notationd: "mi hk"
+      notationc: "mi pk"
+      notationb: "mi ks"
+      notationa: "mi ch"
       urls: 
        - "https://en.wikipedia.org/wiki/Metric_horsepower"
       alias:
@@ -5267,7 +5415,8 @@ concepts:
       en: $1 hydrated compound $2
       property: infix
       area: "chemistry"
-      notation: "mo ⋅<br/>mo •"
+      notation: "mo ⋅"
+      notationa: "mo •"
       urls: 
        - "https://en.wikipedia.org/wiki/Hydrate"
        - "https://en.wikipedia.org/wiki/Cobalt(II)_chloride"
@@ -5331,7 +5480,8 @@ concepts:
       en: hyperdeterminant of $1
       property: "function, fenced"
       area: "multilinear algebra"
-      notation: "mi det<br/>mrow | $1 |"
+      notation: "mi det"
+      notationa: "mrow | $1 |"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
        - "https://en.wikipedia.org/wiki/Hyperdeterminant"
@@ -5354,7 +5504,10 @@ concepts:
       en: identity element
       property: symbol
       area: "group theory"
-      notation: "mi e<br/>mi I<br/>mi E<br/>mn 1"
+      notation: "mi e"
+      notationc: "mi I"
+      notationb: "mi E"
+      notationa: "mn 1"
       urls: 
        - "https://mathworld.wolfram.com/IdentityElement.html"
        - "https://en.wikipedia.org/wiki/Identity_element"
@@ -5368,7 +5521,9 @@ concepts:
       en: identity function of $1
       property: function
       area: "algebra"
-      notation: "mi id<br/>msub id $1<br/>msub I $1"
+      notation: "mi id"
+      notationb: "msub id $1"
+      notationa: "msub I $1"
       urls: 
        - "https://mathworld.wolfram.com/IdentityFunction.html"
        - "https://en.wikipedia.org/wiki/Identity_function"
@@ -5383,7 +5538,9 @@ concepts:
       en: identity functor of $1
       property: function
       area: "category theory"
-      notation: "msub 1 $1<br/>msubI$1<br/>msub Id $1"
+      notation: "msub 1 $1"
+      notationb: "msubI$1"
+      notationa: "msub Id $1"
       urls: 
        - "https://ncatlab.org/nlab/show/identity+functor"
        - "https://en.wikipedia.org/wiki/Functor"
@@ -5406,7 +5563,10 @@ concepts:
       en: image $1 $2
       property: mixfix
       area: "set theory"
-      notation: "$1 [ $2 ]<br/>msub $1 *<br/>msup $1 →<br/>$1 '' $2"
+      notation: "$1 [ $2 ]"
+      notationc: "msub $1 *"
+      notationb: "msup $1 →"
+      notationa: "$1 '' $2"
       urls: 
        - "https://mathworld.wolfram.com/Image.html"
        - "https://en.wikipedia.org/wiki/Image_(mathematics)"
@@ -5551,7 +5711,8 @@ concepts:
       en: $1 independent $2
       property: infix
       area: "probability theory"
-      notation: "mo ⟂<br/>mo ⫫"
+      notation: "mo ⟂"
+      notationa: "mo ⫫"
       urls: 
        - "https://en.wikipedia.org/wiki/Independence_(probability_theory)"
        - "https://en.wikipedia.org/wiki/Independence_(mathematical_logic)"
@@ -5562,7 +5723,9 @@ concepts:
       en: index of subgroup
       property: fenced
       area: "group theory"
-      notation: "mrow [ $1 : $2 ]<br/>mrow ( $1 : $2 )<br/>mrow |$1 : $2 |"
+      notation: "mrow [ $1 : $2 ]"
+      notationb: "mrow ( $1 : $2 )"
+      notationa: "mrow |$1 : $2 |"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_subgroup"
     
@@ -5581,7 +5744,8 @@ concepts:
       en: infimum of $1
       property: "function, largeop"
       area: "order theory"
-      notation: "mi inf<br/>mo ⋀"
+      notation: "mi inf"
+      notationa: "mo ⋀"
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
        - "https://en.wikipedia.org/wiki/Infimum_and_supremum"
@@ -5594,7 +5758,8 @@ concepts:
       en: infimum limit of $1
       property: indexed
       area: "limits"
-      notation: "mi lim inf<br/>munder lim ¯"
+      notation: "mi lim inf"
+      notationa: "munder lim ¯"
       urls: 
        - "https://mathworld.wolfram.com/InfimumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
@@ -5667,7 +5832,8 @@ concepts:
       en: $1 inner product $2
       property: infix, fenced
       area: "linear algebra"
-      notation: "mo ⋅<br/>mrow [ $1, $2 ]"
+      notation: "mo ⋅"
+      notationa: "mrow [ $1, $2 ]"
       urls: 
        - "https://mathworld.wolfram.com/InnerProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -5689,7 +5855,8 @@ concepts:
       en: integer part of $1
       property: "function, fenced"
       area: "number theory"
-      notation: "mi int<br/>[ $1 ]"
+      notation: "mi int"
+      notationa: "[ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/IntegerPart.html"
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
@@ -5699,7 +5866,8 @@ concepts:
       en: interior of $1
       property: msup
       area: "topology"
-      notation: "msup $1 o<br/>msup $1 ∘"
+      notation: "msup $1 o"
+      notationa: "msup $1 ∘"
       urls: 
        - "https://mathworld.wolfram.com/Interior.html"
        - "https://en.wikipedia.org/wiki/Interior_(topology)"
@@ -5711,7 +5879,8 @@ concepts:
       en: interior product of $1
       property: "infix, indexed function"
       area: "differential forms"
-      notation: "mo ⨼<br/>msub ι $1"
+      notation: "mo ⨼"
+      notationa: "msub ι $1"
       urls: 
        - "https://mathworld.wolfram.com/InteriorProduct.html"
        - "https://en.wikipedia.org/wiki/Interior_product"
@@ -5721,7 +5890,8 @@ concepts:
       en: $1 intersection number $2
       property: infix
       area: "algebraic geometry"
-      notation: "mo ⋅<br/>"
+      notation: "mo ⋅"
+      notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Intersection_number"
     
@@ -5753,9 +5923,10 @@ concepts:
     - concept: inverse-moment-of-function
       arity: 2
       en: inverse moment of function $1 $2
-      property: "<br/>msub, mixfix"
+      property: "msub, mixfix"
       area: "mathematics"
-      notation: "msub μ mrow - $1 /mrow<br/>mrow E [ msup $1 mrow - $2 /mrow ]"
+      notation: "msub μ mrow - $1 /mrow"
+      notationa: "mrow E [ msup $1 mrow - $2 /mrow ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
       alias:
@@ -5786,7 +5957,8 @@ concepts:
       en: ionic charge
       property: msup
       area: "chemistry"
-      notation: "msup $1 $2<br/>"
+      notation: "msup $1 $2"
+      notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Ion#Chemistry"
     
@@ -5805,7 +5977,8 @@ concepts:
       en: $1 isomorphism $2
       property: infix
       area: "set theory"
-      notation: "mover ↦ ∼<br/>mo ≅"
+      notation: "mover ↦ ∼"
+      notationa: "mo ≅"
       urls: 
        - "https://mathworld.wolfram.com/Isomorphism.html"
        - "https://en.wikipedia.org/wiki/Isomorphism"
@@ -5914,7 +6087,12 @@ concepts:
       en: jacobian elliptic function of $1
       property: function
       area: "special-functions"
-      notation: "mi sn<br/>mi cn<br/>mi dn<br/>mi sd<br/>mi cd<br/>mi sc"
+      notation: "mi sn"
+      notatione: "mi cn"
+      notationd: "mi dn"
+      notationc: "mi sd"
+      notationb: "mi cd"
+      notationa: "mi sc"
       urls: 
        - "https://dlmf.nist.gov/22.2"
        - "https://dlmf.nist.gov/22.2#E5"
@@ -5929,7 +6107,8 @@ concepts:
       en: jacobson radical of $1
       property: function
       area: "ring theory"
-      notation: "mi J<br/>mi rad"
+      notation: "mi J"
+      notationa: "mi rad"
       urls: 
        - "https://mathworld.wolfram.com/JacobsonRadical.html"
        - "https://en.wikipedia.org/wiki/Jacobson_radical"
@@ -5952,7 +6131,10 @@ concepts:
       en: janko group
       property: symbol
       area: "group theory"
-      notation: "msub J 1<br/>msub J 2<br/>msub J 3<br/>msub J 4"
+      notation: "msub J 1"
+      notationc: "msub J 2"
+      notationb: "msub J 3"
+      notationa: "msub J 4"
       urls: 
        - "https://mathworld.wolfram.com/JankoGroups.html"
        - "https://en.wikipedia.org/wiki/Janko_group"
@@ -6065,7 +6247,8 @@ concepts:
       en: kelvin function of $1
       property: function
       area: "special functions"
-      notation: "msub ber ν⁡<br/>msub bei ν⁡"
+      notation: "msub ber ν⁡"
+      notationa: "msub bei ν⁡"
       urls: 
        - "https://mathworld.wolfram.com/KelvinFunctions.html"
        - "https://en.wikipedia.org/wiki/Kelvin_functions"
@@ -6102,7 +6285,8 @@ concepts:
       en: khinchin constant
       property: constant
       area: "continued fractions"
-      notation: "mi K<br/>msub K 0"
+      notation: "mi K"
+      notationa: "msub K 0"
       urls: 
        - "https://mathworld.wolfram.com/KhinchinsConstant.html"
        - "https://en.wikipedia.org/wiki/Khinchin%27s_constant"
@@ -6143,7 +6327,8 @@ concepts:
       en: klein four group
       property: symbol
       area: "group theory"
-      notation: "mi V<br/>msub K 4"
+      notation: "mi V"
+      notationa: "msub K 4"
       urls: 
        - "https://mathworld.wolfram.com/KleinFour-Group.html"
        - "https://en.wikipedia.org/wiki/Klein_four-group"
@@ -6153,7 +6338,8 @@ concepts:
       en: kloosterman sum of $1
       property: function
       area: "analytic number theory"
-      notation: "mi S<br/>mi K"
+      notation: "mi S"
+      notationa: "mi K"
       urls: 
        - "https://mathworld.wolfram.com/KloostermansSum.html"
        - "https://en.wikipedia.org/wiki/Kloosterman_sum"
@@ -6163,7 +6349,8 @@ concepts:
       en: kneser graph
       property: "indexed symbol"
       area: "graph theory"
-      notation: "mrow K ( $1, $2 )<br/>msub mi KG /mi $1, $2"
+      notation: "mrow K ( $1, $2 )"
+      notationa: "msub mi KG /mi $1, $2"
       urls: 
        - "https://mathworld.wolfram.com/KneserGraph.html"
        - "https://en.wikipedia.org/wiki/Kneser_graph"
@@ -6275,7 +6462,8 @@ concepts:
       en: kronecker symbol
       property: fenced, fenced stacked
       area: "number theory"
-      notation: "mrow ( $1 | $2 )<br/>( mfrac $1 $2 )"
+      notation: "mrow ( $1 | $2 )"
+      notationa: "( mfrac $1 $2 )"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerSymbol.html"
        - "https://en.wikipedia.org/wiki/Kronecker_symbol"
@@ -6309,7 +6497,8 @@ concepts:
       en: kullback leibler distance of $1
       property: function
       area: "mathematical statistics"
-      notation: "mi KL<br/>msub D KL"
+      notation: "mi KL"
+      notationa: "msub D KL"
       urls: 
        - "http://users.monash.edu/~lloyd/tildeMML/KL/"
        - "https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence"
@@ -6351,7 +6540,11 @@ concepts:
       en: lagrange point
       property: symbol
       area: "celestial mechanics"
-      notation: "msub L 1<br/>msub L 2<br/>msub L 3<br/>msub L 4<br/>msub L 5"
+      notation: "msub L 1"
+      notationd: "msub L 2"
+      notationc: "msub L 3"
+      notationb: "msub L 4"
+      notationa: "msub L 5"
       urls: 
        - "https://en.wikipedia.org/wiki/Lagrange_point"
       alias:
@@ -6379,7 +6572,9 @@ concepts:
       en: landau constant
       property: constant
       area: "complex analysis"
-      notation: "mi A<br/>mi B<br/>mi L"
+      notation: "mi A"
+      notationb: "mi B"
+      notationa: "mi L"
       urls: 
        - "https://mathworld.wolfram.com/LandauConstant.html"
        - "https://en.wikipedia.org/wiki/Landau%27s_constants"
@@ -6387,9 +6582,11 @@ concepts:
     - concept: laplace-operator
       arity: 1
       en: laplace operator of $1
-      property: "<br/>embellished operator, "
+      property: "embellished operator"
       area: "differential operators"
-      notation: "msup ∇ 2<br/>mrow ∇ · ∇<br/>mi Δ"
+      notation: "msup ∇ 2"
+      notationb: "mrow ∇ · ∇"
+      notationa: "mi Δ"
       urls: 
        - "https://en.wikipedia.org/wiki/Laplace_operator"
        - "https://ncatlab.org/nlab/show/Laplace+operator"
@@ -6545,7 +6742,8 @@ concepts:
       en: legendre symbol
       property: fenced, fenced stacked
       area: "number theory"
-      notation: "mrow ( $1 | $2 )<br/>mrow ( mfrac $1 $2 )"
+      notation: "mrow ( $1 | $2 )"
+      notationa: "mrow ( mfrac $1 $2 )"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
@@ -6615,7 +6813,8 @@ concepts:
       en: $1 lexicographic product $2
       property: infix, mixfix
       area: "graph theory"
-      notation: "mo ∙<br/>$1 [ $2 ]"
+      notation: "mo ∙"
+      notationa: "$1 [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Lexicographic_product_of_graphs"
       alias:
@@ -6723,7 +6922,9 @@ concepts:
       en: gunter link of $1
       property: unit
       area: "units"
-      notation: "mi l.<br/>mi li.<br/>mi lnk."
+      notation: "mi l."
+      notationb: "mi li."
+      notationa: "mi lnk."
       urls: 
        - "https://en.wikipedia.org/wiki/Link_(unit)"
     
@@ -6779,7 +6980,7 @@ concepts:
     - concept: logarithmic-moment-of-function
       arity: 2
       en: logarithmic moment of function $1 $2
-      property: "<br/>, mixfix"
+      property: "mixfix"
       area: "mathematics"
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
       urls: 
@@ -6802,7 +7003,8 @@ concepts:
       en: lommel function
       property: "indexed function"
       area: "special functions"
-      notation: "msub S mrow $1,$2 /mrow<br/>msub s mrow $1, $2 /mrow"
+      notation: "msub S mrow $1,$2 /mrow"
+      notationa: "msub s mrow $1, $2 /mrow"
       urls: 
        - "https://mathworld.wolfram.com/LommelFunction.html"
        - "https://en.wikipedia.org/wiki/Lommel_function"
@@ -6868,7 +7070,8 @@ concepts:
       en: lower shadow of $1
       property: function
       area: "combinatorics"
-      notation: "mi 𝜕<br/>msub 𝜕 -"
+      notation: "mi 𝜕"
+      notationa: "msub 𝜕 -"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
       alias:
@@ -6890,7 +7093,8 @@ concepts:
       en: lucas sequence of $1
       property: "indexed function"
       area: "integer sequences"
-      notation: "msub U $1<br/>msub V $1"
+      notation: "msub U $1"
+      notationa: "msub V $1"
       urls: 
        - "https://mathworld.wolfram.com/LucasSequence.html"
        - "https://en.wikipedia.org/wiki/Lucas_sequence"
@@ -6961,7 +7165,8 @@ concepts:
       en: mapping cone of $1
       property: "indexed symbol"
       area: "homotopy theory"
-      notation: "msub C $1<br/>mrow C $1"
+      notation: "msub C $1"
+      notationa: "mrow C $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_cone_(topology)"
        - "https://en.wikipedia.org/wiki/Mapping_cone_(homological_algebra)"
@@ -6974,7 +7179,9 @@ concepts:
       en: matching polynomial of $1
       property: "indexed function"
       area: "graph theory"
-      notation: "msub m $1<br/>msub M $1<br/>msub μ $1"
+      notation: "msub m $1"
+      notationb: "msub M $1"
+      notationa: "msub μ $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Matching_polynomial"
     
@@ -6983,7 +7190,8 @@ concepts:
       en: mathieu function of first kind of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub ce $1<br/>msub se $1"
+      notation: "msub ce $1"
+      notationa: "msub se $1"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7006,7 +7214,8 @@ concepts:
       en: mathieu function of second kind of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub fe $1<br/>msub ge $1"
+      notation: "msub fe $1"
+      notationa: "msub ge $1"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7029,7 +7238,11 @@ concepts:
       en: mathieu group of $1
       property: "indexed symbol"
       area: "group theory"
-      notation: "msub M 11<br/>msub M 12<br/>msub M 22<br/>msub M 23<br/>msub M 24"
+      notation: "msub M 11"
+      notationd: "msub M 12"
+      notationc: "msub M 22"
+      notationb: "msub M 23"
+      notationa: "msub M 24"
       urls: 
        - "https://mathworld.wolfram.com/MathieuGroups.html"
        - "https://en.wikipedia.org/wiki/Multiply_transitive_group"
@@ -7047,7 +7260,9 @@ concepts:
       en: matrix of $1
       property: mtable, fenced
       area: "algebra"
-      notation: "mtable<br/>mrow [ $1 ]<br/>mrow ( $1"
+      notation: "mtable"
+      notationb: "mrow [ $1 ]"
+      notationa: "mrow ( $1"
       urls: 
        - "https://mathworld.wolfram.com/Matrix.html"
        - "https://mathworld.wolfram.com/SquareBracket.html"
@@ -7218,7 +7433,8 @@ concepts:
       en: mills ratio of $1
       property: function
       area: "probability theory"
-      notation: "mi m<br/>mi M"
+      notation: "mi m"
+      notationa: "mi M"
       urls: 
        - "https://mathworld.wolfram.com/MillsRatio.html"
        - "https://en.wikipedia.org/wiki/Mills_ratio"
@@ -7314,7 +7530,11 @@ concepts:
       en: modified mathieu function of $1
       property: function
       area: "special functions"
-      notation: "msub Ce $1<br/>msub Se $1<br/>msub Me $1<br/>msub Fe $1<br/>msub Ge $1"
+      notation: "msub Ce $1"
+      notationd: "msub Se $1"
+      notationc: "msub Me $1"
+      notationb: "msub Fe $1"
+      notationa: "msub Ge $1"
       urls: 
        - "https://dlmf.nist.gov/28#PT4"
        - "https://dlmf.nist.gov/28.20#E3"
@@ -7333,7 +7553,9 @@ concepts:
       en: modified spherical bessel function of $1
       property: function
       area: "special functions"
-      notation: "msubsup i $1 (1)<br/>msubsup i $1 (2)<br/>msub k $1"
+      notation: "msubsup i $1 (1)"
+      notationb: "msubsup i $1 (2)"
+      notationa: "msub k $1"
       urls: 
        - "https://mathworld.wolfram.com/ModifiedSphericalBesselFunction.html"
        - "https://dlmf.nist.gov/10.47#E7"
@@ -7367,7 +7589,8 @@ concepts:
       en: $1 modulo $2
       property: infix, mixfix
       area: "modular arithmetic"
-      notation: "mo mod<br/>mrow $1 ( mod $2"
+      notation: "mo mod"
+      notationa: "mrow $1 ( mod $2"
       urls: 
        - "https://mathworld.wolfram.com/Modulo.html"
        - "https://en.wikipedia.org/wiki/Modulo_(jargon)"
@@ -7390,9 +7613,10 @@ concepts:
     - concept: moment-of-function
       arity: 2
       en: moment of function $1 $2
-      property: "<br/>msub, mixfix"
+      property: "msub, mixfix"
       area: "mathematics"
-      notation: "msub μ $1<br/>mrow E [ msup $1 $2 ]"
+      notation: "msub μ $1"
+      notationa: "mrow E [ msup $1 $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
       alias:
@@ -7485,7 +7709,8 @@ concepts:
       en: motzkin number of $1
       property: "indexed symbol"
       area: "combinatorial analysis"
-      notation: "msub M $1<br/>mi M"
+      notation: "msub M $1"
+      notationa: "mi M"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
        - "https://en.wikipedia.org/wiki/Motzkin_number"
@@ -7497,7 +7722,8 @@ concepts:
       en: multiple integral of $1
       property: indexed
       area: "multivariable calculus"
-      notation: "mo ∫ ⋯ ∫<br/>mo ∫"
+      notation: "mo ∫ ⋯ ∫"
+      notationa: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/MultipleIntegral.html"
        - "https://en.wikipedia.org/wiki/%E2%88%AB%E2%88%ABf(x,y)dxdy"
@@ -7509,7 +7735,8 @@ concepts:
       en: multiplicative inverse of $1
       property: msup, mixfix
       area: "abstract algebra"
-      notation: "msup $1 -1<br/>mrow 1 / $1"
+      notation: "msup $1 -1"
+      notationa: "mrow 1 / $1"
       urls: 
        - "https://mathworld.wolfram.com/Inverse.html"
        - "https://en.wikipedia.org/wiki/Inverse_function"
@@ -7525,7 +7752,8 @@ concepts:
       en: multiplicative order of $1
       property: "indexed function"
       area: "modular arithmetic"
-      notation: "msub O $1<br/>msub ord $1"
+      notation: "msub O $1"
+      notationa: "msub ord $1"
       urls: 
        - "https://mathworld.wolfram.com/MultiplicativeOrder.html"
        - "https://en.wikipedia.org/wiki/Multiplicative_order"
@@ -7654,7 +7882,8 @@ concepts:
       en: neighbourhood
       property: "indexed function, function"
       area: "graph theory"
-      notation: "msub N $1 ( $2 )<br/>mrow N ( $1"
+      notation: "msub N $1 ( $2 )"
+      notationa: "mrow N ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_(graph_theory)"
       alias:
@@ -7748,7 +7977,8 @@ concepts:
       en: norm of $1
       property: fenced
       area: "linear algebra"
-      notation: "mrow ‖ $1 ‖<br/>mrow | $1"
+      notation: "mrow ‖ $1 ‖"
+      notationa: "mrow | $1"
       urls: 
        - "https://mathworld.wolfram.com/Norm.html"
        - "https://en.wikipedia.org/wiki/Norm_(mathematics)"
@@ -7829,7 +8059,9 @@ concepts:
       en: octonions
       property: symbol
       area: "compositional algebra"
-      notation: "mi 𝕆<br/>miO<br/>mi O"
+      notation: "mi 𝕆"
+      notationb: "miO"
+      notationa: "mi O"
       urls: 
        - "https://mathworld.wolfram.com/Octonion.html"
        - "https://en.wikipedia.org/wiki/Octonion"
@@ -7877,7 +8109,8 @@ concepts:
       en: open interval
       property: fenced
       area: "algebra"
-      notation: "mrow ( $1, $2 )<br/>mrow ] $1 , $2 ["
+      notation: "mrow ( $1, $2 )"
+      notationa: "mrow ] $1 , $2 ["
       urls: 
        - "https://mathworld.wolfram.com/OpenInterval.html"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p1.t1.r28"
@@ -7933,7 +8166,8 @@ concepts:
       en: order of group of $1
       property: "function, fenced"
       area: "group theory"
-      notation: "mi ord<br/>mrow | $1 |"
+      notation: "mi ord"
+      notationa: "mrow | $1 |"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
     
@@ -8077,7 +8311,11 @@ concepts:
       en: parallel morphism
       property: embellished infix
       area: "category theory"
-      notation: "<munderover><br/><mrow/><br/><munder><mo>⟶</mo> $1</munder><br/><mover><mo>⟶</mo> $2</mover><br/></munderover>"
+      notation: "<munderover>"
+      notationd: "<mrow/>"
+      notationc: "<munder><mo>⟶</mo> $1</munder>"
+      notationb: "<mover><mo>⟶</mo> $2</mover>"
+      notationa: "</munderover>"
       urls: 
        - "https://ncatlab.org/nlab/show/parallel+morphisms"
     
@@ -8086,7 +8324,8 @@ concepts:
       en: partial charge
       property: symbol
       area: "chemistry"
-      notation: "msup δ $1<br/>mrow δ $1"
+      notation: "msup δ $1"
+      notationa: "mrow δ $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Partial_charge"
        - "https://chem.libretexts.org/Bookshelves/General_Chemistry/Map%3A_Chemistry_-_The_Central_Science_(Brown_et_al.)/08._Basic_Concepts_of_Chemical_Bonding/8.S%3A_Basic_Concepts_of_Chemical_Bonding_(Summary)"
@@ -8203,9 +8442,11 @@ concepts:
     - concept: permutation
       arity: 1
       en: permutation of $1
-      property: fenced<br/>mtable, mixfix
+      property: fenced, mtable, mixfix
       area: "combinatorics"
-      notation: "mrow ($1, ... $n)<br/>mtable<br/>mrow (312)(54)(8)(976"
+      notation: "mrow ($1, ... $n)"
+      notationb: "mtable"
+      notationa: "mrow (312)(54)(8)(976"
       urls: 
        - "https://mathworld.wolfram.com/Permutation.html"
        - "https://en.wikipedia.org/wiki/Permutation"
@@ -8240,7 +8481,8 @@ concepts:
       en: pfaffian of $1
       property: function
       area: "multilinear algebra"
-      notation: "mi Pf<br/>mi pf"
+      notation: "mi Pf"
+      notationa: "mi pf"
       urls: 
        - "https://mathworld.wolfram.com/Pfaffian.html"
        - "https://en.wikipedia.org/wiki/Pfaffian"
@@ -8266,7 +8508,8 @@ concepts:
       en: phase of $1
       property: function
       area: "physics"
-      notation: "mi ϕ<br/>mi ph"
+      notation: "mi ϕ"
+      notationa: "mi ph"
       urls: 
        - "https://mathworld.wolfram.com/Phase.html"
        - "https://en.wikipedia.org/wiki/Phase_(waves)"
@@ -8278,7 +8521,8 @@ concepts:
       en: phi coefficient
       property: symbol
       area: "statistics"
-      notation: "mi φ<br/>msub r φ"
+      notation: "mi φ"
+      notationa: "msub r φ"
       urls: 
        - "https://en.wikipedia.org/wiki/Phi_coefficient"
       alias:
@@ -8302,7 +8546,8 @@ concepts:
       en: planck constant
       property: constant
       area: "physics"
-      notation: "mi h<br/>mi ℎ"
+      notation: "mi h"
+      notationa: "mi ℎ"
       urls: 
        - "https://en.wikipedia.org/wiki/Planck_constant"
        - "https://ncatlab.org/nlab/show/Planck's+constant"
@@ -8313,7 +8558,8 @@ concepts:
       en: plastic constant
       property: constant
       area: "geometry"
-      notation: "mi P<br/>mi p"
+      notation: "mi P"
+      notationa: "mi p"
       urls: 
        - "https://mathworld.wolfram.com/PlasticConstant.html"
        - "https://en.wikipedia.org/wiki/Plastic_number"
@@ -8330,7 +8576,10 @@ concepts:
       en: playing card suit of $1
       property: unit
       area: "game theory"
-      notation: "mo ♣<br/>mo ♠<br/>mo ♦<br/>mo ♥"
+      notation: "mo ♣"
+      notationc: "mo ♠"
+      notationb: "mo ♦"
+      notationa: "mo ♥"
       urls: 
        - "https://en.wikipedia.org/wiki/Playing_card_suit"
        - "https://en.wikipedia.org/wiki/Poker_probability"
@@ -8479,7 +8728,8 @@ concepts:
       en: positive part of $1
       property: msup, msub
       area: "elementary mathematics"
-      notation: "msup $1 +<br/>msub $1 +"
+      notation: "msup $1 +"
+      notationa: "msub $1 +"
       urls: 
        - "https://mathworld.wolfram.com/PositiveElement.html"
        - "https://en.wikipedia.org/wiki/Positive_and_negative_parts"
@@ -8510,7 +8760,11 @@ concepts:
       en: power set of $1
       property: "function, msup"
       area: "set theory"
-      notation: "mi P<br/>mi 𝒫<br/>mi ℙ<br/>mi ℘<br/>msup 2 $1"
+      notation: "mi P"
+      notationd: "mi 𝒫"
+      notationc: "mi ℙ"
+      notationb: "mi ℘"
+      notationa: "msup 2 $1"
       urls: 
        - "https://mathworld.wolfram.com/PowerSet.html"
        - "https://en.wikipedia.org/wiki/Power_set"
@@ -8530,7 +8784,8 @@ concepts:
       en: present value
       property: symbol
       area: "economics"
-      notation: "mi PV<br/>mi v"
+      notation: "mi PV"
+      notationa: "mi v"
       urls: 
        - "https://mathworld.wolfram.com/PresentValue.html"
        - "https://en.wikipedia.org/wiki/Present_value"
@@ -8540,7 +8795,8 @@ concepts:
       en: prime constant
       property: symbol
       area: "number theory"
-      notation: "mi P<br/>mi ρ"
+      notation: "mi P"
+      notationa: "mi ρ"
       urls: 
        - "https://mathworld.wolfram.com/PrimeConstant.html"
        - "https://en.wikipedia.org/wiki/Prime_constant"
@@ -8572,7 +8828,8 @@ concepts:
       en: prime gap of $1
       property: "indexed function"
       area: "number theory"
-      notation: "mi G<br/>mi g"
+      notation: "mi G"
+      notationa: "mi g"
       urls: 
        - "https://mathworld.wolfram.com/PrimeGaps.html"
        - "https://en.wikipedia.org/wiki/Prime_gap"
@@ -8646,7 +8903,8 @@ concepts:
       en: projective space
       property: symbol
       area: "projective geometry"
-      notation: "mi ℙ<br/>mi ℝ⁢ ℙ"
+      notation: "mi ℙ"
+      notationa: "mi ℝ⁢ ℙ"
       urls: 
        - "https://mathworld.wolfram.com/ProjectiveSpace.html"
        - "https://en.wikipedia.org/wiki/Algebraic_geometry_of_projective_spaces"
@@ -8781,7 +9039,8 @@ concepts:
       en: qed
       property: symbol
       area: "mathematical symbols"
-      notation: "mo □<br/>mo ∎"
+      notation: "mo □"
+      notationa: "mo ∎"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -8877,7 +9136,8 @@ concepts:
       en: radial mathieu function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi Mc<br/>mi Ms"
+      notation: "mi Mc"
+      notationa: "mi Ms"
       urls: 
        - "https://dlmf.nist.gov/28.20#iv"
        - "https://dlmf.nist.gov/28.20#E15"
@@ -8903,7 +9163,9 @@ concepts:
       en: radius vector
       property: symbol
       area: "geometry"
-      notation: "mix<br/>mir<br/>mis"
+      notation: "mix"
+      notationb: "mir"
+      notationa: "mis"
       urls: 
        - "https://mathworld.wolfram.com/RadiusVector.html"
        - "https://en.wikipedia.org/wiki/Position_(vector)"
@@ -8976,7 +9238,9 @@ concepts:
       en: rank of $1
       property: function
       area: "graph theory, linear algebra, "
-      notation: "mi r<br/>mi rank<br/>mi rk"
+      notation: "mi r"
+      notationb: "mi rank"
+      notationa: "mi rk"
       urls: 
        - "https://mathworld.wolfram.com/Rank.html"
        - "https://en.wikipedia.org/wiki/Rank_(graph_theory)"
@@ -9001,7 +9265,9 @@ concepts:
       en: real part of $1
       property: function
       area: "complex analysis"
-      notation: "mi ℜ<br/>mi Re<br/>mi ℛℯ"
+      notation: "mi ℜ"
+      notationb: "mi Re"
+      notationa: "mi ℛℯ"
       urls: 
        - "https://mathworld.wolfram.com/RealPart.html"
        - "https://dlmf.nist.gov/1.9#E2"
@@ -9044,7 +9310,8 @@ concepts:
       en: reciprocal polynomial of $1
       property: msup
       area: "algebra"
-      notation: "msup $1 *<br/>msup $1 R"
+      notation: "msup $1 *"
+      notationa: "msup $1 R"
       urls: 
        - "https://mathworld.wolfram.com/ReciprocalPolynomial.html"
        - "https://en.wikipedia.org/wiki/Reciprocal_polynomial"
@@ -9102,7 +9369,8 @@ concepts:
       en: residue of $1
       property: function
       area: "complex analysis"
-      notation: "mi Res<br/>mi res"
+      notation: "mi Res"
+      notationa: "mi res"
       urls: 
        - "https://mathworld.wolfram.com/Residue.html"
        - "https://en.wikipedia.org/wiki/Residue_(complex_analysis)"
@@ -9135,7 +9403,8 @@ concepts:
       en: restricted quantifier $1 $2
       property: mixfix
       area: "formal logic"
-      notation: "msub mrow ( Ǝ $1 ) /mrow $2<br/>msub mrow ( ∀ $1 ) /mrow $2"
+      notation: "msub mrow ( Ǝ $1 ) /mrow $2"
+      notationa: "msub mrow ( ∀ $1 ) /mrow $2"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Restricted_quantifier"
        - "https://human.libretexts.org/Bookshelves/Philosophy/Book%3A_A_Modern_Formal_Logic_Primer_(Teller)/Volume_II%3A_Predicate_Logic/4%3A_Transcription/4.1%3A_Restricted_Quantifiers"
@@ -9145,7 +9414,8 @@ concepts:
       en: $1 restricted wreath product $2
       property: infix
       area: "group theory"
-      notation: "mo wr<br/>msub wr $1"
+      notation: "mo wr"
+      notationa: "msub wr $1"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -9157,7 +9427,8 @@ concepts:
       en: restriction
       property: indexed postfix
       area: "elementary mathematics"
-      notation: "$1 mo msub ↾ $2 /mo<br/>$1 mo msub | $2 /mo"
+      notation: "$1 mo msub ↾ $2 /mo"
+      notationa: "$1 mo msub | $2 /mo"
       urls: 
        - "https://en.wikipedia.org/wiki/Restricted_representation"
        - "https://en.wikipedia.org/wiki/Restriction_(mathematics)"
@@ -9169,7 +9440,8 @@ concepts:
       en: resultant of $1
       property: function
       area: "polynomials"
-      notation: "mi res<br/>mi Res"
+      notation: "mi res"
+      notationa: "mi Res"
       urls: 
        - "https://mathworld.wolfram.com/Resultant.html"
        - "https://en.wikipedia.org/wiki/Resultant"
@@ -9205,7 +9477,9 @@ concepts:
       en: ricci scalar
       property: symbol
       area: "riemannian geometry"
-      notation: "mi S<br/>mi R<br/>mi Sc"
+      notation: "mi S"
+      notationb: "mi R"
+      notationa: "mi Sc"
       urls: 
        - "https://mathworld.wolfram.com/RicciScalar.html"
        - "https://en.wikipedia.org/wiki/Scalar_curvature"
@@ -9243,7 +9517,9 @@ concepts:
       en: riemann sphere of $1
       property: scripted symbol
       area: "projective geometry"
-      notation: "mover ℂ ^<br/>mover ℂ ¯<br/>msub ℂ ∞"
+      notation: "mover ℂ ^"
+      notationb: "mover ℂ ¯"
+      notationa: "msub ℂ ∞"
       urls: 
        - "https://mathworld.wolfram.com/RiemannSphere.html"
        - "https://en.wikipedia.org/wiki/Riemann_sphere"
@@ -9317,7 +9593,10 @@ concepts:
       en: right angle of $1
       property: prefix
       area: "geometry"
-      notation: "mo ∟<br/>mo ⊾<br/>mo ⦜<br/>mo ⦝"
+      notation: "mo ∟"
+      notationc: "mo ⊾"
+      notationb: "mo ⦜"
+      notationa: "mo ⦝"
       urls: 
        - "https://mathworld.wolfram.com/RightAngle.html"
        - "https://en.wikipedia.org/wiki/Right_angle"
@@ -9355,7 +9634,8 @@ concepts:
       en: rising factorial $1 $2
       property: mixfix
       area: "combinatorics"
-      notation: "msup $1 mover $2 ¯<br/>msup $1 mrow ( $2 ) /mrow"
+      notation: "msup $1 mover $2 ¯"
+      notationa: "msup $1 mrow ( $2 ) /mrow"
       urls: 
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/RisingFactorial.html"
@@ -9372,7 +9652,16 @@ concepts:
       en: roman numeral
       property: symbol
       area: "number theory"
-      notation: "mi i<br/>mi ii<br/>mi iii<br/>mi iv<br/>mi v<br/>mi vi<br/>mi vii<br/>mi viii<br/>mi ix<br/>mi x"
+      notationi: "mi i"
+      notationh: "mi ii"
+      notationh: "mi iii"
+      notationg: "mi iv"
+      notationf: "mi v"
+      notatione: "mi vi"
+      notationd: "mi vii"
+      notationc: "mi viii"
+      notationb: "mi ix"
+      notationa: "mi x"
       urls: 
        - "https://mathworld.wolfram.com/RomanNumerals.html"
        - "https://en.wikipedia.org/wiki/Roman_numerals"
@@ -9459,7 +9748,9 @@ concepts:
       en: sample space
       property: symbol
       area: "probability theory"
-      notation: "mi S<br/>mi Ω<br/>mi U"
+      notation: "mi S"
+      notationb: "mi Ω"
+      notationa: "mi U"
       urls: 
        - "https://mathworld.wolfram.com/SampleSpace.html"
        - "https://en.wikipedia.org/wiki/Sample_space"
@@ -9470,7 +9761,10 @@ concepts:
       en: sample variance of $1
       property: embellished symbol
       area: "probability theory"
-      notation: "msub m 2<br/>msup s 2<br/>msubsup s $1 2<br/>msubsup σ $1 2"
+      notation: "msub m 2"
+      notationc: "msup s 2"
+      notationb: "msubsup s $1 2"
+      notationa: "msubsup σ $1 2"
       urls: 
        - "https://mathworld.wolfram.com/SampleVariance.html"
        - "https://www.encyclopediaofmath.org/index.php/Sample_variance"
@@ -9537,7 +9831,8 @@ concepts:
       en: schwartz space
       property: symbol
       area: "topology"
-      notation: "mi𝒮<br/>mi S"
+      notation: "mi𝒮"
+      notationa: "mi S"
       urls: 
        - "https://mathworld.wolfram.com/SchwartzSpace.html"
        - "https://en.wikipedia.org/wiki/Schwartz_space"
@@ -9548,7 +9843,8 @@ concepts:
       en: schwarzian derivative $1 $2
       property: fenced, mixfix
       area: "complex analysis"
-      notation: "mrow { $1, $2 }<br/>mrow ( S $1 ) ($2"
+      notation: "mrow { $1, $2 }"
+      notationa: "mrow ( S $1 ) ($2"
       urls: 
        - "https://mathworld.wolfram.com/SchwarzianDerivative.html"
        - "https://en.wikipedia.org/wiki/Schwarzian_derivative"
@@ -9570,7 +9866,8 @@ concepts:
       en: sectional curvature of $1
       property: function
       area: "riemannian geometry"
-      notation: "mi K<br/>mi κ"
+      notation: "mi K"
+      notationa: "mi κ"
       urls: 
        - "https://mathworld.wolfram.com/SectionalCurvature.html"
        - "https://en.wikipedia.org/wiki/Sectional_curvature"
@@ -9602,7 +9899,8 @@ concepts:
       en: seminorm of $1
       property: fenced
       area: "linear algebra"
-      notation: "mo ‖ $1 ‖<br/>mo | $1"
+      notation: "mo ‖ $1 ‖"
+      notationa: "mo | $1"
       urls: 
        - "https://mathworld.wolfram.com/Seminorm.html"
        - "https://en.wikipedia.org/wiki/Norm_(mathematics)"
@@ -9759,7 +10057,8 @@ concepts:
       en: sinc function of $1
       property: function
       area: "special functions"
-      notation: "mi S<br/>mi sinc"
+      notation: "mi S"
+      notationa: "mi sinc"
       urls: 
        - "https://mathworld.wolfram.com/SincFunction.html"
        - "https://en.wikipedia.org/wiki/Sinc_function"
@@ -9978,7 +10277,8 @@ concepts:
       en: spherical bessel function of third kind
       property: "indexed function"
       area: "special functions"
-      notation: "msubsup h $1 (1)<br/>msubsup h $2 (2"
+      notation: "msubsup h $1 (1)"
+      notationa: "msubsup h $2 (2"
       urls: 
        - "https://mathworld.wolfram.com/SphericalBesselFunctionoftheThirdKind.html"
        - "https://dlmf.nist.gov/10.47#E5"
@@ -10044,7 +10344,8 @@ concepts:
       en: stable distribution
       property: symbol
       area: "probability theory"
-      notation: "msub S 1<br/>msub S 2"
+      notation: "msub S 1"
+      notationa: "msub S 2"
       urls: 
        - "https://mathworld.wolfram.com/StableDistribution.html"
        - "https://en.wikipedia.org/wiki/Stable_distribution"
@@ -10115,7 +10416,8 @@ concepts:
       en: star
       property: constant
       area: "combinatorial game theory"
-      notation: "mo ∗<br/>mrow { 0 | 0 }"
+      notation: "mo ∗"
+      notationa: "mrow { 0 | 0 }"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_(game_theory)"
     
@@ -10311,7 +10613,9 @@ concepts:
       en: successor of $1
       property: "function, msup"
       area: "number theory"
-      notation: "msup $1 +<br/>mi s<br/>mi S"
+      notation: "msup $1 +"
+      notationb: "mi s"
+      notationa: "mi S"
       urls: 
        - "https://en.wikipedia.org/wiki/Proclus"
        - "https://en.wikipedia.org/wiki/Successor_cardinal"
@@ -10323,7 +10627,8 @@ concepts:
       en: $1 such that $2
       property: infix
       area: "set theory"
-      notation: "$1 | $2<br/>$1 : $2"
+      notation: "$1 | $2"
+      notationa: "$1 : $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Set_(mathematics)#Set-builder_notation"
     
@@ -10343,7 +10648,8 @@ concepts:
       en: $1 superfluous submodule $2
       property: infix
       area: "abstract algebra"
-      notation: "msub ⊆ s<br/>mo ≪"
+      notation: "msub ⊆ s"
+      notationa: "mo ≪"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -10371,7 +10677,8 @@ concepts:
       en: supremum of $1
       property: "function, largeop"
       area: "order theory, lattice theory"
-      notation: "mi sup<br/>mo ⋁"
+      notation: "mi sup"
+      notationa: "mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
       alias:
@@ -10383,7 +10690,8 @@ concepts:
       en: supremum limit of $1
       property: indexed
       area: "limits"
-      notation: "mi lim sup<br/>mover lim ¯"
+      notation: "mi lim sup"
+      notationa: "mover lim ¯"
       urls: 
        - "https://mathworld.wolfram.com/SupremumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
@@ -10435,7 +10743,8 @@ concepts:
       en: symmetric algebra of $1
       property: function
       area: "algebra"
-      notation: "mi S<br/>mi Sym"
+      notation: "mi S"
+      notationa: "mi Sym"
       urls: 
        - "https://en.wikipedia.org/wiki/Symmetric_algebra"
        - "https://ncatlab.org/nlab/show/symmetric+algebra"
@@ -10446,7 +10755,9 @@ concepts:
       en: $1 symmetric difference $2
       property: infix
       area: "set theory"
-      notation: "mo △<br/>mo ⊕<br/>mo ⊖"
+      notation: "mo △"
+      notationb: "mo ⊕"
+      notationa: "mo ⊖"
       urls: 
        - "https://mathworld.wolfram.com/SymmetricDifference.html"
        - "https://en.wikipedia.org/wiki/Symmetric_difference"
@@ -10457,7 +10768,13 @@ concepts:
       en: symmetric group of $1
       property: "msub, function, postfix"
       area: "group theory"
-      notation: "msub S $1<br/>msub 𝔖 $1<br/>msub Σ $1<br/>mrow Σ ( $1 )<br/>mrow Sym ( $1 )<br/>mrow $1 !<br/>"
+      notation: "msub S $1"
+      notationf: "msub 𝔖 $1"
+      notatione: "msub Σ $1"
+      notationd: "mrow Σ ( $1 )"
+      notationc: "mrow Sym ( $1 )"
+      notationb: "mrow $1 !"
+      notationa: ""
       urls: 
        - "https://mathworld.wolfram.com/SymmetricGroup.html"
        - "https://en.wikipedia.org/wiki/Symmetric_group"
@@ -10605,7 +10922,8 @@ concepts:
       en: tensor algebra of $1
       property: function
       area: "multilinear algebra"
-      notation: "mi T<br/>msup T •"
+      notation: "mi T"
+      notationa: "msup T •"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_algebra"
     
@@ -10699,7 +11017,8 @@ concepts:
       en: todd class of $1
       property: function
       area: "characteristic classes"
-      notation: "mi td<br/>mi Td"
+      notation: "mi td"
+      notationa: "mi Td"
       urls: 
        - "https://en.wikipedia.org/wiki/Todd_class"
        - "https://ncatlab.org/nlab/show/Todd+class"
@@ -10844,7 +11163,8 @@ concepts:
       en: triangle function of $1
       property: function
       area: "special functions"
-      notation: "mi Λ<br/>mi tri"
+      notation: "mi Λ"
+      notationa: "mi tri"
       urls: 
        - "https://mathworld.wolfram.com/TriangleFunction.html"
        - "https://en.wikipedia.org/wiki/Triangular_function"
@@ -10944,7 +11264,10 @@ concepts:
       en: turan graph $1 $2
       property: "function, indexed function"
       area: "graph theory"
-      notation: "mi T<br/>mi D<br/>msub T $1<br/>msub T $1,$2"
+      notation: "mi T"
+      notationc: "mi D"
+      notationb: "msub T $1"
+      notationa: "msub T $1,$2"
       urls: 
        - "https://mathworld.wolfram.com/TuranGraph.html"
        - "https://en.wikipedia.org/wiki/Tur%C3%A1n_graph"
@@ -10967,7 +11290,10 @@ concepts:
       en: turn of $1
       property: unit
       area: "geometry"
-      notation: "mi cyc<br/>mi rev<br/>mi tr<br/>mi pla"
+      notation: "mi cyc"
+      notationc: "mi rev"
+      notationb: "mi tr"
+      notationa: "mi pla"
       urls: 
        - "https://en.wikipedia.org/wiki/Turn_(geometry)"
       alias:
@@ -10989,7 +11315,9 @@ concepts:
       en: tychonoff space
       property: symbol
       area: "topology"
-      notation: "msub T 3<br/>msub T π<br/>msub T 3½"
+      notation: "msub T 3"
+      notationb: "msub T π"
+      notationa: "msub T 3½"
       urls: 
        - "https://mathworld.wolfram.com/TychonoffSpace.html"
        - "https://en.wikipedia.org/wiki/Tychonoff_space"
@@ -11039,9 +11367,12 @@ concepts:
     - concept: uniformly-convergent
       arity: 1
       en: uniformly convergent of $1
-      property: infix<br/>indexed, postfix
+      property: infix, indexed, postfix
       area: "convergence"
-      notation: "mo ⇉<br/>mover ⟶ unif.<br/>mo unif lim<br/>mtext uniformly"
+      notation: "mo ⇉"
+      notationc: "mover ⟶ unif."
+      notationb: "mo unif lim"
+      notationa: "mtext uniformly"
       urls: 
        - "https://en.wikipedia.org/wiki/Uniform_convergence"
     
@@ -11083,7 +11414,8 @@ concepts:
       en: universal gas constant
       property: constant
       area: "physics"
-      notation: "mi R<br/>mover R -"
+      notation: "mi R"
+      notationa: "mover R -"
       urls: 
        - "https://en.wikipedia.org/wiki/Gas_constant"
       alias:
@@ -11107,7 +11439,9 @@ concepts:
       en: universal set
       property: symbol
       area: "set theory"
-      notation: "miV<br/>miU<br/>miξ"
+      notation: "miV"
+      notationb: "miU"
+      notationa: "miξ"
       urls: 
        - "https://mathworld.wolfram.com/UniversalSet.html"
        - "https://en.wikipedia.org/wiki/Universal_set"
@@ -11120,7 +11454,8 @@ concepts:
       en: unique existential of $1
       property: prefix
       area: "logic"
-      notation: "mo ∃ !<br/>msub ∃ mrow =1 /mrow"
+      notation: "mo ∃ !"
+      notationa: "msub ∃ mrow =1 /mrow"
       urls: 
        - "https://en.wikipedia.org/wiki/Uniqueness_quantification"
        - "https://arxiv.org/pdf/1902.03852.pdf"
@@ -11140,7 +11475,9 @@ concepts:
       en: $1 unrestricted wreath product $2
       property: infix
       area: "group theory"
-      notation: "mo ≀<br/>mo Wr<br/>msub Wr $1"
+      notation: "mo ≀"
+      notationb: "mo Wr"
+      notationa: "msub Wr $1"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -11182,7 +11519,8 @@ concepts:
       en: upper half plane
       property: symbol
       area: "complex analysis"
-      notation: "mi ℍ<br/>msup ℍ +"
+      notation: "mi ℍ"
+      notationa: "msup ℍ +"
       urls: 
        - "https://mathworld.wolfram.com/UpperHalf-Plane.html"
        - "https://en.wikipedia.org/wiki/Upper_half-plane"
@@ -11223,7 +11561,8 @@ concepts:
       en: $1 vector concatenation $2
       property: infix
       area: "machine learning"
-      notation: "mo ◦<br/>mo ⊕"
+      notation: "mo ◦"
+      notationa: "mo ⊕"
       urls: 
        - "https://arxiv.org/pdf/1903.00172v1.pdf"
        - "https://arxiv.org/abs/1901.10879"
@@ -11351,7 +11690,8 @@ concepts:
       en: $1 way below $2
       property: infix
       area: "domain theory"
-      notation: "mo≪<br/>mo≫"
+      notation: "mo≪"
+      notationa: "mo≫"
       urls: 
        - "http://mizar.org/fm/1997-6/pdf6-1/waybel_3.pdf"
        - "https://en.wikipedia.org/wiki/Domain_theory"
@@ -11364,7 +11704,8 @@ concepts:
       en: $1 weak convergence $2
       property: infix
       area: "analysis"
-      notation: "mover →w<br/>mo ⇀"
+      notation: "mover →w"
+      notationa: "mo ⇀"
       urls: 
        - "https://mathworld.wolfram.com/WeakConvergence.html"
        - "https://en.wikipedia.org/wiki/Weak_convergence_(Hilbert_space)"
@@ -11505,7 +11846,8 @@ concepts:
       en: whittaker function $1 $2
       property: "indexed function"
       area: "special functions"
-      notation: "msub M mrow $1, $2 /mrow<br/>msub W mrow $1, $2 /mrow"
+      notation: "msub M mrow $1, $2 /mrow"
+      notationa: "msub W mrow $1, $2 /mrow"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"
@@ -11681,7 +12023,8 @@ concepts:
       en: wronskian of $1, $2
       property: operator
       area: "special functions"
-      notation: "mrow 𝒲 { $1, $2 }<br/>mi W"
+      notation: "mrow 𝒲 { $1, $2 }"
+      notationa: "mi W"
       urls: 
        - "https://mathworld.wolfram.com/Wronskian.html"
        - "https://en.wikipedia.org/wiki/Wronskian"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -360,7 +360,8 @@ concepts:
       en: analytic manifold
       property: symbol
       area: "topology"
-      notation: "msup C w"
+      comments:
+       - "<math><msup><mi>C</mi><mi>w</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Analytic_manifold"
        - "https://ncatlab.org/nlab/show/analytic+manifold"
@@ -619,8 +620,9 @@ concepts:
       en: baire space
       property: symbol
       area: "set theory"
-      notation: "msup N N"
-      notationa: "msup ω ω"
+      comments:
+       - "<math><msup><mi>N</mi><mi>N</mi></msup></math>"
+       - "<math><msup><mi>ω</mi><mi>ω</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/BaireSpace.html"
        - "https://en.wikipedia.org/wiki/Baire_space"
@@ -886,7 +888,8 @@ concepts:
       en: binary golay code
       property: symbol
       area: "coding theory"
-      notation: "msub G 23"
+      comments:
+       - "<math><msub><mi>G</mi><mn>23</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BinaryGolayCode.html"
        - "https://ncatlab.org/nlab/show/binary+Golay+code"
@@ -922,8 +925,9 @@ concepts:
       en: bit
       property: symbol
       area: "computer science"
-      notation: "mn 0"
-      notationa: "mn 1"
+      comments:
+       - "<math><mn>0</mn></math>"
+       - "<math><mn>1</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/Bit.html"
        - "https://en.wikipedia.org/wiki/Bit"
@@ -1212,7 +1216,8 @@ concepts:
       en: category of sets
       property: symbol
       area: "category theory"
-      notation: "miSet"
+      comments:
+       - "<math><mi>Set</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Category_of_sets"
        - "https://www.encyclopediaofmath.org/index.php/Category_of_a_set"
@@ -1223,7 +1228,8 @@ concepts:
       en: category of small categories
       property: symbol
       area: "category theory"
-      notation: "miCat"
+      comments:
+       - "<math><mi>Cat</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Category_of_small_categories"
     
@@ -1473,7 +1479,8 @@ concepts:
       en: chi squared distribution
       property: symbol
       area: "probability theory"
-      notation: "msup χ 2"
+      comments:
+       - "<math><msup><mi>χ</mi><mn>2</mn>></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Chi-SquaredDistribution.html"
        - "https://en.wikipedia.org/wiki/Chi-squared_distribution"
@@ -1806,7 +1813,7 @@ concepts:
        - "https://en.wikipedia.org/wiki/Nome_(mathematics)"
     
     - concept: complete-graph
-      arity: 0
+      arity: 1
       en: complete graph
       property: symbol
       area: "graph theory"
@@ -1834,7 +1841,8 @@ concepts:
       en: complex projective space
       property: symbol
       area: "projective geometry"
-      notation: "mrow ℂ⁢ ℙ"
+      comments:
+       - "<math><mi>ℂ⁢</mi><mi>ℙ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ProjectiveSpace.html"
        - "https://en.wikipedia.org/wiki/Algebraic_geometry_of_projective_spaces"
@@ -2172,10 +2180,11 @@ concepts:
       en: conway group
       property: symbol
       area: "group theory"
-      notation: "msub Co 0"
-      notationc: "msub Co 1"
-      notationb: "msub Co 2"
-      notationa: "msub Co 3"
+      comments:
+       - "<math><msub><mi>Co</mi><mn>0</mn></msub></math>"
+       - "<math><msub><mi>Co</mi><mn>1</mn></msub></math>"
+       - "<math><msub><mi>Co</mi><mn>2</mn></msub></math>"
+       - "<math><msub><mi>Co</mi><mn>3</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConwayGroups.html"
        - "https://en.wikipedia.org/wiki/Conway_group"
@@ -2804,9 +2813,10 @@ concepts:
       en: digamma function
       property: symbol
       area: "special functions"
-      notation: "msub ψ 0"
-      notationb: "msup ψ (0)"
-      notationa: "mi F"
+      comments:
+       - "<math><msub><mi>ψ</mi><mn>0</mn></msup></math>"
+       - "<math><msup><mi>ψ</mi><mrow><mo>(</mo><mn>0</mn><mo>)</mo></mrow></msup></math>"
+       - "<math><mi>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DigammaFunction.html"
        - "https://en.wikipedia.org/wiki/Digamma_function"
@@ -2890,10 +2900,11 @@ concepts:
       en: dirac matrix
       property: constant
       area: "mathematical physics"
-      notation: "msup γ 0"
-      notationc: "msup γ 1"
-      notationb: "msup γ 2"
-      notationa: "msup γ 3"
+      comments:
+       - "<math><msup><mi>γ</mi><mn>0</mn></msup></math>"
+       - "<math><msup><mi>γ</mi><mn>1</mn></msup></math>"
+       - "<math><msup><mi>γ</mi><mn>2</mn></msup></math>"
+       - "<math><msup><mi>γ</mi><mn>3</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracMatrices.html"
        - "https://en.wikipedia.org/wiki/Gamma_matrices"
@@ -3674,7 +3685,8 @@ concepts:
       en: euclidean plane
       property: symbol
       area: "geometry"
-      notation: "msup ℝ 2"
+      comments:
+       - "<math><msup><mi>ℝ</mi><mn>2</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/EuclideanPlane.html"
       alias:
@@ -3978,7 +3990,8 @@ concepts:
       en: feferman schutte ordinal
       property: symbol
       area: "ordinal numbers"
-      notation: "msub Γ 0"
+      comments:
+       - "<math><msub><mi>Γ</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Feferman%E2%80%93Sch%C3%BCtte_ordinal"
     
@@ -4305,7 +4318,8 @@ concepts:
       en: frechet topology
       property: constant
       area: "topology"
-      notation: "msub T 1"
+      comments:
+       - "<math><msub><mi>T</mi><mn>1</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
       alias:
@@ -4637,7 +4651,8 @@ concepts:
       en: gelfond constant
       property: constant
       area: "transcendental constants"
-      notation: "msup e π"
+      comments:
+       - "<math><msup><mi>e</mi><mi>π</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/GelfondsConstant.html"
        - "https://en.wikipedia.org/wiki/Gelfond%27s_constant"
@@ -4713,7 +4728,7 @@ concepts:
        - power-mean
     
     - concept: genocchi-number
-      arity: 0
+      arity: 1
       en: genocchi number
       property: symbol
       area: "integer sequences"
@@ -4729,7 +4744,8 @@ concepts:
       en: geodesic curvature
       property: symbol
       area: "riemannian geometry"
-      notation: "msub k g"
+      comments:
+       - "<math><msub><mi>k</mi><mi>g</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeodesicCurvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12220,7 +12220,7 @@ concepts:
       property: "indexed symbol"
       area: "linear algebra"
       comments:
-       - "<math><msub><mn>0</mn>><mrow><mi>i</mi><mi>j</mi></mrow></msub></math>"
+       - "<math><msub><mn>0</mn><mrow><mi>i</mi><mi>j</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_matrix"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -3837,7 +3837,7 @@ concepts:
       en: $1 th forward difference of $3 over $2
       property: operator
       area: "numerical analysis"
-      comment: "<math><msubsup><mi>&Delta;</mi><mi>x</mi><mi>n</mi></msubsup><mrow>mi<>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+      comment: "<math><msubsup><mi>&Delta;</mi><mi>x</mi><mi>n</mi></msubsup><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ForwardDifference.html)"
        - "https://dlmf.nist.gov/18.1#EGx1"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4873,7 +4873,8 @@ concepts:
       en: graham number
       property: constant
       area: "ramsey theory"
-      notation: "msub g 64"
+      comments:
+       - "<math><msub><mi>G</mi><mn>64</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GrahamsNumber.html"
        - "https://en.wikipedia.org/wiki/Graham%27s_number"
@@ -5124,7 +5125,8 @@ concepts:
       en: hausdorff space
       property: constant
       area: "topology"
-      notation: "msub T 2"
+      comments:
+       - "<math><msub><mi>T</mi><mn>2</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
       alias:
@@ -6033,7 +6035,8 @@ concepts:
       en: inverse wishart distribution
       property: symbol
       area: "probability theory"
-      notation: "msubsup W p -1"
+      comments:
+       - "<math><msubsup><mi>W</mi><mi>p</mi><mn>−1</mn></msubsup></math>"
       urls: 
        - "https://mathworld.wolfram.com/WishartDistribution.html"
        - "https://en.wikipedia.org/wiki/Wishart_distribution"
@@ -6221,10 +6224,11 @@ concepts:
       en: janko group
       property: symbol
       area: "group theory"
-      notation: "msub J 1"
-      notationc: "msub J 2"
-      notationb: "msub J 3"
-      notationa: "msub J 4"
+      comments:
+       - "<math><msub><mi>J</mi><mn>1</mn></msub></math>"
+       - "<math><msub><mi>J</mi><mn>2</mn></msub></math>"
+       - "<math><msub><mi>J</mi><mn>3</mn></msub></math>"
+       - "<math><msub><mi>J</mi><mn>4</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/JankoGroups.html"
        - "https://en.wikipedia.org/wiki/Janko_group"
@@ -6314,7 +6318,8 @@ concepts:
       en: kaprekar constant
       property: symbol
       area: "number theory"
-      notation: "mn 6174"
+      comments:
+       - "<math><mn>6174</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/KaprekarConstant.html"
        - "https://en.wikipedia.org/wiki/6174_(number)"
@@ -6486,7 +6491,8 @@ concepts:
       en: kolmogorov space
       property: constant
       area: "topology"
-      notation: "msub T 0"
+      comments:
+       - "<math><msub><mi>T</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
     
@@ -6634,11 +6640,12 @@ concepts:
       en: lagrange point
       property: symbol
       area: "celestial mechanics"
-      notation: "msub L 1"
-      notationd: "msub L 2"
-      notationc: "msub L 3"
-      notationb: "msub L 4"
-      notationa: "msub L 5"
+      comments:
+       - "<math><msub><mi>L</mi><mn>1</mn></msub></math>"
+       - "<math><msub><mi>L</mi><mn>2</mn></msub></math>"
+       - "<math><msub><mi>L</mi><mn>3</mn></msub></math>"
+       - "<math><msub><mi>L</mi><mn>4</mn></msub></math>"
+       - "<math><msub><mi>L</mi><mn>5</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lagrange_point"
       alias:
@@ -6772,7 +6779,8 @@ concepts:
       en: leech lattice
       property: symbol
       area: "group theory"
-      notation: "msub Λ 24"
+      comments:
+       - "<math><msub><mo>Λ</mo><mn>24</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeechLattice.html"
        - "https://en.wikipedia.org/wiki/Leech_lattice"
@@ -7888,7 +7896,7 @@ concepts:
        - multiset-number
     
     - concept: multivariate-gaussian-distribution
-      arity: 0
+      arity: 1
       en: multivariate gaussian distribution
       property: symbol
       area: "probability theory"
@@ -8016,7 +8024,8 @@ concepts:
       en: neron tate height
       property: symbol
       area: "number theory"
-      notation: "mover h ^"
+      comments:
+       - "<math><mover><mi>h</mi><mo>^</mo></mover></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/N%C3%A9ron%E2%80%93Tate_height"
       alias:
@@ -8106,7 +8115,7 @@ concepts:
        - "https://en.wikipedia.org/wiki/Divisor"
     
     - concept: null-graph
-      arity: 0
+      arity: 1
       en: null graph
       property: symbol
       area: "graph theory"
@@ -8419,7 +8428,7 @@ concepts:
        - "https://ncatlab.org/nlab/show/parallel+morphisms"
     
     - concept: partial-charge
-      arity: 0
+      arity: 1
       en: partial charge
       property: symbol
       area: "chemistry"
@@ -8497,7 +8506,7 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Peirce_arrow"
     
     - concept: pell-number
-      arity: 0
+      arity: 1
       en: pell number
       property: symbol
       area: "number theory"
@@ -8507,7 +8516,7 @@ concepts:
        - "https://en.wikipedia.org/wiki/Pell_number"
     
     - concept: pell-luca-number
-      arity: 0
+      arity: 1
       en: pell luca number
       property: symbol
       area: "number theory"
@@ -8880,7 +8889,8 @@ concepts:
       en: preregular space
       property: constant
       area: "topology"
-      notation: "msub R 1"
+      comments:
+       - "<math><msub><mi>R</mi><mn>1</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions)s"
     
@@ -9095,7 +9105,8 @@ concepts:
       en: pullback
       property: symbol
       area: "differential geometry"
-      notation: "msup φ *"
+      comments:
+       - "<math><msup><mi>φ</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Pullback_(differential_geometry)"
     
@@ -9115,7 +9126,8 @@ concepts:
       en: pythagoras constant
       property: constant
       area: "geometry"
-      notation: "msqrt 2"
+      comments:
+       - "<math><msqrt><mn>2</mn></msqrt></math>"
       urls: 
        - "https://mathworld.wolfram.com/PythagorassConstant.html"
        - "https://en.wikipedia.org/wiki/Sqrt(2)"
@@ -9149,8 +9161,9 @@ concepts:
       en: qed
       property: symbol
       area: "mathematical symbols"
-      notation: "mo □"
-      notationa: "mo ∎"
+      comments:
+       - "<math><mo>□</mo></math>"
+       - "<math><mo>∎</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -9950,8 +9963,9 @@ concepts:
       en: schwartz space
       property: symbol
       area: "topology"
-      notation: "mi𝒮"
-      notationa: "mi S"
+      comments:
+       - "<math><mi>𝒮</mi></math>"
+       - "<math><mi>S</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchwartzSpace.html"
        - "https://en.wikipedia.org/wiki/Schwartz_space"
@@ -10093,7 +10107,8 @@ concepts:
       en: short rate
       property: symbol
       area: "mathematical finance"
-      notation: "msub r t"
+      comments:
+       - "<math><msub><mi>r</mi><mi>t</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Short_rate"
        - "https://en.wikipedia.org/wiki/Short-rate_model"
@@ -10142,7 +10157,8 @@ concepts:
       en: silver ratio
       property: constant
       area: "number theory"
-      notation: "msub δ S"
+      comments:
+       - "<math><msub><mi>δ</mi><mi>S</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SilverRatio.html"
        - "https://en.wikipedia.org/wiki/Silver_ratio"
@@ -10465,8 +10481,9 @@ concepts:
       en: stable distribution
       property: symbol
       area: "probability theory"
-      notation: "msub S 1"
-      notationa: "msub S 2"
+      comments:
+       - "<math><msub><mi>S</mi><mn>1</mn></msub></math>"
+       - "<math><msub><mi>S</mi><mn>2</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/StableDistribution.html"
        - "https://en.wikipedia.org/wiki/Stable_distribution"
@@ -10911,7 +10928,7 @@ concepts:
       en: symmetric space
       property: constant
       area: "topology"
-      notation: "msub R 0"
+       - "<math><msub><mi>R</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions)s"
     
@@ -10969,7 +10986,7 @@ concepts:
       en: tate algebra
       property: symbol
       area: "analytic geometry"
-      notation: "msub T n"
+       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tate_algebra"
        - "https://ncatlab.org/nlab/show/Tate+algebra"
@@ -11447,9 +11464,9 @@ concepts:
       en: tychonoff space
       property: symbol
       area: "topology"
-      notation: "msub T 3"
-      notationb: "msub T π"
-      notationa: "msub T 3½"
+       - "<math><msub><mi>T</mi><mn>3</mn></msub></math>"
+       - "<math><msub><mi>T</mi><mn>π</mn></msub></math>"
+       - "<math><msub><mi>T</mi><mn>3½</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TychonoffSpace.html"
        - "https://en.wikipedia.org/wiki/Tychonoff_space"
@@ -11573,9 +11590,10 @@ concepts:
       en: universal set
       property: symbol
       area: "set theory"
-      notation: "miV"
-      notationb: "miU"
-      notationa: "miξ"
+      comments:
+       - "<math><mi>V</mi></math>"
+       - "<math><mi>U</mi></math>"
+       - "<math><mi>ξ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/UniversalSet.html"
        - "https://en.wikipedia.org/wiki/Universal_set"
@@ -11792,7 +11810,8 @@ concepts:
       en: volume element
       property: symbol
       area: "measure theory"
-      notation: "mrow d V"
+      comments:
+       - "<math><mi>d</mi><mi>V</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/VolumeElement.html"
        - "https://en.wikipedia.org/wiki/Volume_element"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6363,7 +6363,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-       - "<math><msub><mi>&#x03f5;</mi><mrow><mi>i</mi><mi>j</mi><mi>k</mi></mrow></msub></math>
+       - "<math><msub><mi>&#x03f5;</mi><mrow><mi>i</mi><mi>j</mi><mi>k</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Levi-CivitaSymbol.html"
        - "https://en.wikipedia.org/wiki/Levi-Civita_symbol"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1382,7 +1382,7 @@ concepts:
     
     - concept: christoffel-symbol-of-first-kind
       arity: 3
-      en: christoffel symbol of first kind>mrow msub Δ $1 [$2] ($3" of $1, $2, $3
+      en: christoffel symbol of first kind of $1, $2, $3
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2798,7 +2798,7 @@ concepts:
       area: "special functions"
       notation: "msub ψ 0"
       notationb: "msup ψ (0)"
-             - "<math><mi>Ϝ</mi></math>"
+      notationa: "mi F"
       urls: 
        - "https://mathworld.wolfram.com/DigammaFunction.html"
        - "https://en.wikipedia.org/wiki/Digamma_function"
@@ -3347,7 +3347,7 @@ concepts:
       area: "analytic geometry, graph theory"
       comments:
        - "<math><mi>e</mi></math>"
-             - "<math><mi>ϵ</mi></math>"
+       - "<math><mi>ϵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Eccentricity.html"
        - "https://en.wikipedia.org/wiki/Eccentricity_(mathematics)"
@@ -3698,7 +3698,7 @@ concepts:
       area: "analysis"
       comments:
        - "<math><mi>γ</mi></math>"
-             - "<math><mi>𝛾</mi></math>"
+       - "<math><mi>𝛾</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3715,8 +3715,8 @@ concepts:
       area: "physics"
       comments:
        - "<math><mi>Eu</mi></math>"
-             - "<math><mi>e</mi></math>"
-             - "<math><mi>𝑒</mi></math>"
+       - "<math><mi>e</mi></math>"
+       - "<math><mi>𝑒</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerNumber.html"
        - "https://en.wikipedia.org/wiki/Euler_number"
@@ -4821,7 +4821,7 @@ concepts:
       area: "geometry"
       comments:
        - "<math><mi>φ</mi></math>"
-             - "<math><mi>ϕ</mi></math>"
+       - "<math><mi>ϕ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GoldenRatio.html"
        - "https://en.wikipedia.org/wiki/Golden_ratio"
@@ -4836,7 +4836,6 @@ concepts:
        - divine-section
        - golden-proportion
        - golden-cut
-       - 
     
     - concept: graham-number
       arity: 0
@@ -8123,7 +8122,6 @@ concepts:
       area: "compositional algebra"
       comments:
        - "<math><mi>𝕆</mi></math>"
-      notationb: "miO"
        - "<math><mi>O</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octonion.html"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -734,7 +734,8 @@ concepts:
       en: bernoulli number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub B $1"
+      comments:
+       - "<math><msub><mi>B</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BernoulliNumber.html"
        - "https://en.wikipedia.org/wiki/Bernoulli_number"
@@ -829,7 +830,8 @@ concepts:
       en: betti number of $1
       property: "indexed symbol"
       area: "graph theory"
-      notation: "msub b $1"
+      comments:
+       - "<math><msub><mi>b</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BettiNumber.html"
        - "https://en.wikipedia.org/wiki/Betti_number"
@@ -1195,7 +1197,8 @@ concepts:
       en: catalan number of $1
       property: "indexed symbol"
       area: "combinatorics"
-      notation: "msub C $1"
+      comments:
+       - "<math><msub><mi>C</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CatalanNumber.html"
        - "https://en.wikipedia.org/wiki/Catalan_number"
@@ -1310,7 +1313,8 @@ concepts:
       en: centralizer of $1
       property: function
       area: "group theory"
-      notation: "msub C $1"
+      comments:
+       - "<math><msub><mi>C</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Centralizer.html"
        - "https://en.wikipedia.org/wiki/Centralizer_and_normalizer"
@@ -1372,7 +1376,8 @@ concepts:
       en: characteristic function of $1
       property: "indexed function, function"
       area: "probability theory"
-      notation: "msub 𝟏 $1"
+      comments:
+       - "<math><msub><mi>𝟏</mi><mi>x</mi></msub></math>"
       notationa: "mrow 𝟏 { $1 }"
       urls: 
        - "https://mathworld.wolfram.com/CharacteristicFunction.html"
@@ -1401,7 +1406,8 @@ concepts:
       en: charlier polynomial of $1
       property: function
       area: "special functions"
-      notation: "msub C $1"
+      comments:
+       - "<math><msub><mi>C</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CharlierPolynomial.html"
        - "https://en.wikipedia.org/wiki/Charlier_polynomials"
@@ -1527,9 +1533,10 @@ concepts:
       en: chromatic polynomial of $1
       property: function
       area: "graph theory"
-      notation: "msub P $1"
-      notationb: "msub π $1"
-      notationa: "msub χ $1"
+      comments:
+       - "<math><msub><mi>P</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>π</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>χ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChromaticPolynomial.html"
        - "https://en.wikipedia.org/wiki/Chromatic_polynomial"
@@ -1775,7 +1782,8 @@ concepts:
       en: companion lehmer number of $1
       property: "indexed function"
       area: "number theory"
-      notation: "msub V $1"
+      comments:
+       - "<math><msub><mi>V</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerNumber.html"
        - "https://mathworld.wolfram.com/LehmersNumber.html"
@@ -1817,7 +1825,8 @@ concepts:
       en: complete graph
       property: symbol
       area: "graph theory"
-      notation: "msub K $1"
+      comments:
+       - "<math><msub><mi>K</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CompleteGraph.html"
        - "https://en.wikipedia.org/wiki/Complete_graph"
@@ -2286,7 +2295,8 @@ concepts:
       en: covariant derivative of $1
       property: "indexed operator"
       area: "differential geometry"
-      notation: "msub ∇ $1"
+      comments:
+       - "<math><msub><mi>∇</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CovariantDerivative.html"
        - "https://en.wikipedia.org/wiki/Covariant_derivative"
@@ -2362,7 +2372,8 @@ concepts:
       en: cullen number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub C $1"
+      comments:
+       - "<math><msub><mi>C</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CullenNumber.html"
        - "https://en.wikipedia.org/wiki/Cullen_number"
@@ -2372,7 +2383,8 @@ concepts:
       en: cumulant of $1
       property: "indexed symbol"
       area: "probability theory"
-      notation: "msub κ $1"
+      comments:
+       - "<math><msub><mi>κ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cumulant.html"
        - "https://en.wikipedia.org/wiki/Cumulant"
@@ -2385,7 +2397,8 @@ concepts:
       en: cumulative distribution function of $1
       property: "indexed symbol"
       area: "probability theory"
-      notation: "msub F $1"
+      comments:
+       - "<math><msub><mi>F</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CumulativeDistributionFunction.html"
        - "https://en.wikipedia.org/wiki/Cumulative_distribution_function"
@@ -2484,7 +2497,8 @@ concepts:
       en: cyclotomic polynomial of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub Φ $1"
+      comments:
+       - "<math><msub><mi>Φ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CyclotomicPolynomial.html"
        - "https://en.wikipedia.org/wiki/Cyclotomic_polynomial"
@@ -2769,7 +2783,8 @@ concepts:
       en: different ideal of $1
       property: function
       area: "algebraic number theory"
-      notation: "msub δ $1"
+      comments:
+       - "<math><msub><mi>δ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Different_ideal"
       alias:
@@ -2826,9 +2841,10 @@ concepts:
       en: dihedral group
       property: symbol
       area: "group theory"
-      notation: "msub D $1"
-      notationb: "msub Dih $1"
-      notationa: "msub D 2$1"
+      comments:
+       - "<math><msub><mi>D</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Dih</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>D2</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/DihedralGroup.html"
        - "https://en.wikipedia.org/wiki/Dihedral_group"
@@ -3662,7 +3678,8 @@ concepts:
       en: euclid number $1
       property: symbol
       area: "number theory"
-      notation: "msub E $1"
+      comments:
+       - "<math><msub><mi>E</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/EuclidNumber.html"
        - "https://en.wikipedia.org/wiki/Euclid_number"
@@ -3674,7 +3691,7 @@ concepts:
       area: "geometry"
       comments:
        - "<math><mi>d</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "msub d $1"
+       - "<math><msub><mi>d</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euclidean_distance"
       alias:
@@ -3759,7 +3776,8 @@ concepts:
       en: euler polynomial of $1
       property: function
       area: "special-functions"
-      notation: "msub E $1"
+      comments:
+       - "<math><msub><mi>E</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerPolynomial.html"
        - "https://dlmf.nist.gov/24.1#P2"
@@ -3843,7 +3861,7 @@ concepts:
       comments:
        - "<math><mi>E</mi><mrow><mi>X</mi></mrow></math>"
        - "<math><mi>M</mi><mrow><mi>X</mi></mrow></math>"
-      notationb: "msub μ $1"
+       - "<math><msub><mi>μ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
       alias:
@@ -3930,7 +3948,8 @@ concepts:
       en: f distribution of $1
       property: "indexed symbol"
       area: "probability theory"
-      notation: "msub F $1"
+      comments:
+       - "<math><msub><mi>F</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/F-Distribution.html"
        - "https://www.encyclopediaofmath.org/index.php/F-distribution"
@@ -4011,7 +4030,8 @@ concepts:
       en: fermat number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub F $1"
+      comments:
+       - "<math><msub><mi>F</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FermatNumber.html"
        - "https://en.wikipedia.org/wiki/Fermat_number"
@@ -4021,7 +4041,8 @@ concepts:
       en: fermat quotient of $1
       property: function
       area: "number theory"
-      notation: "msub q $1"
+      comments:
+       - "<math><msub><mi>q</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FermatQuotient.html"
        - "https://en.wikipedia.org/wiki/Fermat_quotient"
@@ -4052,7 +4073,8 @@ concepts:
       en: fibonacci number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub F $1"
+      comments:
+       - "<math><msub><mi>F</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FibonacciNumber.html"
        - "https://en.wikipedia.org/wiki/Fibonacci_number"
@@ -4065,7 +4087,8 @@ concepts:
       en: fibonacci polynomial of $1
       property: "indexed function"
       area: "polynomials"
-      notation: "msub F $1"
+      comments:
+       - "<math><msub><mi>F</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FibonacciPolynomial.html"
        - "https://en.wikipedia.org/wiki/Fibonacci_polynomials"
@@ -4076,7 +4099,8 @@ concepts:
       en: fibre product of $1
       property: indexed infix
       area: "category theory"
-      notation: "msub × $1"
+      comments:
+       - "<math><msub><mi>×</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Pullback_(category_theory)"
        - "https://www.encyclopediaofmath.org/index.php/Fibre_product"
@@ -4718,7 +4742,8 @@ concepts:
       en: generalized mean of $1
       property: function
       area: "means"
-      notation: "msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeneralizedMean.html"
        - "https://en.wikipedia.org/wiki/Generalized_mean"
@@ -4732,7 +4757,8 @@ concepts:
       en: genocchi number
       property: symbol
       area: "integer sequences"
-      notation: "msub G $1"
+      comments:
+       - "<math><msub><mi>G</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GenocchiNumber.html"
        - "https://en.wikipedia.org/wiki/Genocchi_number"
@@ -5016,7 +5042,8 @@ concepts:
       en: hahn polynomial of $1
       property: function
       area: "orthogonal polynomials"
-      notation: "msub q $1"
+      comments:
+       - "<math><msub><mi>q</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HahnPolynomial.html"
        - "https://en.wikipedia.org/wiki/Hahn_polynomials"
@@ -5174,7 +5201,8 @@ concepts:
       en: hecke operator of $1
       property: operator
       area: "modular forms"
-      notation: "msub T $1"
+      comments:
+       - "<math><msub><mi>T</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeckeOperator.html"
        - "https://en.wikipedia.org/wiki/Hecke_operator"
@@ -5195,7 +5223,8 @@ concepts:
       en: height of abelian group of $1
       property: function
       area: "group theory"
-      notation: "msub h $1"
+      comments:
+       - "<math><msub><mi>h</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_(abelian_group)"
     
@@ -5409,7 +5438,8 @@ concepts:
       en: homology group of $1
       property: function
       area: "homology theory"
-      notation: "msub H $1"
+      comments:
+       - "<math><msub><mi>H</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomologyGroup.html"
        - "https://en.wikipedia.org/wiki/Singular_homology"
@@ -5606,8 +5636,8 @@ concepts:
       area: "algebra"
       comments:
        - "<math><mi>id</mi><mrow><mi>X</mi></mrow></math>"
-      notationb: "msub id $1"
-      notationa: "msub I $1"
+       - "<math><msub><mi>id</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>I</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/IdentityFunction.html"
        - "https://en.wikipedia.org/wiki/Identity_function"
@@ -5622,9 +5652,10 @@ concepts:
       en: identity functor of $1
       property: function
       area: "category theory"
-      notation: "msub 1 $1"
-      notationb: "msub I $1"
-      notationa: "msub Id $1"
+      comments:
+       - "<math><msub><mi>1</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>I</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Id</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/identity+functor"
        - "https://en.wikipedia.org/wiki/Functor"
@@ -6026,7 +6057,8 @@ concepts:
       en: inverse tangent integral of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub Ti $1"
+      comments:
+       - "<math><msub><mi>Ti</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polylogarithm"
     
@@ -6297,7 +6329,8 @@ concepts:
       en: jordan totient function of $1
       property: function
       area: "number theory"
-      notation: "msub J $1"
+      comments:
+       - "<math><msub><mi>J</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Jordan%27s_totient_function"
     
@@ -6514,7 +6547,8 @@ concepts:
       en: krawtchouk polynomial of $1
       property: function
       area: "orthogonal polynomials"
-      notation: "msub K $1"
+      comments:
+       - "<math><msub><mi>K</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrawtchoukPolynomial.html"
        - "https://en.wikipedia.org/wiki/Kravchuk_polynomials"
@@ -6757,7 +6791,8 @@ concepts:
       en: lebesgue constant of $1
       property: indexed constant
       area: "fourier series"
-      notation: "msub L $1"
+      comments:
+       - "<math><msub><mi>L</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LebesgueConstants.html"
        - "https://en.wikipedia.org/wiki/Lebesgue_constant_(interpolation)"
@@ -6822,7 +6857,8 @@ concepts:
       en: legendre chi function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub χ $1"
+      comments:
+       - "<math><msub><mi>χ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Legendre_chi_function"
        - "https://mathworld.wolfram.com/LegendresChi-Function.html"
@@ -6832,7 +6868,8 @@ concepts:
       en: legendre polynomial of $1
       property: function
       area: "orthogonal polynomials"
-      notation: "msub P $1"
+      comments:
+       - "<math><msub><mi>P</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Legendre_polynomials"
@@ -6859,7 +6896,8 @@ concepts:
       en: lehmer mean of $1
       property: "indexed function"
       area: "means"
-      notation: "msub L $1"
+      comments:
+       - "<math><msub><mi>L</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerMean.html"
        - "https://en.wikipedia.org/wiki/Lehmer_mean"
@@ -6869,7 +6907,8 @@ concepts:
       en: lehmer number of $1
       property: "indexed function"
       area: "number theory"
-      notation: "msub U $1"
+      comments:
+       - "<math><msub><mi>U</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerNumber.html"
        - "https://mathworld.wolfram.com/LehmersNumber.html"
@@ -6880,7 +6919,8 @@ concepts:
       en: level of $1
       property: function
       area: "scales of measurement"
-      notation: "msub L $1"
+      comments:
+       - "<math><msub><mi>L</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Level_(logarithmic_quantity)"
        - "https://en.wikipedia.org/wiki/Categorical_variable"
@@ -6942,7 +6982,8 @@ concepts:
       en: lie derivative of $1
       property: "indexed operator"
       area: "lie algebra"
-      notation: "msub ℒ $1"
+      comments:
+       - "<math><msub><mi>ℒ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LieDerivative.html"
        - "https://en.wikipedia.org/wiki/Lie_derivative"
@@ -7187,7 +7228,8 @@ concepts:
       en: lucas number of $1
       property: "indexed symbol"
       area: "integer sequences"
-      notation: "msub L $1"
+      comments:
+       - "<math><msub><mi>L</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LucasNumber.html"
        - "https://en.wikipedia.org/wiki/Lucas_number"
@@ -7198,8 +7240,9 @@ concepts:
       en: lucas sequence of $1
       property: "indexed function"
       area: "integer sequences"
-      notation: "msub U $1"
-      notationa: "msub V $1"
+      comments:
+       - "<math><msub><mi>U</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>V</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LucasSequence.html"
        - "https://en.wikipedia.org/wiki/Lucas_sequence"
@@ -7270,7 +7313,8 @@ concepts:
       en: mapping cone of $1
       property: "indexed symbol"
       area: "homotopy theory"
-      notation: "msub C $1"
+      comments:
+       - "<math><msub><mi>C</mi><mi>x</mi></msub></math>"
       notationa: "mrow C $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_cone_(topology)"
@@ -7284,9 +7328,10 @@ concepts:
       en: matching polynomial of $1
       property: "indexed function"
       area: "graph theory"
-      notation: "msub m $1"
-      notationb: "msub M $1"
-      notationa: "msub μ $1"
+      comments:
+       - "<math><msub><mi>m</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>μ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Matching_polynomial"
     
@@ -7295,8 +7340,9 @@ concepts:
       en: mathieu function of first kind of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub ce $1"
-      notationa: "msub se $1"
+      comments:
+       - "<math><msub><mi>ce</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>se</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7319,8 +7365,9 @@ concepts:
       en: mathieu function of second kind of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub fe $1"
-      notationa: "msub ge $1"
+      comments:
+       - "<math><msub><mi>fe</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>ge</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7384,7 +7431,8 @@ concepts:
       en: matrix ring of $1
       property: function
       area: "abstract algebra"
-      notation: "msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Matrix_ring"
        - "https://www.encyclopediaofmath.org/index.php/Matrix_ring"
@@ -7474,7 +7522,8 @@ concepts:
       en: mersenne number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MersenneNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Mersenne_number"
@@ -7484,7 +7533,8 @@ concepts:
       en: mersenne prime of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MersennePrime.html"
        - "https://en.wikipedia.org/wiki/Mersenne_number"
@@ -7588,7 +7638,8 @@ concepts:
       en: mittag leffler function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub E $1"
+      comments:
+       - "<math><msub><mi>E</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Mittag-LefflerFunction.html"
        - "https://en.wikipedia.org/wiki/Mittag-Leffler_function"
@@ -7614,7 +7665,8 @@ concepts:
       en: modified bessel function of first kind of $1
       property: function
       area: "special functions"
-      notation: "msub I $1"
+      comments:
+       - "<math><msub><mi>I</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/10#PT3"
        - "https://dlmf.nist.gov/10.25#E2"
@@ -7625,7 +7677,8 @@ concepts:
       en: modified bessel function of second kind of $1
       property: function
       area: "special functions"
-      notation: "msub K $1"
+      comments:
+       - "<math><msub><mi>K</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/10#PT3"
        - "https://dlmf.nist.gov/10.25#E2"
@@ -7636,11 +7689,12 @@ concepts:
       en: modified mathieu function of $1
       property: function
       area: "special functions"
-      notation: "msub Ce $1"
-      notationd: "msub Se $1"
-      notationc: "msub Me $1"
-      notationb: "msub Fe $1"
-      notationa: "msub Ge $1"
+      comments:
+       - "<math><msub><mi>Ce</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Se</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Me</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Fe</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Ge</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/28#PT4"
        - "https://dlmf.nist.gov/28.20#E3"
@@ -7673,7 +7727,8 @@ concepts:
       en: modified struve function of $1
       property: function
       area: "special functions"
-      notation: "msub L $1"
+      comments:
+       - "<math><msub><mi>L</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModifiedStruveFunction.html"
        - "https://dlmf.nist.gov/11.2#E2"
@@ -7721,7 +7776,8 @@ concepts:
       en: moment of function $1 $2
       property: "msub, mixfix"
       area: "mathematics"
-      notation: "msub μ $1"
+      comments:
+       - "<math><msub><mi>μ</mi><mi>x</mi></msub></math>"
       notationa: "mrow E [ msup $1 $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -7815,7 +7871,8 @@ concepts:
       en: motzkin number of $1
       property: "indexed symbol"
       area: "combinatorial analysis"
-      notation: "msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
       notationa: "mi M"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
@@ -7858,8 +7915,9 @@ concepts:
       en: multiplicative order of $1
       property: "indexed function"
       area: "modular arithmetic"
-      notation: "msub O $1"
-      notationa: "msub ord $1"
+      comments:
+       - "<math><msub><mi>O</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>ord</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MultiplicativeOrder.html"
        - "https://en.wikipedia.org/wiki/Multiplicative_order"
@@ -7900,7 +7958,8 @@ concepts:
       en: multivariate gaussian distribution
       property: symbol
       area: "probability theory"
-      notation: "msub 𝒩 $1"
+      comments:
+       - "<math><msub><mi>𝒩</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Multivariate_normal_distribution"
       alias:
@@ -8098,7 +8157,8 @@ concepts:
       en: normalizer of $1
       property: function
       area: "group theory"
-      notation: "msub N $1"
+      comments:
+       - "<math><msub><mi>N</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Normalizer.html"
        - "https://en.wikipedia.org/wiki/Centralizer_and_normalizer"
@@ -8491,7 +8551,8 @@ concepts:
       en: peclet number of $1
       property: "indexed symbol"
       area: "fluid dynamics"
-      notation: "msub Pe $1"
+      comments:
+       - "<math><msub><mi>Pe</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/P%C3%A9clet_number"
        - "https://www.encyclopediaofmath.org/index.php/Peclet_number"
@@ -8512,7 +8573,8 @@ concepts:
       en: pell number
       property: symbol
       area: "number theory"
-      notation: "msub P $1"
+      comments:
+       - "<math><msub><mi>P</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PellNumber.html"
        - "https://en.wikipedia.org/wiki/Pell_number"
@@ -8522,7 +8584,8 @@ concepts:
       en: pell luca number
       property: symbol
       area: "number theory"
-      notation: "msub Q $1"
+      comments:
+       - "<math><msub><mi>Q</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Pell-LucasNumber.html"
        - "https://en.wikipedia.org/wiki/Pell_number"
@@ -8808,7 +8871,8 @@ concepts:
       en: polylogarithm of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub Li $1"
+      comments:
+       - "<math><msub><mi>Li</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Polylogarithm.html"
        - "https://en.wikipedia.org/wiki/Polylogarithm"
@@ -8831,7 +8895,8 @@ concepts:
       en: pontryagin class of $1
       property: "indexed symbol"
       area: "differential topology"
-      notation: "msub p $1"
+      comments:
+       - "<math><msub><mi>p</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PontryaginClass.html"
        - "https://en.wikipedia.org/wiki/Pontryagin_class"
@@ -9250,7 +9315,8 @@ concepts:
       en: racah polynomial of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub R $1"
+      comments:
+       - "<math><msub><mi>R</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RacahPolynomial.html"
        - "https://en.wikipedia.org/wiki/Racah_polynomials"
@@ -9306,7 +9372,8 @@ concepts:
       en: ramanujan sum of $1
       property: "indexed function"
       area: "number theory"
-      notation: "msub c $1"
+      comments:
+       - "<math><msub><mi>c</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansSum.html"
        - "https://dlmf.nist.gov/27.10#E4"
@@ -9343,7 +9410,8 @@ concepts:
       en: ramification index of $1
       property: msub
       area: "algebraic number theory"
-      notation: "msub e $1"
+      comments:
+       - "<math><msub><mi>e</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamificationIndex.html"
        - "https://en.wikipedia.org/wiki/Ramification_(mathematics)#In_algebraic_number_theory"
@@ -9942,7 +10010,8 @@ concepts:
       en: schroder number of $1
       property: "indexed symbol"
       area: "combinatorics"
-      notation: "msub S $1"
+      comments:
+       - "<math><msub><mi>S</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchroederNumber.html"
        - "https://en.wikipedia.org/wiki/Schr%C3%B6der_number"
@@ -10233,7 +10302,8 @@ concepts:
       en: skewes number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub Sk $1"
+      comments:
+       - "<math><msub><mi>Sk</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SkewesNumber.html"
        - "https://en.wikipedia.org/wiki/Skewes%27_number"
@@ -10323,7 +10393,8 @@ concepts:
       en: special linear group of $1
       property: "indexed function"
       area: "group theory"
-      notation: "msub SL $1"
+      comments:
+       - "<math><msub><mi>SL</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialLinearGroup.html"
        - "https://en.wikipedia.org/wiki/Special_linear_group"
@@ -10390,7 +10461,8 @@ concepts:
       en: spectrum of matrix of $1
       property: msub
       area: "linear algebra"
-      notation: "msub σ $1"
+      comments:
+       - "<math><msub><mi>σ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_matrix"
     
@@ -10545,7 +10617,8 @@ concepts:
       en: stanley reisner ideal of $1
       property: msub
       area: "commutative algebra"
-      notation: "msub I $1"
+      comments:
+       - "<math><msub><mi>I</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/Stanley-Reisner_ring"
@@ -10615,7 +10688,8 @@ concepts:
       en: stieltjes wigert polynomial of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub S $1"
+      comments:
+       - "<math><msub><mi>S</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stieltjes-WigertPolynomial.html"
        - "https://en.wikipedia.org/wiki/Stieltjes%E2%80%93Wigert_polynomials"
@@ -10915,9 +10989,10 @@ concepts:
       en: symmetric group of $1
       property: "msub, function, postfix"
       area: "group theory"
-      notation: "msub S $1"
-      notationf: "msub 𝔖 $1"
-      notatione: "msub Σ $1"
+      comments:
+       - "<math><msub><mi>S</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>𝔖</mi><mi>x</mi></msub></math>"
+       - "<math><msub><mi>Σ</mi><mi>x</mi></msub></math>"
       notationd: "mrow Σ ( $1 )"
       notationc: "mrow Sym ( $1 )"
       notationb: "mrow $1 !"
@@ -10956,7 +11031,8 @@ concepts:
       en: szego polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
-      notation: "msub ϕ $1"
+      comments:
+       - "<math><msub><mi>ϕ</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Szeg%C5%91_polynomial"
        - "https://www.encyclopediaofmath.org/index.php/Szego_polynomial"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -723,7 +723,8 @@ concepts:
       en: bergman space
       property: "indexed function"
       area: "complex analysis"
-      notation: "msup A $1 ($2"
+      comments:
+       - "<math><msup><mi>A</mi><mi>n</mi></msup><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BergmanSpace.html"
        - "https://en.wikipedia.org/wiki/Bergman_space"
@@ -749,7 +750,8 @@ concepts:
       en: bernoulli polynomial $1 $2
       property: "indexed function"
       area: "number theory"
-      notation: "msub B $1 ($2"
+      comments:
+       - "<math><msub><mi>B</mi><mi>n</mi></msub><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BernoulliPolynomial.html"
        - "https://en.wikipedia.org/wiki/Bernoulli_polynomials"
@@ -762,7 +764,8 @@ concepts:
       en: $1 th bessel function of $2
       property: "indexed function"
       area: "special functions"
-      notation: "msub J $1 ($2"
+      comments:
+       - "<math><msub><mi>J</mi><mi>n</mi></msub><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselFunction.html"
        - "https://en.wikipedia.org/wiki/Bessel_function"
@@ -774,7 +777,8 @@ concepts:
       en: $1 th bessel function of second kind of $2
       property: "indexed function"
       area: "special functions"
-      notation: "msub Y $1 ($2"
+      comments:
+       - "<math><msub><mi>Y</mi><mi>n</mi></msub><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselFunctionoftheSecondKind.html"
        - "https://dlmf.nist.gov/10.2#E3"
@@ -785,7 +789,8 @@ concepts:
       en: $1 th bessel polynomial of $2
       property: "indexed function"
       area: "special functions"
-      notation: "msub y $1 ($2"
+      comments:
+       - "<math><msub><mi>y</mi><mi>n</mi></msub><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselPolynomial.html"
        - "https://en.wikipedia.org/wiki/Bessel_polynomials"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -63,7 +63,7 @@ concepts:
     - concept: ad
       arity: 1
       en: $1 a d
-      property: postfix
+      property: postfix. prefix
       area: "calendar units"
       notation: "mi AD"
       urls: 
@@ -74,7 +74,8 @@ concepts:
       en: additive inverse of $1
       property: prefix
       area: "abstract algebra"
-      notation: "mo -"
+      comments:
+       - "<math><mo>-</mo><mi>n</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Additive_inverse"
       alias:
@@ -308,7 +309,7 @@ concepts:
     - concept: alternative-denial
       arity: 2
       en: $1 alternative denial $2
-      property: infix<br/>prefix
+      property: infix, prefix
       area: "propositional calculus"
       notation: "mo | <br/>mo ↑<br/>mrow D $1 $2"
       urls: 
@@ -1233,7 +1234,7 @@ concepts:
     - concept: ceiling
       arity: 1
       en: ceiling of $1
-      property: fenced<br/>function
+      property: fenced, function
       area: "number theory"
       notation: "⌈ $1 ⌉<br/>〛 $1 〚<br/>] $1 [<br/>ceil ($1"
       urls: 
@@ -1316,7 +1317,7 @@ concepts:
     - concept: characteristic-function
       arity: 1
       en: characteristic function of $1
-      property: "indexed function<br/>function"
+      property: "indexed function, function"
       area: "probability theory"
       notation: "msub 𝟏 $1<br/>mrow 𝟏 { $1 }"
       urls: 
@@ -1560,7 +1561,7 @@ concepts:
     - concept: closed-neighbourhood
       arity: 2
       en: closed neighbourhood
-      property: "indexed function<br/>function"
+      property: "indexed function, function"
       area: "graph theory"
       notation: "msub N $1 [ $2 ]<br/>mrow N [ $1 ]"
       urls: 
@@ -1569,7 +1570,7 @@ concepts:
     - concept: closure
       arity: 1
       en: closure of $1
-      property: "function<br/>msup"
+      property: "function, msup"
       area: "abstract algebra,, topology"
       notation: "mi cl<br/>mi Cl<br/>msup $1 −"
       urls: 
@@ -1684,7 +1685,7 @@ concepts:
     - concept: commutator-subgroup
       arity: 1
       en: commutator subgroup of $1
-      property: msup<br/>fenced
+      property: msup, fenced
       area: "abstract algebra"
       notation: "msup $1 '<br/>msup $1 (1)<br/>mrow [ $1, $1 ]"
       urls: 
@@ -2504,7 +2505,7 @@ concepts:
     - concept: degree
       arity: 1
       en: degree of $1
-      property: prefix<br/>postfix
+      property: prefix, postfix
       area: "physics, geometry"
       notation: "mo °"
       urls: 
@@ -2636,7 +2637,7 @@ concepts:
     - concept: diameter
       arity: 1
       en: diameter of $1
-      property: symbol<br/>prefix unit
+      property: symbol, prefix unit
       area: "geometry"
       notation: "mi d<br/>mo ⌀<br/>mi DIA<br/>mi dia"
       urls: 
@@ -2745,7 +2746,7 @@ concepts:
     - concept: dimension
       arity: 1
       en: dimension of $1
-      property: "function<br/>fenced"
+      property: "function, fenced"
       area: "linear algebra, graph theory"
       notation: "mi dim<br/>mrow [ $1 ]"
       urls: 
@@ -2857,7 +2858,7 @@ concepts:
     - concept: directional-derivative
       arity: 1
       en: directional derivative of $1
-      property: "function<br/>mixfix"
+      property: "function, mixfix"
       area: "differential calculus"
       notation: "msub ∇ v<br/>msub D v<br/>mrow v ⋅ ∇ $1"
       urls: 
@@ -2996,7 +2997,7 @@ concepts:
     - concept: divergence
       arity: 1
       en: divergence of $1
-      property: "function<br/>mixfix"
+      property: "function, mixfix"
       area: "vector calculus"
       notation: "mi div<br/>mrow ∇ ⋅ $1"
       urls: 
@@ -3010,7 +3011,7 @@ concepts:
     - concept: divided-difference
       arity: 1
       en: divided difference of $1
-      property: "fenced<br/>mixfix"
+      property: "fenced, mixfix"
       area: "special functions"
       notation: "mrow [ $1, ... $n ]<br/>mrow #f [$1, ..., $n ]<br/>mrow D [ $1, ... $n ] #f"
       urls: 
@@ -3710,7 +3711,7 @@ concepts:
     - concept: exterior
       arity: 1
       en: exterior of $1
-      property: "function<br/>msup"
+      property: "function, msup"
       area: "topology"
       notation: "mi ext<br/>msup $1 e"
       urls: 
@@ -3970,7 +3971,7 @@ concepts:
     - concept: floor
       arity: 1
       en: floor of $1
-      property: fenced<br/>function
+      property: fenced, function
       area: "number theory"
       notation: "⌊ $1 ⌋<br/>〚 $1 〛<br/>[ $1 ]<br/>floor ($1"
       urls: 
@@ -4083,7 +4084,7 @@ concepts:
     - concept: fractional-part
       arity: 1
       en: fractional part of $1
-      property: "function<br/>fenced"
+      property: "function, fenced"
       area: "arithmetic"
       notation: "mi frac<br/>mrow ⟦ $1 ⟧<br/>mrow { $1 }"
       urls: 
@@ -4166,7 +4167,7 @@ concepts:
     - concept: free-module
       arity: 2
       en: free module $1 $2
-      property: mixfix<br/>msup
+      property: mixfix, msup
       area: "module theory"
       notation: "mrow $1 { $2 }<br/>msup $1 ($2"
       urls: 
@@ -4251,7 +4252,7 @@ concepts:
     - concept: functor-category
       arity: 2
       en: functor category
-      property: msup<br/>fenced
+      property: msup, fenced
       area: "category theory"
       notation: "msup $1 $2<br/>mrow [$1, $2]"
       urls: 
@@ -4757,7 +4758,7 @@ concepts:
     - concept: group-of-units
       arity: 1
       en: group of units of $1
-      property: msup<br/>function
+      property: msup, function
       area: "ring theory"
       notation: "msup $1 *<br/>msup $1 ×<br/>mi U"
       urls: 
@@ -4767,7 +4768,7 @@ concepts:
     - concept: group-ring
       arity: 2
       en: group ring $1 $2
-      property: mixfix<br/>infix
+      property: mixfix, infix
       area: "ring theory"
       notation: "mrow $1 [ $2 ]<br/>mrow $1 $2"
       urls: 
@@ -5328,7 +5329,7 @@ concepts:
     - concept: hyperdeterminant
       arity: 1
       en: hyperdeterminant of $1
-      property: "function<br/>fenced"
+      property: "function, fenced"
       area: "multilinear algebra"
       notation: "mi det<br/>mrow | $1 |"
       urls: 
@@ -5578,7 +5579,7 @@ concepts:
     - concept: infimum
       arity: 1
       en: infimum of $1
-      property: "function<br/>largeop"
+      property: "function, largeop"
       area: "order theory"
       notation: "mi inf<br/>mo ⋀"
       urls: 
@@ -5628,7 +5629,7 @@ concepts:
     - concept: injection
       arity: 3
       en: injection $1, from $2 to $3
-      property: mixfix<br/>
+      property: mixfix, 
       area: "set theory"
       comments:
        - "<math><mi>f</mi><mo>:</mo><mi>X</mi><mo>↣</mo><mi>Y</mi></math>"
@@ -5664,7 +5665,7 @@ concepts:
     - concept: inner-product
       arity: 2
       en: $1 inner product $2
-      property: infix<br/>fenced
+      property: infix, fenced
       area: "linear algebra"
       notation: "mo ⋅<br/>mrow [ $1, $2 ]"
       urls: 
@@ -5686,7 +5687,7 @@ concepts:
     - concept: integer-part
       arity: 1
       en: integer part of $1
-      property: "function<br/>fenced"
+      property: "function, fenced"
       area: "number theory"
       notation: "mi int<br/>[ $1 ]"
       urls: 
@@ -5708,7 +5709,7 @@ concepts:
     - concept: interior-product
       arity: 1
       en: interior product of $1
-      property: "infix<br/>indexed function"
+      property: "infix, indexed function"
       area: "differential forms"
       notation: "mo ⨼<br/>msub ι $1"
       urls: 
@@ -5752,7 +5753,7 @@ concepts:
     - concept: inverse-moment-of-function
       arity: 2
       en: inverse moment of function $1 $2
-      property: "<br/>msub<br/>mixfix"
+      property: "<br/>msub, mixfix"
       area: "mathematics"
       notation: "msub μ mrow - $1 /mrow<br/>mrow E [ msup $1 mrow - $2 /mrow ]"
       urls: 
@@ -6272,7 +6273,7 @@ concepts:
     - concept: kronecker-symbol
       arity: 2
       en: kronecker symbol
-      property: fenced<br/>fenced stacked
+      property: fenced, fenced stacked
       area: "number theory"
       notation: "mrow ( $1 | $2 )<br/>( mfrac $1 $2 )"
       urls: 
@@ -6386,7 +6387,7 @@ concepts:
     - concept: laplace-operator
       arity: 1
       en: laplace operator of $1
-      property: "<br/>embellished operator<br/>"
+      property: "<br/>embellished operator, "
       area: "differential operators"
       notation: "msup ∇ 2<br/>mrow ∇ · ∇<br/>mi Δ"
       urls: 
@@ -6542,7 +6543,7 @@ concepts:
     - concept: legendre-symbol
       arity: 2
       en: legendre symbol
-      property: fenced<br/>fenced stacked
+      property: fenced, fenced stacked
       area: "number theory"
       notation: "mrow ( $1 | $2 )<br/>mrow ( mfrac $1 $2 )"
       urls: 
@@ -6612,7 +6613,7 @@ concepts:
     - concept: lexicographic-product
       arity: 2
       en: $1 lexicographic product $2
-      property: infix<br/>mixfix
+      property: infix, mixfix
       area: "graph theory"
       notation: "mo ∙<br/>$1 [ $2 ]"
       urls: 
@@ -6778,7 +6779,7 @@ concepts:
     - concept: logarithmic-moment-of-function
       arity: 2
       en: logarithmic moment of function $1 $2
-      property: "<br/><br/>mixfix"
+      property: "<br/>, mixfix"
       area: "mathematics"
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
       urls: 
@@ -7044,7 +7045,7 @@ concepts:
     - concept: matrix
       arity: 1
       en: matrix of $1
-      property: mtable<br/>fenced
+      property: mtable, fenced
       area: "algebra"
       notation: "mtable<br/>mrow [ $1 ]<br/>mrow ( $1"
       urls: 
@@ -7364,7 +7365,7 @@ concepts:
     - concept: modulo
       arity: 2
       en: $1 modulo $2
-      property: infix<br/>mixfix
+      property: infix, mixfix
       area: "modular arithmetic"
       notation: "mo mod<br/>mrow $1 ( mod $2"
       urls: 
@@ -7389,7 +7390,7 @@ concepts:
     - concept: moment-of-function
       arity: 2
       en: moment of function $1 $2
-      property: "<br/>msub<br/>mixfix"
+      property: "<br/>msub, mixfix"
       area: "mathematics"
       notation: "msub μ $1<br/>mrow E [ msup $1 $2 ]"
       urls: 
@@ -7506,7 +7507,7 @@ concepts:
     - concept: multiplicative-inverse
       arity: 1
       en: multiplicative inverse of $1
-      property: msup<br/>mixfix
+      property: msup, mixfix
       area: "abstract algebra"
       notation: "msup $1 -1<br/>mrow 1 / $1"
       urls: 
@@ -7651,7 +7652,7 @@ concepts:
     - concept: neighbourhood
       arity: 2
       en: neighbourhood
-      property: "indexed function<br/>function"
+      property: "indexed function, function"
       area: "graph theory"
       notation: "msub N $1 ( $2 )<br/>mrow N ( $1"
       urls: 
@@ -7930,7 +7931,7 @@ concepts:
     - concept: order-of-group
       arity: 1
       en: order of group of $1
-      property: "function<br/>fenced"
+      property: "function, fenced"
       area: "group theory"
       notation: "mi ord<br/>mrow | $1 |"
       urls: 
@@ -8202,7 +8203,7 @@ concepts:
     - concept: permutation
       arity: 1
       en: permutation of $1
-      property: fenced<br/>mtable<br/>mixfix
+      property: fenced<br/>mtable, mixfix
       area: "combinatorics"
       notation: "mrow ($1, ... $n)<br/>mtable<br/>mrow (312)(54)(8)(976"
       urls: 
@@ -8476,7 +8477,7 @@ concepts:
     - concept: positive-part
       arity: 1
       en: positive part of $1
-      property: msup<br/>msub
+      property: msup, msub
       area: "elementary mathematics"
       notation: "msup $1 +<br/>msub $1 +"
       urls: 
@@ -8507,7 +8508,7 @@ concepts:
     - concept: power-set
       arity: 1
       en: power set of $1
-      property: "function<br/>msup"
+      property: "function, msup"
       area: "set theory"
       notation: "mi P<br/>mi 𝒫<br/>mi ℙ<br/>mi ℘<br/>msup 2 $1"
       urls: 
@@ -9478,7 +9479,7 @@ concepts:
     - concept: scalar-triple-product
       arity: 3
       en: scalar triple product  of $1, $2 and $3
-      property: mixfix<br/>fenced
+      property: mixfix, fenced
       area: "vector algebra"
       comments:
        - "<math><mi>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi>B</mi><mo>&middot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
@@ -9545,7 +9546,7 @@ concepts:
     - concept: schwarzian-derivative
       arity: 2
       en: schwarzian derivative $1 $2
-      property: fenced<br/>mixfix
+      property: fenced, mixfix
       area: "complex analysis"
       notation: "mrow { $1, $2 }<br/>mrow ( S $1 ) ($2"
       urls: 
@@ -10308,7 +10309,7 @@ concepts:
     - concept: successor
       arity: 1
       en: successor of $1
-      property: "function<br/>msup"
+      property: "function, msup"
       area: "number theory"
       notation: "msup $1 +<br/>mi s<br/>mi S"
       urls: 
@@ -10368,7 +10369,7 @@ concepts:
     - concept: supremum
       arity: 1
       en: supremum of $1
-      property: "function<br/>largeop"
+      property: "function, largeop"
       area: "order theory, lattice theory"
       notation: "mi sup<br/>mo ⋁"
       urls: 
@@ -10408,7 +10409,7 @@ concepts:
     - concept: surjection
       arity: 3
       en: surjection  $1 $2 $3
-      property: mixfix<br/>infix
+      property: mixfix, infix
       area: "set theory"
       comments:
        - "<math><mi>f</mi><mo>:</mo><mi>X</mi><mo>&#x21a0;</mo><mi>Y</mi></math>"
@@ -10454,7 +10455,7 @@ concepts:
     - concept: symmetric-group
       arity: 1
       en: symmetric group of $1
-      property: "msub<br/>function<br/>postfix"
+      property: "msub<br/>function, postfix"
       area: "group theory"
       notation: "msub S $1<br/>msub 𝔖 $1<br/>msub Σ $1<br/>mrow Σ ( $1 )<br/>mrow Sym ( $1 )<br/>mrow $1 !<br/>"
       urls: 
@@ -10941,7 +10942,7 @@ concepts:
     - concept: turan-graph
       arity: 2
       en: turan graph $1 $2
-      property: "function<br/>indexed function"
+      property: "function, indexed function"
       area: "graph theory"
       notation: "mi T<br/>mi D<br/>msub T $1<br/>msub T $1,$2"
       urls: 
@@ -11038,7 +11039,7 @@ concepts:
     - concept: uniformly-convergent
       arity: 1
       en: uniformly convergent of $1
-      property: infix<br/>indexed<br/>postfix
+      property: infix<br/>indexed, postfix
       area: "convergence"
       notation: "mo ⇉<br/>mover ⟶ unif.<br/>mo unif lim<br/>mtext uniformly"
       urls: 
@@ -11569,7 +11570,7 @@ concepts:
     - concept: winding-number
       arity: 1
       en: winding number of $1
-      property: "function<br/>symbol"
+      property: "function, symbol"
       area: "algebraic topology"
       notation: "mi 𝒩<br/>mi w"
       urls: 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -839,9 +839,10 @@ concepts:
       en: $1 biconditional $2
       property: infix
       area: "logic"
-      notation: "mo ⇔"
-      notationb: "mo ≡"
-      notationa: "mo iff"
+      comments:
+       - "<math><mi>X</mi><mo>⇔</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>≡</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>iff</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Biconditional.html"
        - "https://ncatlab.org/nlab/show/biconditional"
@@ -1778,7 +1779,8 @@ concepts:
       en: $1 comparability $2
       property: infix
       area: "order theory"
-      notation: "munderover = > <"
+      comments:
+       - "<math><mi>X</mi><mo>⪋</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
       alias:
@@ -3235,7 +3237,8 @@ concepts:
       en: $1 double category $2
       property: infix
       area: "category theory"
-      notation: "mover → →"
+      comments:
+       - "<math><mi>X</mi><mo>⇉</mo><mi>Y</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/double+category"
     
@@ -4979,8 +4982,9 @@ concepts:
       en: $1 hadamard product $2
       property: infix
       area: "algebra"
-      notation: "mo ∘"
-      notationa: "mo ⊙"
+      comments:
+       - "<math><mi>X</mi><mo>∘</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊙</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/HadamardProduct.html"
        - "https://en.wikipedia.org/wiki/Hadamard_product_(matrices)"
@@ -5957,8 +5961,8 @@ concepts:
       en: $1 intersection number $2
       property: infix
       area: "algebraic geometry"
-      notation: "mo ⋅"
-      notationa: ""
+      comments:
+       - "<math><mi>X</mi><mo>⋅</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Intersection_number"
     
@@ -6044,8 +6048,9 @@ concepts:
       en: $1 isomorphism $2
       property: infix
       area: "set theory"
-      notation: "mover ↦ ∼"
-      notationa: "mo ≅"
+      comments:
+       - "<math><mi>X</mi><mover><mo>↦</mo><mo>∼</mo></mover><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>≅</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Isomorphism.html"
        - "https://en.wikipedia.org/wiki/Isomorphism"
@@ -11820,8 +11825,9 @@ concepts:
       en: $1 weak convergence $2
       property: infix
       area: "analysis"
-      notation: "mover →w"
-      notationa: "mo ⇀"
+      comments:
+       - <math><mi>X</mi><mover><mo>→</mo><mi>w</mi></mover><mi>Y</mi></math>"
+       - <math><mi>X</mi><mo>⇀</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeakConvergence.html"
        - "https://en.wikipedia.org/wiki/Weak_convergence_(Hilbert_space)"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9137,8 +9137,8 @@ concepts:
       property: mixfix<br/>fenced
       area: "vector algebra"
       comment:
-       - "<math><mi>A</mi><mo>&cdot;</mo>(mrow><mo>(</mo><mi>B</mi><mo>&cdot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
-       - "<math>mo>[</mo><mi>A</mi><mo>,</mo>(mrow><mi>B</mi><mo>,</mo><mi>C</mi><mo>]</mo></math>"
+       - "<math><mi>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi>B</mi><mo>&middot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
+       - "<math><mo>[</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>,</mo><mi>C</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ScalarTripleProduct.html"
        - "https://en.wikipedia.org/wiki/Triple_product"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -350,7 +350,7 @@ concepts:
       urls: 
        - "https://math.stackexchange.com/questions/828828/amalgamated-product"
        - "https://en.wikipedia.org/wiki/Free_product"
-       - "http//home.iiserb.ac.in/~kashyap/Group/thesis_abhay.pdf"
+       - "https://home.iiserb.ac.in/~kashyap/Group/thesis_abhay.pdf"
       alias:
        - amalgamated-free-product
        - free-product-with-amalgamation

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -8360,7 +8360,8 @@ concepts:
       en: p core of $1
       property: function
       area: "group theory"
-      notation: "msub O p"
+      comments:
+       - "<math><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi>G</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Core_(group)"
        - "https://en.wikipedia.org/wiki/P-soluble_group"
@@ -8477,7 +8478,8 @@ concepts:
       en: pauli matrix of $1
       property: "indexed symbol"
       area: "mathematical physics"
-      notation: "msub σ $1"
+      comments:
+       - "<math><msub><mi>σ</mi><mi>G</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PauliMatrices.html"
        - "https://mathworld.wolfram.com/PauliMatrix.html"
@@ -9647,9 +9649,10 @@ concepts:
       en: riemann sphere of $1
       property: scripted symbol
       area: "projective geometry"
-      notation: "mover ℂ ^"
-      notationb: "mover ℂ ¯"
-      notationa: "msub ℂ ∞"
+      comments:
+       - "<math><mover><mi>ℂ</mi><mo>^</mo></mover></math>"
+       - "<math><mover><mi>ℂ</mi><mo>¯</mo></mover></math>"
+       - "<math><msub><mi>ℂ</mi><mo>∞</mo></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannSphere.html"
        - "https://en.wikipedia.org/wiki/Riemann_sphere"
@@ -9736,7 +9739,8 @@ concepts:
       en: right derivative of $1
       property: operator
       area: "calculus"
-      notation: "msub ∂ +"
+      comments:
+       - "<math><msub><mo>∂</mo><mo>+</mo></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
     
@@ -10976,7 +10980,8 @@ concepts:
       en: tangent space of $1
       property: "indexed function"
       area: "topology"
-      notation: "msub T $1"
+      comments:
+       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentSpace.html"
        - "https://en.wikipedia.org/wiki/Tangent_space"
@@ -10999,7 +11004,8 @@ concepts:
       en: tate module of $1
       property: "indexed function"
       area: "group theory"
-      notation: "msub T $1"
+      comments:
+       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tate_module"
        - "https://ncatlab.org/nlab/show/Tate+module"
@@ -11116,7 +11122,8 @@ concepts:
       en: theta function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "msub θ $1"
+      comments:
+       - "<math><msub><mi>θ</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ThetaFunction.html"
        - "https://en.wikipedia.org/wiki/Theta_function"
@@ -11233,7 +11240,8 @@ concepts:
       en: torsion subgroup of $1
       property: msub
       area: "group theory"
-      notation: "msub $1 T"
+      comments:
+       - "<math><msub><mi>G</mi><mi>T</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_subgroup"
        - "https://ncatlab.org/nlab/show/torsion+subgroup"
@@ -11326,7 +11334,8 @@ concepts:
       en: triangular number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub T $1"
+      comments:
+       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TriangularNumber.html"
        - "https://en.wikipedia.org/wiki/Triangular_number"
@@ -11403,7 +11412,8 @@ concepts:
       en: tube domain of $1
       property: msub
       area: "complex analysis"
-      notation: "msub T $1"
+      comments:
+       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tube_domain"
        - "https://www.encyclopediaofmath.org/index.php/Tube_domain"
@@ -11490,7 +11500,8 @@ concepts:
       en: ulam number of $1
       property: "indexed symbol"
       area: "integer sequences"
-      notation: "msub U $1"
+      comments:
+       - "<math><msub><mi>U</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/UlamNumber.html"
        - "https://en.wikipedia.org/wiki/Ulam_number"
@@ -11555,7 +11566,8 @@ concepts:
       en: unitary group of $1
       property: "indexed symbol"
       area: "group theory"
-      notation: "msub U $1"
+      comments:
+       - "<math><msub><mi>U</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/UnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Unitary_group"
@@ -11709,7 +11721,8 @@ concepts:
       en: vect of $1
       property: "indexed symbol"
       area: "category theory"
-      notation: "msub Vect $1"
+      comments:
+       - "<math><msub><mi>Vect</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Vect"
     
@@ -11961,7 +11974,8 @@ concepts:
       en: wheel graph of $1
       property: "indexed symbol"
       area: "graph theory"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WheelGraph.html"
        - "https://en.wikipedia.org/wiki/Wheel_graph"
@@ -12029,7 +12043,8 @@ concepts:
       en: wiener process of $1
       property: "indexed symbol"
       area: "martingale theory"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerProcess.html"
        - "https://en.wikipedia.org/wiki/Wiener_process"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -658,7 +658,7 @@ concepts:
       en: baumslag solitar group
       property: function
       area: "group theory"
-      notation: "mrow BS ( $1, $2"
+      notation: "mrow BS ( $1, $2 )"
       urls: 
        - "https://en.wikipedia.org/wiki/Baumslag%E2%80%93Solitar_group"
        - "https://www.encyclopediaofmath.org/index.php/Baumslag-Solitar_group"
@@ -1921,7 +1921,8 @@ concepts:
       en: concentration of $1
       property: fenced
       area: "chemistry"
-      notation: "mrow [ $1 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://chem.libretexts.org/Bookshelves/General_Chemistry/Map%3A_Chemistry_-_The_Central_Science_(Brown_et_al.)/04._Reactions_in_Aqueous_Solution/4.5%3A_Concentration_of_Solutions"
     
@@ -2459,7 +2460,7 @@ concepts:
       property: fenced
       area: "differential topology"
       notation: "mrow [[ $1 ]]"
-      notationa: "mrow [ $1 ]"
+      notationa: "<math><mrow><mo>[</mo><mi>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Current.html"
        - "https://en.wikipedia.org/wiki/Current_(mathematics)"
@@ -2906,7 +2907,7 @@ concepts:
       area: "linear algebra, graph theory"
       comments:
        - "<math><mi>dim</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mrow [ $1 ]"
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
        - "https://en.wikipedia.org/wiki/Dimension_(mathematics_and_physics)"
@@ -5052,7 +5053,7 @@ concepts:
       comments:
        - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
        - "<math><msup><mi>X</mi><mo>×</mo></msup></math>"
-      notationa: "<math><mi>U</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mi>U</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5657,7 +5658,7 @@ concepts:
       area: "multilinear algebra"
       comments:
        - "<math><mi>det</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mrow | $1 |"
+       - "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
        - "https://en.wikipedia.org/wiki/Hyperdeterminant"
@@ -6434,7 +6435,8 @@ concepts:
       en: kauffman bracket of $1
       property: fenced
       area: "knot theory"
-      notation: "mrow ⟨ $1 ⟩"
+      comments:
+       - "<math><mrow><mo>⟨</mo><mi>x</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bracket_polynomial"
       alias:
@@ -7488,7 +7490,7 @@ concepts:
       property: mtable, fenced
       area: "algebra"
       notation: "mtable"
-      notationb: "mrow [ $1 ]"
+      notationb: "<math><mrow><mo>[</mo><mi>x</mi><mo>]</mo></mrow></math>"
       notationa: "mrow ( $1"
       urls: 
        - "https://mathworld.wolfram.com/Matrix.html"
@@ -7949,7 +7951,7 @@ concepts:
       area: "combinatorial analysis"
       comments:
        - "<math><msub><mi>M</mi><mi>x</mi></msub></math>"
-      notationa: "<math><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
        - "https://en.wikipedia.org/wiki/Motzkin_number"
@@ -8221,7 +8223,8 @@ concepts:
       en: norm of $1
       property: fenced
       area: "linear algebra"
-      notation: "mrow ‖ $1 ‖"
+      comments:
+       - "<math><mrow><mo>‖</mo><mi>x</mi><mo>‖</mo></mrow></math>"
       notationa: "mrow | $1"
       urls: 
        - "https://mathworld.wolfram.com/Norm.html"
@@ -8270,7 +8273,8 @@ concepts:
       en: numerical part of $1
       property: fenced
       area: "SI units"
-      notation: "mrow { $1 }"
+      comments:
+       - "<math><mrow><mo>{</mo><mi>x</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values"
     
@@ -8415,7 +8419,7 @@ concepts:
       area: "group theory"
       comments:
        - "<math><mi>ord</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mrow | $1 |"
+       - "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
     
@@ -9445,8 +9449,8 @@ concepts:
       area: "geometry"
       comments:
        - "<math><mi>x</mi></math>"
-      notationb: "<math><mi>r</mi></math>"
-      notationa: "<math><mi>s</mi></math>"
+       - "<math><mi>r</mi></math>"
+       - "<math><mi>s</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RadiusVector.html"
        - "https://en.wikipedia.org/wiki/Position_(vector)"
@@ -10927,8 +10931,8 @@ concepts:
       area: "number theory"
       comments:
        - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
-      notationb: "<math><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
-      notationa: "<math><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Proclus"
        - "https://en.wikipedia.org/wiki/Successor_cardinal"
@@ -11448,7 +11452,8 @@ concepts:
       en: total variation of $1
       property: fenced
       area: "measure theory"
-      notation: "mrow |$1 |"
+      comments:
+       - "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TotalVariation.html"
        - "https://en.wikipedia.org/wiki/Total_variation"
@@ -11721,7 +11726,8 @@ concepts:
       en: unit part of $1
       property: fenced
       area: "SI units"
-      notation: "mrow [ $1 ]"
+      comments:
+       - "<math><mrow><mo>[</mo><mi>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values"
        - "https://physics.stackexchange.com/questions/77690/square-bracket-notation-for-dimensions-and-units-usage-and-conventions"
@@ -12139,7 +12145,8 @@ concepts:
       en: weighted mean of $1
       property: fenced
       area: "special functions"
-      notation: "mrow ⟨ $1 ⟩"
+      comments:
+       - "<math><mrow><mo>⟨</mo><mi>x</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeightedMean.html"
        - "https://en.wikipedia.org/wiki/Weighted_arithmetic_mean"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -641,7 +641,7 @@ concepts:
     
     - concept: bell-polynomial
       arity: n
-      en: bell polynomial
+      en: $1 th bell polynomial of $2, $3, ...
       property: "indexed function"
       area: "polynomials"
       notation: "mrow msub B $1 ($2, ... $n"
@@ -688,7 +688,7 @@ concepts:
     
     - concept: bernoulli-polynomial
       arity: 2
-      en: bernoulli polynomial
+      en: bernoulli polynomial $1 $2
       property: "indexed function"
       area: "number theory"
       notation: "msub B $1 ($2"
@@ -701,7 +701,7 @@ concepts:
     
     - concept: bessel-function
       arity: 2
-      en: bessel function
+      en: $1 th bessel function of $2
       property: "indexed function"
       area: "special functions"
       notation: "msub J $1 ($2"
@@ -713,7 +713,7 @@ concepts:
     
     - concept: bessel-function-of-second-kind
       arity: 2
-      en: bessel function of second kind
+      en: $1 th bessel function of second kind of $2
       property: "indexed function"
       area: "special functions"
       notation: "msub Y $1 ($2"
@@ -724,7 +724,7 @@ concepts:
     
     - concept: bessel-polynomial
       arity: 2
-      en: bessel polynomial
+      en: $1 th bessel polynomial of $2
       property: "indexed function"
       area: "special functions"
       notation: "msub y $1 ($2"
@@ -1015,7 +1015,7 @@ concepts:
     
     - concept: calderon-toeplitz-operator
       arity: 2
-      en: calderon toeplitz operator
+      en: calderon toeplitz operator $1 $2
       property: "indexed symbol"
       area: "operator theory"
       notation: "msub T mrow $1, $2"
@@ -3272,7 +3272,7 @@ concepts:
     
     - concept: equivariant-cohomology
       arity: 2
-      en: equivariant cohomology
+      en: equivariant cohomology $1 $2
       property: function
       area: "algebraic topology"
       notation: "msubsup H $1 $2"
@@ -3361,8 +3361,8 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Etale_cohomology"
     
     - concept: euclid-number
-      arity: 0
-      en: euclid number
+      arity: 1
+      en: euclid number $1
       property: symbol
       area: "number theory"
       notation: "msub E $1"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -374,7 +374,7 @@ concepts:
     
     - concept: anharmonic-ratio
       arity: 4
-      en: anharmonic-ratio
+      en: "anharmonic-ratio of $1 , $2 , $3 , $4"
       property: fenced
       area: "geometry"
       notation: "mrow ($1 , $2 ; $3 , $4"
@@ -1775,7 +1775,7 @@ concepts:
     
     - concept: configuration
       arity: 4
-      en: configuration
+      en: "configuration $1 sub $2, $3 sub $4"
       property: mixfix
       area: "geometry"
       notation: "(msub $1 $2 msub $3 $4"
@@ -2098,7 +2098,7 @@ concepts:
     
     - concept: cross-ratio
       arity: 4
-      en: cross-ratio
+      en: "cross-ratio of $1, $2, $3, $4"
       property: fenced
       area: "geometry"
       notation: "mrow ( $1, $2 ; $3, $4"
@@ -5871,7 +5871,7 @@ concepts:
     
     - concept: lagrange-bracket
       arity: 4
-      en: lagrange-bracket
+      en: "lagrange bracket of $1, $2, canonical coordinates $3, $4"
       property: indexed fenced
       area: "classical mechanics"
       notation: "msub<br/>mrow [ $1, $2] /mrow<br/>mrow $3, $4 /mrow"
@@ -7529,8 +7529,8 @@ concepts:
        - "https://en.wikipedia.org/wiki/List_of_partition_topics"
     
     - concept: partition-frequency-representation
-      arity: 4
-      en: partition-frequency-representation
+      arity: "*"
+      en: "partition $1 sup $2, $2 sup $3, ..."
       property: mixfix
       area: "number theory"
       notation: "mrow ( msup $1 $2 /msup msup $3 $4 /msup ..."
@@ -9328,7 +9328,7 @@ concepts:
     
     - concept: square
       arity: 4
-      en: square
+      en: "square $1 $2 $3 $4"
       property: prefix
       area: "geometry"
       notation: "mrow ◻ $1 $2 $3 $4y"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1759,7 +1759,8 @@ concepts:
       en: commutator
       property: fenced
       area: "abstract algebra"
-      notation: "mrow [ $1, $2 ]"
+      comments:
+       - "<math><mo>[</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Commutator.html"
        - "https://en.wikipedia.org/wiki/Commutator"
@@ -1813,7 +1814,8 @@ concepts:
       en: complement of interval
       property: fenced
       area: "order theory"
-      notation: "mrow ] $1, $2 ["
+      comments:
+       - "<math><mo>]</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>[</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Interval_(mathematics)"
     
@@ -3014,9 +3016,10 @@ concepts:
       en: directional derivative of $1
       property: "function, mixfix"
       area: "differential calculus"
-      notation: "msub ∇ v"
-      notationb: "msub D v"
-      notationa: "mrow v ⋅ ∇ $1"
+      comments:
+       - "<math><msup><mi>∇</mi><mi>v</mi></msup><mi>f</mi></math>"
+       - "<math><msup><mi>D</mi><mi>v</mi></msup><mi>f</mi></math>"
+       - "<math><mrow><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectionalDerivative.html"
        - "https://en.wikipedia.org/wiki/Directional_derivative"
@@ -3075,7 +3078,8 @@ concepts:
       en: dirichlet kernel of $1
       property: function
       area: "mathematical analysis"
-      notation: "msub D n"
+      comments:
+       - "<math><msup><mi>D</mi><mi>n</mi></msup><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletKernel.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_kernel"
@@ -3121,12 +3125,26 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Discriminant"
     
     - concept: disjoint-union
-      arity: 1
+      arity: 2
       en: disjoint union of $1
       property: indexed
       area: "set theory"
-      notation: "msup ∪ *"
-      notationa: "mo ⊔"
+      comments:
+       - "<math><msub><mo>&#x2a06;</mo><mrow><mi>i</mi><mo>&#x2208;</mo><mi>A</mi></mrow></msub><msup><mi>A</mi><mi>i</mi></msup></math>"
+      urls: 
+       - "https://mathworld.wolfram.com/DisjointUnion.html"
+       - "https://en.wikipedia.org/wiki/Disjoint_union"
+       - "https://en.wikipedia.org/wiki/Tagged_union"
+       - "https://en.wikipedia.org/wiki/Disjoint_union_(topology)"
+       - "https://ncatlab.org/nlab/show/disjoint+union"
+
+    - concept: disjoint-union
+      arity: 2
+      en: disjoint union of $1
+      property: infix
+      area: "set theory"
+      comments:
+       - "<math><mi>A</mi><msup><mi></mi><mo>*</mo></msup><mi>B</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DisjointUnion.html"
        - "https://en.wikipedia.org/wiki/Disjoint_union"
@@ -3139,7 +3157,8 @@ concepts:
       en: distance
       property: fenced
       area: "geometry"
-      notation: "|$1 $2|"
+      comments:
+       - "<math><mo>|</mo><mi>X</mi><mo>&#x2009;</mo><mi>Y</mi><mo>|</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance"
     
@@ -3161,8 +3180,8 @@ concepts:
       property: "function, mixfix"
       area: "vector calculus"
       comments:
-       - "<math><mi>div</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mrow ∇ ⋅ $1"
+       - "<math><mi>div</mi><mi>f</mi></math>"
+       - "<math><mi>∇</mi><mo>⋅</mo><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3362,9 +3381,8 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
-      notationb: "msup $1 $1"
-      notationa: "msup $1 '"
+       - "<math><msup><mi>V</mi><mo>*</mo></msup></math>"
+       - "<math><msup><mi>V</mi><mo>&#x2032;</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
@@ -3377,9 +3395,10 @@ concepts:
       en: duodecimal of $1
       property: unit
       area: "arithmetic"
-      notation: "msub $1 z"
-      notationb: "msub $1 12"
-      notationa: "mi doz"
+      comments:
+       - "<math><msub><mi>n</mi><mi>z</mi></msub></math>"
+       - "<math><msub><mi>n</mi><mn>12</mn></msub></math>"
+       - "<math><msub><mi>n</mi><mi>doz</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Duodecimal.html"
        - "https://en.wikipedia.org/wiki/Duodecimal#Base_notation"
@@ -3573,7 +3592,8 @@ concepts:
       en: equivalence class of $1
       property: fenced
       area: "set theory"
-      notation: "mrow [ $1 ]"
+      comments:
+       - "<math><mo>[</mo><mi>X</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/EquivalenceClass.html"
        - "https://en.wikipedia.org/wiki/Equivalence_class"
@@ -3601,7 +3621,8 @@ concepts:
       en: equivariant cohomology $1 $2
       property: function
       area: "algebraic topology"
-      notation: "msubsup H $1 $2"
+      comments:
+       - "<math><msubsup><mi>H</mi><mi>G</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi>X</mi><mo>;</mo><mo>&#x039b;</mo><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Equivariant_cohomology"
        - "https://ncatlab.org/nlab/show/equivariant+cohomology"
@@ -3653,10 +3674,11 @@ concepts:
       en: essential infimum of $1
       property: function
       area: "measure theory"
-      notation: "mi ess inf"
+      comments:
+       - "<math><mi>ess inf</mi><mi>x</mi></math>"
       urls: 
-       - "https://mathworld.wolfram.com/EssentialSupremum.html"
-       - "https://en.wikipedia.org/wiki/Essential_supremum_and_essential_infimum"
+       - "https://mathworld.wolfram.com/essentialsupremum.html"
+       - "https://en.wikipedia.org/wiki/essential_supremum_and_essential_infimum"
        - "https://ncatlab.org/nlab/show/essential+supremum"
     
     - concept: essential-supremum
@@ -3664,7 +3686,8 @@ concepts:
       en: essential supremum of $1
       property: function
       area: "measure theory"
-      notation: "mi ess sup"
+      comments:
+       - "<math><mi>ess sup</mi><mi>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EssentialSupremum.html"
        - "https://en.wikipedia.org/wiki/Essential_supremum_and_essential_infimum"
@@ -3688,7 +3711,8 @@ concepts:
       en: etale cohomology of $1
       property: function
       area: "algebraic topology"
-      notation: "msubsup H et •"
+      comments:
+       - "<math><msubsup><mi>H</mi><mi>et</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/%C3%89tale_cohomology"
        - "https://ncatlab.org/nlab/show/etale+cohomology"
@@ -3868,7 +3892,8 @@ concepts:
       en: expectation value of $1
       property: fenced
       area: "quantum physics"
-      notation: "mrow ⟨ $1 ⟩"
+      comments:
+       - "<math><mo>⟨</mo><mi>X</mi><mo>⟩</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExpectationValue.html"
        - "https://en.wikipedia.org/wiki/Expectation_value_(quantum_mechanics)"
@@ -4195,10 +4220,11 @@ concepts:
       en: floor of $1
       property: fenced, function
       area: "number theory"
-      notation: "⌊ $1 ⌋"
-      notationc: "〚 $1 〛"
-      notationb: "[ $1 ]"
-      notationa: "floor ($1"
+      comments:
+       - "<math><mo>⌊</mo><mi>X</mi><mo>⌋</mo></math>"
+       - "<math><mo>&#x27e6;</mo><mi>X</mi><mo>&#x27e7;</mo></math>"
+       - "<math><mo>[</mo><mi>X</mi><mo>]</mo></math>"
+       - "<math><mi>floor</mi><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://youtu.be/RxNs4SwP6lk"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -4232,7 +4258,8 @@ concepts:
       en: fourier cosine transform of $1
       property: operator
       area: "functional analysis"
-      notation: "msub ℱ c"
+      comments:
+       - "<math><msub><mi>ℱ</mi><mi>c</mi></msub><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierCosineTransform.html"
        - "https://dlmf.nist.gov/1.14#E9"
@@ -4243,7 +4270,8 @@ concepts:
       en: fourier sine transform of $1
       property: operator
       area: "functional analysis"
-      notation: "msub ℱ s"
+      comments:
+       - "<math><msub><mi>ℱ</mi><mi>s</mi></msub><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierSineTransform.html"
        - "https://dlmf.nist.gov/1.14#E10"
@@ -4254,7 +4282,8 @@ concepts:
       en: fourier transform of $1
       property: mover
       area: "fourier analysis"
-      notation: "mover $1 ^"
+      comments:
+       - "<math><mover><mi>f</mi><mo>^</mo></mover></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierTransform.html"
        - "https://en.wikipedia.org/wiki/%E2%84%B1"
@@ -4313,8 +4342,8 @@ concepts:
       area: "arithmetic"
       comments:
        - "<math><mi>frac</mi><mrow><mi>X</mi></mrow></math>"
-      notationb: "mrow ⟦ $1 ⟧"
-      notationa: "mrow { $1 }"
+       - "<math><mo>&#x27e6;</mo><mi>x</mi><mo>&#x27e7;</mo></math>"
+       - "<math><mo>{</mo><mi>x</mi><mo>}</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/FractionalPart.html"
        - "https://en.wikipedia.org/wiki/Fractional_part"
@@ -4389,7 +4418,8 @@ concepts:
       en: free algebra $1 $2
       property: mixfix
       area: "ring theory"
-      notation: "mrow $1⟨$2⟩"
+      comments:
+       - "<math><mi>R</mi><mo>⟨</mo><mi>X</mi><mo>⟩</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeAlgebra.html"
        - "https://en.wikipedia.org/wiki/Free_algebra"
@@ -4468,7 +4498,8 @@ concepts:
       en: frolicher nijenhuis bracket
       property: fenced
       area: "differntial geometry"
-      notation: "mrow [ $1 , $2 ]"
+      comments:
+       - "<math><mo>[</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>]</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fr%C3%B6licher%E2%80%93Nijenhuis_bracket"
        - "https://encyclopediaofmath.org/wiki/Fr%C3%B6licher-Nijenhuis_bracket"
@@ -4490,8 +4521,9 @@ concepts:
       en: functor category
       property: msup, fenced
       area: "category theory"
-      notation: "msup $1 $2"
-      notationa: "mrow [$1, $2]"
+      comments:
+       - "<math><msup><mi>f</mi><mi>g</mi><msup></math>"
+       - "<math><mo>[</mo><mi>f</mi><mo>,</mo><mi>g</mi><mo>]</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -6911,8 +6943,9 @@ concepts:
       en: legendre symbol
       property: fenced, fenced stacked
       area: "number theory"
-      notation: "mrow ( $1 | $2 )"
-      notationa: "mrow ( mfrac $1 $2 )"
+      comments:
+       - "<math><mo>(</mo><mi>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></math>"
+       - "<math><mo>(</mo><mfrac><mi>a</mi><mi>p</mi></mfrac><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1293,7 +1293,7 @@ concepts:
       property: fenced, function
       area: "number theory"
       comments:
-       - "<math><mo>⌈</mo><mi>X</mi><mo>Y</mo></math>"
+       - "<math><mo>⌈</mo><mi>X</mi><mo>⌉</mo></math>"
        - "<math><mo>&#x27e7;</mo><mi>X</mi><mo>&#x27e6;</mo></math>"
        - "<math><mo>]</mo><mi>X</mi><mo>[</mo></math>"
        - "<math><mi>ceil</mi><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -940,7 +940,8 @@ concepts:
       en: bipolar set of $1
       property: msup
       area: "functional analysis"
-      notation: "msup $1 °°"
+      comments:
+       - "<math><msup><mi>X</mi><mo>°°</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -1648,7 +1649,7 @@ concepts:
       comments:
        - "<math><mi>cl</mi><mrow><mi>X</mi></mrow></math>"
        - "<math><mi>Cl</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "msup $1 −"
+       - "<math><msup><mi>X</mi><mo>−</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
        - "https://en.wikipedia.org/wiki/Congruence_closure"
@@ -1765,7 +1766,8 @@ concepts:
       en: commutator subgroup of $1
       property: msup, fenced
       area: "abstract algebra"
-      notation: "msup $1 '"
+      comments:
+       - "<math><msup><mi>X</mi><mo>'</mo></msup></math>"
       notationb: "msup $1 (1)"
       notationa: "mrow [ $1, $1 ]"
       urls: 
@@ -1838,7 +1840,8 @@ concepts:
       en: complex conjugate of $1
       property: msup
       area: "complex analysis"
-      notation: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       notationa: "mover $1 ¯"
       urls: 
        - "https://mathworld.wolfram.com/ComplexConjugate.html"
@@ -1864,8 +1867,9 @@ concepts:
       en: complexification of $1
       property: msup
       area: "complex manifolds"
-      notation: "msup $1 ℂ"
-      notationa: "msup $1 C"
+      comments:
+       - "<math><msup><mi>X</mi><mi>ℂ</mi></msup></math>"
+       - "<math><msup><mi>X</mi><mi>C</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complexification"
        - "https://ncatlab.org/nlab/show/complexification"
@@ -2021,8 +2025,9 @@ concepts:
       en: conjugate transpose of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 H"
-      notationa: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mi>H</mi></msup></math>"
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugateTranspose.html"
        - "https://en.wikipedia.org/wiki/Conjugate_transpose"
@@ -2150,7 +2155,8 @@ concepts:
       en: converse of $1
       property: msup
       area: "relational algebra"
-      notation: "msup $1 ˘"
+      comments:
+       - "<math><msup><mi>X</mi><mo>˘</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relation_algebra"
       alias:
@@ -2161,9 +2167,10 @@ concepts:
       en: converse graph of $1
       property: msup
       area: "graph theory"
-      notation: "msup $1 '"
-      notationb: "msup $1 T"
-      notationa: "msup $1 R"
+      comments:
+       - "<math><msup><mi>X</mi><mo>'</mo></msup></math>"
+       - "<math><msup><mi>X</mi><mi>T</mi></msup></math>"
+       - "<math><msup><mi>X</mi><mi>R</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Transpose_graph"
       alias:
@@ -3319,7 +3326,8 @@ concepts:
       en: dual basis of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualBasis.html"
        - "https://en.wikipedia.org/wiki/Dual_basis"
@@ -3334,7 +3342,8 @@ concepts:
       en: dual bundle of $1
       property: msup
       area: "vector bundles"
-      notation: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualBundle.html"
        - "https://en.wikipedia.org/wiki/Dual_bundle"
@@ -3347,7 +3356,8 @@ concepts:
       en: dual space of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       notationb: "msup $1 $1"
       notationa: "msup $1 '"
       urls: 
@@ -3911,7 +3921,7 @@ concepts:
       area: "topology"
       comments:
        - "<math><mi>ext</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "msup $1 e"
+       - "<math><msup><mi>X</mi><mi>e</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
        - "https://en.wikipedia.org/wiki/Exterior_(topology)"
@@ -4398,7 +4408,8 @@ concepts:
       en: free monoid of $1
       property: msup
       area: "abstract algebra"
-      notation: "msup $1 *"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Free_monoid"
        - "https://en.wikipedia.org/wiki/Monoid_factorisation"
@@ -4995,8 +5006,9 @@ concepts:
       en: group of units of $1
       property: msup, function
       area: "ring theory"
-      notation: "msup $1 *"
-      notationb: "msup $1 ×"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup><mi>X</mi><mo>×</mo></msup></math>"
       notationa: "mi U"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5688,7 +5700,7 @@ concepts:
       area: "set theory"
       notation: "$1 [ $2 ]"
       notationc: "msub $1 *"
-      notationb: "msup $1 →"
+       - "<math><msup><mi>X</mi><mo>→</mo></msup></math>"
       notationa: "$1 '' $2"
       urls: 
        - "https://mathworld.wolfram.com/Image.html"
@@ -5996,8 +6008,9 @@ concepts:
       en: interior of $1
       property: msup
       area: "topology"
-      notation: "msup $1 o"
-      notationa: "msup $1 ∘"
+      comments:
+       - "<math><msup><mi>X</mi><mo>o</mo></msup></math>"
+       - "<math><msup><mi>X</mi><mo>∘</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Interior.html"
        - "https://en.wikipedia.org/wiki/Interior_(topology)"
@@ -6099,7 +6112,8 @@ concepts:
       en: isogonal conjugate of $1
       property: msup
       area: "geometry"
-      notation: "msup $1 -1"
+      comments:
+       - "<math><msup><mi>X</mi><mn>-1</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/IsogonalConjugate.html"
        - "https://en.wikipedia.org/wiki/Isogonal_conjugate"
@@ -7859,7 +7873,8 @@ concepts:
       en: moore penrose inverse of $1
       property: msup
       area: "linear algebra"
-      notation: "msup $1 +"
+      comments:
+       - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse"
       alias:
@@ -7909,7 +7924,8 @@ concepts:
       en: multiplicative inverse of $1
       property: msup, mixfix
       area: "abstract algebra"
-      notation: "msup $1 -1"
+      comments:
+       - "<math><msup><mi>X</mi><mn>-1</mn></msup></math>"
       notationa: "mrow 1 / $1"
       urls: 
        - "https://mathworld.wolfram.com/Inverse.html"
@@ -8308,7 +8324,8 @@ concepts:
       en: opposite of $1
       property: msup
       area: "category theory,, group theory"
-      notation: "msup $1 op"
+      comments:
+       - "<math><msup><mi>X</mi><mi>op</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Opposite_category"
        - "https://ncatlab.org/nlab/show/opposite+category"
@@ -8356,7 +8373,8 @@ concepts:
       en: orthocomplement of $1
       property: msup
       area: "lattice theory"
-      notation: "msup $1 ⊥"
+      comments:
+       - "<math><msup><mi>X</mi><mo>⊥</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complemented_lattice"
     
@@ -8837,7 +8855,8 @@ concepts:
       en: polar set of $1
       property: msup
       area: "functional analysis"
-      notation: "msup $1 °"
+      comments:
+       - "<math><msup><mi>X</mi><mo>°</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -8920,7 +8939,8 @@ concepts:
       en: positive part of $1
       property: msup, msub
       area: "elementary mathematics"
-      notation: "msup $1 +"
+      comments:
+       - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
       notationa: "msub $1 +"
       urls: 
        - "https://mathworld.wolfram.com/PositiveElement.html"
@@ -9500,7 +9520,8 @@ concepts:
       en: real polar of $1
       property: msup
       area: "functional analysis"
-      notation: "msup $1 r"
+      comments:
+       - "<math><msup><mi>X</mi><mi>r</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -9521,8 +9542,9 @@ concepts:
       en: reciprocal polynomial of $1
       property: msup
       area: "algebra"
-      notation: "msup $1 *"
-      notationa: "msup $1 R"
+      comments:
+       - "<math><msup><mi>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup><mi>X</mi><mi>R</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ReciprocalPolynomial.html"
        - "https://en.wikipedia.org/wiki/Reciprocal_polynomial"
@@ -10847,7 +10869,8 @@ concepts:
       en: successor of $1
       property: "function, msup"
       area: "number theory"
-      notation: "msup $1 +"
+      comments:
+       - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
       notationb: "mi s"
       notationa: "mi S"
       urls: 
@@ -11390,7 +11413,8 @@ concepts:
       en: transitive closure of $1
       property: msup
       area: "set theory"
-      notation: "msup $1 +"
+      comments:
+       - "<math><msup><mi>X</mi><mo>+</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/TransitiveClosure.html"
        - "https://en.wikipedia.org/wiki/Transitive_closure"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1570,7 +1570,7 @@ concepts:
       arity: 1
       en: closure of $1
       property: "function<br/>msup"
-      area: "abstract algebra,<br/>topology"
+      area: "abstract algebra,, topology"
       notation: "mi cl<br/>mi Cl<br/>msup $1 −"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
@@ -1620,7 +1620,7 @@ concepts:
       arity: 1
       en: coherence of $1
       property: "indexed function"
-      area: "signal processing<br/>quantum physics"
+      area: "signal processing, quantum physics"
       notation: "mi C<br/>mi γ"
       urls: 
        - "https://en.wikipedia.org/wiki/Coherence_(signal_processing)"
@@ -1901,7 +1901,7 @@ concepts:
       arity: 2
       en: $1 congruence relation $2
       property: infix
-      area: "algebra<br/>geometry"
+      area: "algebra, geometry"
       notation: "mo ≡<br/>mo ≅"
       urls: 
        - "https://en.wikipedia.org/wiki/Congruence_relation"
@@ -2505,7 +2505,7 @@ concepts:
       arity: 1
       en: degree of $1
       property: prefix<br/>postfix
-      area: "physics<br/>geometry"
+      area: "physics, geometry"
       notation: "mo °"
       urls: 
        - "https://mathworld.wolfram.com/Degree.html"
@@ -2746,7 +2746,7 @@ concepts:
       arity: 1
       en: dimension of $1
       property: "function<br/>fenced"
-      area: "linear algebra<br/>graph theory"
+      area: "linear algebra, graph theory"
       notation: "mi dim<br/>mrow [ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
@@ -3225,7 +3225,7 @@ concepts:
       arity: 0
       en: eccentricity
       property: symbol
-      area: "analytic geometry<br/>graph theory"
+      area: "analytic geometry, graph theory"
       notation: "mi e<br/>mi ϵ"
       urls: 
        - "https://mathworld.wolfram.com/Eccentricity.html"
@@ -7894,7 +7894,7 @@ concepts:
       arity: 1
       en: opposite of $1
       property: msup
-      area: "category theory,<br/>group theory"
+      area: "category theory,, group theory"
       notation: "msup $1 op"
       urls: 
        - "https://en.wikipedia.org/wiki/Opposite_category"
@@ -7949,7 +7949,7 @@ concepts:
       arity: 2
       en: $1 orthogonal $2
       property: infix
-      area: "geometry,<br/>algebra"
+      area: "geometry,, algebra"
       comments:
        - "<math><mrow><mi>X</mi><mo>⊥</mo><mi>Y</mi></mrow></math>"
       urls: 
@@ -8670,7 +8670,8 @@ concepts:
       en: $1 proportional $2
       property: infix
       area: "arithmetic"
-      notation: "mo ∝<br/>mo ~"
+       - "<math><mrow><mi>X</mi><mo>∝</mo><mi>Y</mi></mrow></math>"
+       - "<math><mrow><mi>X</mi><mo>~</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Proportional.html"
        - "https://en.wikipedia.org/wiki/Proportionality_(mathematics)"
@@ -8973,7 +8974,7 @@ concepts:
       arity: 1
       en: rank of $1
       property: function
-      area: "graph theory<br/>linear algebra<br/>"
+      area: "graph theory, linear algebra, "
       notation: "mi r<br/>mi rank<br/>mi rk"
       urls: 
        - "https://mathworld.wolfram.com/Rank.html"
@@ -10368,7 +10369,7 @@ concepts:
       arity: 1
       en: supremum of $1
       property: "function<br/>largeop"
-      area: "order theory<br/>lattice theory"
+      area: "order theory, lattice theory"
       notation: "mi sup<br/>mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1568,7 +1568,6 @@ concepts:
       area: "special functions"
       comments:
        - "<math><msub><mi>Cl</mi><mn>2</mn></msub><mrow><mo>(</mo><mi>&#x03c6;</mi><mo>)</mo></mrow></math>"
-       notation: "msub Cl 2"
       urls: 
        - "https://en.wikipedia.org/wiki/Clausen_function"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -8920,7 +8920,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi>X</mi><mo>&lt;</mo><mi>Y</mi></mrow></math>"
+       - "<math><mrow><mi>X</mi><mo>&amp;lt;</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Subgroup"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9678,7 +9678,7 @@ concepts:
     
     - concept: stalk
       arity: 2
-      en: stalk
+      en: stalk of $1 at $2
       property: msub
       area: "sheaf theory"
       notation: "msub $1 $2"
@@ -9711,7 +9711,7 @@ concepts:
     
     - concept: stanley-reisner-ring
       arity: 2
-      en: stanley reisner ring
+      en: stanley reisner ring $1 $2
       property: mixfix
       area: "commutative algebra"
       notation: "mrow $1 [ $2 ]"
@@ -9766,7 +9766,7 @@ concepts:
     
     - concept: stiefel-manifold
       arity: 2
-      en: stiefel manifold
+      en: stiefel manifold $1 $2
       property: mixfix
       area: "differential geometry"
       notation: "mrow msub V $1 /msub ( $2"
@@ -10376,7 +10376,7 @@ concepts:
     
     - concept: total-derivative
       arity: 2
-      en: total derivative
+      en: total derivative $1 with respect to $2
       property: mixfix
       area: "differential calculus"
       notation: "mrow d msub $1 $2 /msub"
@@ -10528,7 +10528,7 @@ concepts:
     
     - concept: turan-graph
       arity: 2
-      en: turan graph
+      en: turan graph $1 $2
       property: "function<br/>indexed function"
       area: "graph theory"
       notation: "mi T<br/>mi D<br/>msub T $1<br/>msub T $1,$2"
@@ -10602,7 +10602,7 @@ concepts:
     
     - concept: ultrapower
       arity: 2
-      en: ultrapower
+      en: ultrapower $1 $2
       property: mixfix
       area: "abstract algebra"
       notation: "mrow ∏ $1 / $2"
@@ -10913,7 +10913,7 @@ concepts:
     
     - concept: wavelet-transform
       arity: 2
-      en: wavelet transform
+      en: wavelet transform $1 $2
       property: "embellished function"
       area: "functional analysis"
       notation: "mrow [ msub W $1 /msub $2 ]"
@@ -11008,7 +11008,7 @@ concepts:
     
     - concept: weighted-lehmer-mean
       arity: 2
-      en: weighted lehmer mean
+      en: weighted lehmer mean $1 $2
       property: "indexed function"
       area: "means"
       notation: "msub L mrow $1 , $2 /mrow"
@@ -11052,7 +11052,7 @@ concepts:
     
     - concept: whitehead-bracket
       arity: 2
-      en: whitehead bracket
+      en: whitehead bracket $1 $2
       property: fenced
       area: "lie algebra"
       notation: "mrow [ $1, $2 ]"
@@ -11074,7 +11074,7 @@ concepts:
     
     - concept: whittaker-function
       arity: 2
-      en: whittaker function
+      en: whittaker function $1 $2
       property: "indexed function"
       area: "special functions"
       notation: "msub M mrow $1, $2 /mrow<br/>msub W mrow $1, $2 /mrow"
@@ -11237,7 +11237,7 @@ concepts:
     
     - concept: wronskian
       arity: 2
-      en: wronskian
+      en: wronskian of $1, $2
       property: operator
       area: "special functions"
       notation: "mrow 𝒲 { $1, $2 }<br/>mi W"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -318,7 +318,8 @@ concepts:
       en: Free product with amalgamation of $1 and $3 with respect to $2
       property: indexed infix
       area: "group theory"
-      comment: "<math><mi>A</mi><msub><mo>⁎</mo><mi>C</mi></msub><mi>B</mi></math>"
+      comments:
+       - "<math><mi>A</mi><msub><mo>⁎</mo><mi>C</mi></msub><mi>B</mi></math>"
       urls: 
        - "https://math.stackexchange.com/questions/828828/amalgamated-product"
        - "https://en.wikipedia.org/wiki/Free_product"
@@ -3836,7 +3837,8 @@ concepts:
       en: $1 th forward difference of $3 over $2
       property: operator
       area: "numerical analysis"
-      comment: "<math><msubsup><mi>&Delta;</mi><mi>x</mi><mi>n</mi></msubsup><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+      comments:
+       - "<math><msubsup><mi>&Delta;</mi><mi>x</mi><mi>n</mi></msubsup><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ForwardDifference.html)"
        - "https://dlmf.nist.gov/18.1#EGx1"
@@ -9136,7 +9138,7 @@ concepts:
       en: scalar-triple product  of $1, $2 and $3
       property: mixfix<br/>fenced
       area: "vector algebra"
-      comment:
+      comments:
        - "<math><mi>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi>B</mi><mo>&middot;</mo><mi>C</mi><mo>)</mo></mrow></math>"
        - "<math><mo>[</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>,</mo><mi>C</mi><mo>]</mo></math>"
       urls: 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2138,7 +2138,8 @@ concepts:
       en: $1 converges
       property: postfix
       area: "computer science"
-      notation: "mo ↓"
+      comments:
+       - "<math><mi>x</mi><mo>↓</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
       alias:
@@ -2509,7 +2510,8 @@ concepts:
       en: dalembert operator of $1
       property: prefix
       area: "partial differential equations"
-      notation: "mo ☐"
+      comments:
+       - "<math><mo>☐</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/D%27Alembert_operator"
        - "https://www.encyclopediaofmath.org/index.php/D'Alembert_operator"
@@ -2553,7 +2555,8 @@ concepts:
       en: decrease of $1
       property: postfix
       area: "physics"
-      notation: "mo ↓"
+      comments:
+       - "<math><mi>x</mi><mo>↓</mo></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4705"
     
@@ -2624,7 +2627,8 @@ concepts:
       en: degree of $1
       property: prefix, postfix
       area: "physics, geometry"
-      notation: "mo °"
+      comments:
+       - "<math><mi>x</mi><mo>°</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Degree.html"
        - "https://en.wikipedia.org/wiki/Degree_(angle)"
@@ -2695,7 +2699,8 @@ concepts:
       en: dereference of $1
       property: prefix
       area: "programming languages"
-      notation: "mo !"
+      comments:
+       - "<math><mo>!</mo><mi>x</mi></math>"
       urls: 
        - "https://arxiv.org/pdf/1208.5915.pdf"
     
@@ -2758,7 +2763,7 @@ concepts:
       area: "geometry"
       comments:
        - "<math><mi>d</mi><mrow><mi>X</mi></mrow></math>"
-      notationc: "mo ⌀"
+       - "<math><mo>⌀</mo><mi>x</mi></math>"
       notationb: "mi DIA"
       notationa: "mi dia"
       urls: 
@@ -2811,7 +2816,7 @@ concepts:
       area: "calculus"
       comments:
        - "<math><mi>D</mi><mrow><mi>X</mi></mrow></math>"
-      notationb: "mo ∂"
+       - "<math><mo>∂</mo><mi>x</mi></math>"
       notationa: "mfrac d mrow d $1"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialOperator.html"
@@ -3131,7 +3136,8 @@ concepts:
       en: $1 diverges
       property: postfix
       area: "computer science"
-      notation: "mo ↑"
+      comments:
+       - "<math><mi>x</mi><mo>↑</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
       alias:
@@ -3876,7 +3882,8 @@ concepts:
       en: exponential factorial of $1
       property: postfix
       area: "number theory"
-      notation: "mo $"
+      comments:
+       - "<math><mi>x</mi><mo>$</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialFactorial.html"
        - "https://en.wikipedia.org/wiki/Exponential_factorial"
@@ -5394,7 +5401,8 @@ concepts:
       en: hodge star operator of $1
       property: prefix
       area: "differential geometry"
-      notation: "mo ⋆"
+      comments:
+       - "<math><mo>⋆</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hodge_dual"
        - "https://ncatlab.org/nlab/show/Hodge+star+operator"
@@ -5808,7 +5816,8 @@ concepts:
       en: increase of $1
       property: postfix
       area: "physics"
-      notation: "mo ↑"
+      comments:
+       - "<math><mi>x</mi><mo>↑</mo></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4606"
     
@@ -5864,7 +5873,7 @@ concepts:
       area: "order theory"
       comments:
        - "<math><mi>inf</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mo ⋀"
+       - "<math><mo>⋀</mo><mi>X</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
        - "https://en.wikipedia.org/wiki/Infimum_and_supremum"
@@ -5906,7 +5915,8 @@ concepts:
       en: infinitely many concurrently active copies of $1
       property: prefix
       area: "formal languages"
-      notation: "mo !"
+      comments:
+       - "<math><mo>!</mo><mi>x</mi></math>"
       urls: 
        - "https://arxiv.org/pdf/0903.3513.pdf"
     
@@ -7184,7 +7194,8 @@ concepts:
       en: lower closure poset of $1
       property: prefix
       area: "order theory"
-      notation: "mo ↓"
+      comments:
+       - "<math><mo>↓</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     
@@ -8118,7 +8129,8 @@ concepts:
       en: non oriented angle of $1
       property: prefix
       area: "geometry"
-      notation: "mo ∠"
+      comments:
+       - "<math><mo>∠</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Orientation_(vector_space)"
        - "https://en.wikipedia.org/wiki/Euclidean_space#Angle"
@@ -8750,8 +8762,8 @@ concepts:
        - le-nombre-radiant
     
     - concept: playing-card-suit
-      arity: 1
-      en: playing card suit of $1
+      arity: 0
+      en: playing card suit
       property: unit
       area: "game theory"
       notation: "mo ♣"
@@ -8920,7 +8932,8 @@ concepts:
       en: positivitiy predicate of $1
       property: prefix
       area: "predicative mathematics"
-      notation: "mo ◊"
+      comments:
+       - "<math><mo>◊</mo><mi>x</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/positive+element"
     
@@ -9024,7 +9037,8 @@ concepts:
       en: primorial of $1
       property: postfix
       area: "number theory"
-      notation: "mo #"
+      comments:
+       - "<math><mi>x</mi><mo>#</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Primorial.html"
        - "https://en.wikipedia.org/wiki/Primorial"
@@ -9262,7 +9276,8 @@ concepts:
       en: quadrilateral of $1
       property: prefix
       area: "geometry"
-      notation: "mo ◻"
+      comments:
+       - "<math><mo>◻</mo><mi>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Quadrangle.html"
        - "https://en.wikipedia.org/wiki/Quadrilateral"
@@ -9794,10 +9809,11 @@ concepts:
       en: right angle of $1
       property: prefix
       area: "geometry"
-      notation: "mo ∟"
-      notationc: "mo ⊾"
-      notationb: "mo ⦜"
-      notationa: "mo ⦝"
+      comments:
+       - "<math><mo>∟</mo><mi>x</mi></math>"
+       - "<math><mo>⊾</mo><mi>x</mi></math>"
+       - "<math><mo>⦜</mo><mi>x</mi></math>"
+       - "<math><mo>⦝</mo><mi>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RightAngle.html"
        - "https://en.wikipedia.org/wiki/Right_angle"
@@ -10119,7 +10135,8 @@ concepts:
       en: set of invertible maps of $1
       property: prefix
       area: "commutative algebra"
-      notation: "mo !"
+      comments:
+       - "<math><mo>!</mo><mi>x</mi></math>"
       urls: 
        - "https://arxiv.org/abs/2009.015866"
     
@@ -10783,7 +10800,8 @@ concepts:
       en: subfactorial of $1
       property: prefix
       area: "combinatorics"
-      notation: "mo !"
+      comments:
+       - "<math><mo>!</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derangement"
       alias:
@@ -10897,7 +10915,7 @@ concepts:
       area: "order theory, lattice theory"
       comments:
        - "<math><mi>sup</mi><mrow><mi>X</mi></mrow></math>"
-      notationa: "mo ⋁"
+       - "<math><mo>⋁</mo><mi>X</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
       alias:
@@ -11187,7 +11205,8 @@ concepts:
       en: therefore sign of $1
       property: prefix
       area: "logic"
-      notation: "mo ∴"
+      comments:
+       - "<math><mo>∴</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Therefore_sign"
        - "https://en.wikipedia.org/wiki/.%C2%B7."
@@ -11733,7 +11752,8 @@ concepts:
       en: upper closure poset of $1
       property: prefix
       area: "order theory"
-      notation: "mo ↑"
+      comments:
+       - "<math><mo>↑</mo><mi>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1321,7 +1321,8 @@ concepts:
       en: champernowne constant
       property: constant
       area: "number theory"
-      notation: "mi C"
+      comments:
+       - "<math><mi>C</mi></math>"
       notationa: "msub C 10"
       urls: 
        - "https://mathworld.wolfram.com/ChampernowneConstant.html"
@@ -2797,7 +2798,7 @@ concepts:
       area: "special functions"
       notation: "msub ψ 0"
       notationb: "msup ψ (0)"
-      notationa: "mi Ϝ"
+             - "<math><mi>Ϝ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DigammaFunction.html"
        - "https://en.wikipedia.org/wiki/Digamma_function"
@@ -3344,8 +3345,9 @@ concepts:
       en: eccentricity
       property: symbol
       area: "analytic geometry, graph theory"
-      notation: "mi e"
-      notationa: "mi ϵ"
+      comments:
+       - "<math><mi>e</mi></math>"
+             - "<math><mi>ϵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Eccentricity.html"
        - "https://en.wikipedia.org/wiki/Eccentricity_(mathematics)"
@@ -3694,8 +3696,9 @@ concepts:
       en: euler constant
       property: symbol
       area: "analysis"
-      notation: "mi γ"
-      notationa: "mi 𝛾"
+      comments:
+       - "<math><mi>γ</mi></math>"
+             - "<math><mi>𝛾</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3710,9 +3713,10 @@ concepts:
       en: euler number
       property: symbol
       area: "physics"
-      notation: "mi Eu"
-      notationb: "mi e"
-      notationa: "mi 𝑒"
+      comments:
+       - "<math><mi>Eu</mi></math>"
+             - "<math><mi>e</mi></math>"
+             - "<math><mi>𝑒</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerNumber.html"
        - "https://en.wikipedia.org/wiki/Euler_number"
@@ -4815,8 +4819,9 @@ concepts:
       en: golden ratio
       property: constant
       area: "geometry"
-      notation: "mi φ"
-      notationa: "mi ϕ"
+      comments:
+       - "<math><mi>φ</mi></math>"
+             - "<math><mi>ϕ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GoldenRatio.html"
        - "https://en.wikipedia.org/wiki/Golden_ratio"
@@ -5547,9 +5552,10 @@ concepts:
       en: identity element
       property: symbol
       area: "group theory"
-      notation: "mi e"
-      notationc: "mi I"
-      notationb: "mi E"
+      comments:
+       - "<math><mi>e</mi></math>"
+       - "<math><mi>I</mi></math>"
+       - "<math><mi>E</mi></math>"
       notationa: "mn 1"
       urls: 
        - "https://mathworld.wolfram.com/IdentityElement.html"
@@ -6333,7 +6339,8 @@ concepts:
       en: khinchin constant
       property: constant
       area: "continued fractions"
-      notation: "mi K"
+      comments:
+       - "<math><mi>K</mi></math>"
       notationa: "msub K 0"
       urls: 
        - "https://mathworld.wolfram.com/KhinchinsConstant.html"
@@ -6375,7 +6382,8 @@ concepts:
       en: klein four group
       property: symbol
       area: "group theory"
-      notation: "mi V"
+      comments:
+       - "<math><mi>V</mi></math>"
       notationa: "msub K 4"
       urls: 
        - "https://mathworld.wolfram.com/KleinFour-Group.html"
@@ -6622,9 +6630,10 @@ concepts:
       en: landau constant
       property: constant
       area: "complex analysis"
-      notation: "mi A"
-      notationb: "mi B"
-      notationa: "mi L"
+      comments:
+       - "<math><mi>A</mi></math>"
+       - "<math><mi>B</mi></math>"
+       - "<math><mi>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LandauConstant.html"
        - "https://en.wikipedia.org/wiki/Landau%27s_constants"
@@ -8112,9 +8121,10 @@ concepts:
       en: octonions
       property: symbol
       area: "compositional algebra"
-      notation: "mi 𝕆"
+      comments:
+       - "<math><mi>𝕆</mi></math>"
       notationb: "miO"
-      notationa: "mi O"
+       - "<math><mi>O</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octonion.html"
        - "https://en.wikipedia.org/wiki/Octonion"
@@ -8577,7 +8587,8 @@ concepts:
       en: phi coefficient
       property: symbol
       area: "statistics"
-      notation: "mi φ"
+      comments:
+       - "<math><mi>φ</mi></math>"
       notationa: "msub r φ"
       urls: 
        - "https://en.wikipedia.org/wiki/Phi_coefficient"
@@ -8602,8 +8613,9 @@ concepts:
       en: planck constant
       property: constant
       area: "physics"
-      notation: "mi h"
-      notationa: "mi ℎ"
+      comments:
+       - "<math><mi>h</mi></math>"
+       - "<math><mi>ℎ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Planck_constant"
        - "https://ncatlab.org/nlab/show/Planck's+constant"
@@ -8614,8 +8626,9 @@ concepts:
       en: plastic constant
       property: constant
       area: "geometry"
-      notation: "mi P"
-      notationa: "mi p"
+      comments:
+       - "<math><mi>P</mi></math>"
+       - "<math><mi>p</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PlasticConstant.html"
        - "https://en.wikipedia.org/wiki/Plastic_number"
@@ -8841,8 +8854,9 @@ concepts:
       en: present value
       property: symbol
       area: "economics"
-      notation: "mi PV"
-      notationa: "mi v"
+      comments:
+       - "<math><mi>PV</mi></math>"
+       - "<math><mi>v</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PresentValue.html"
        - "https://en.wikipedia.org/wiki/Present_value"
@@ -8852,8 +8866,9 @@ concepts:
       en: prime constant
       property: symbol
       area: "number theory"
-      notation: "mi P"
-      notationa: "mi ρ"
+      comments:
+       - "<math><mi>P</mi></math>"
+       - "<math><mi>ρ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeConstant.html"
        - "https://en.wikipedia.org/wiki/Prime_constant"
@@ -8961,7 +8976,8 @@ concepts:
       en: projective space
       property: symbol
       area: "projective geometry"
-      notation: "mi ℙ"
+      comments:
+       - "<math><mi>ℙ</mi></math>"
       notationa: "mi ℝ⁢ ℙ"
       urls: 
        - "https://mathworld.wolfram.com/ProjectiveSpace.html"
@@ -9541,9 +9557,10 @@ concepts:
       en: ricci scalar
       property: symbol
       area: "riemannian geometry"
-      notation: "mi S"
-      notationb: "mi R"
-      notationa: "mi Sc"
+      comments:
+       - "<math><mi>S</mi></math>"
+       - "<math><mi>R</mi></math>"
+       - "<math><mi>Sc</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciScalar.html"
        - "https://en.wikipedia.org/wiki/Scalar_curvature"
@@ -9716,16 +9733,17 @@ concepts:
       en: roman numeral
       property: symbol
       area: "number theory"
-      notationj: "mi i"
-      notationi: "mi ii"
-      notationh: "mi iii"
-      notationg: "mi iv"
-      notationf: "mi v"
-      notatione: "mi vi"
-      notationd: "mi vii"
-      notationc: "mi viii"
-      notationb: "mi ix"
-      notationa: "mi x"
+      comments:
+       - "<math><mi mathvariant="normal">i</mi></math>"
+       - "<math><mi>ii</mi></math>"
+       - "<math><mi>iii</mi></math>"
+       - "<math><mi>iv</mi></math>"
+       - "<math><mi>v</mi></math>"
+       - "<math><mi>vi</mi></math>"
+       - "<math><mi>vii</mi></math>"
+       - "<math><mi>viii</mi></math>"
+       - "<math><mi>ix</mi></math>"
+       - "<math><mi>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RomanNumerals.html"
        - "https://en.wikipedia.org/wiki/Roman_numerals"
@@ -9812,9 +9830,10 @@ concepts:
       en: sample space
       property: symbol
       area: "probability theory"
-      notation: "mi S"
-      notationb: "mi Ω"
-      notationa: "mi U"
+      comments:
+       - "<math><mi>S</mi></math>"
+       - "<math><mi>Ω</mi></math>"
+       - "<math><mi>U</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SampleSpace.html"
        - "https://en.wikipedia.org/wiki/Sample_space"
@@ -11486,7 +11505,8 @@ concepts:
       en: universal gas constant
       property: constant
       area: "physics"
-      notation: "mi R"
+      comments:
+       - "<math><mi>R</mi></math>"
       notationa: "mover R -"
       urls: 
        - "https://en.wikipedia.org/wiki/Gas_constant"
@@ -11591,7 +11611,8 @@ concepts:
       en: upper half plane
       property: symbol
       area: "complex analysis"
-      notation: "mi ℍ"
+      comments:
+       - "<math><mi>ℍ</mi></math>"
       notationa: "msup ℍ +"
       urls: 
        - "https://mathworld.wolfram.com/UpperHalf-Plane.html"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -5700,7 +5700,7 @@ concepts:
       area: "set theory"
       notation: "$1 [ $2 ]"
       notationc: "msub $1 *"
-       - "<math><msup><mi>X</mi><mo>→</mo></msup></math>"
+      notationb: "<math><msup><mi>X</mi><mo>→</mo></msup></math>"
       notationa: "$1 '' $2"
       urls: 
        - "https://mathworld.wolfram.com/Image.html"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10,7 +10,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-        - "<math><mi>Ab</mi></math>"
+       - "<math><mi>Ab</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AbelianCategory.html"
        - "https://en.wikipedia.org/wiki/Abelian_category"
@@ -34,7 +34,7 @@ concepts:
       property: prefix
       area: "number theory"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Abundance.html"
     
@@ -54,7 +54,7 @@ concepts:
       property: function
       area: "computability theory"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ackermann_function"
        - "https://www.encyclopediaofmath.org/index.php/Ackermann_function"
@@ -88,7 +88,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-        - "<math><mi>μ</mi></math>"
+       - "<math><mi>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -100,7 +100,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-        - "<math><mi>J</mi></math>"
+       - "<math><mi>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -112,7 +112,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-        - "<math><mi>Φ</mi></math>"
+       - "<math><mi>Φ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -149,7 +149,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>Ad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdjointRepresentation.html"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -161,7 +161,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>adj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>adj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjugate_matrix"
     
@@ -171,7 +171,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineGroup.html"
        - "https://en.wikipedia.org/wiki/Affine_group"
@@ -183,7 +183,7 @@ concepts:
       property: function
       area: "affine geometry"
       comments:
-        - "<math><mrow><mi>aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineHull.html"
        - "https://en.wikipedia.org/wiki/Affine_hull"
@@ -195,7 +195,7 @@ concepts:
       property: symbol
       area: "universal algebra?"
       comments:
-        - "<math><mi>𝔸</mi></math>"
+       - "<math><mi>𝔸</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/affine+line"
     
@@ -232,7 +232,7 @@ concepts:
       property: symbol
       area: "set theory"
       comments:
-        - "<math><mi>ℵ</mi></math>"
+       - "<math><mi>ℵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Aleph.html"
        - "https://ncatlab.org/nlab/show/aleph"
@@ -244,7 +244,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>𝔸</mi></math>"
+       - "<math><mi>𝔸</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Algebraics.html"
     
@@ -274,7 +274,7 @@ concepts:
       property: function
       area: "functions"
       comments:
-        - "<math><mrow><mi>af</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>af</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Alternating_factorial"
     
@@ -359,7 +359,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngerFunction.html"
        - "https://en.wikipedia.org/wiki/Anger_function"
@@ -372,7 +372,7 @@ concepts:
       property: function
       area: "hyperbolic geometry"
       comments:
-        - "<math><mrow><mi>Π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngleofParallelism.html"
        - "https://en.wikipedia.org/wiki/Angle_of_parallelism"
@@ -383,7 +383,7 @@ concepts:
       property: symbol
       area: "classical mechanics"
       comments:
-        - "<math><mi>L</mi></math>"
+       - "<math><mi>L</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Angular_momentum"
        - "https://en.wikipedia.org/wiki/Introduction_to_angular_momentum"
@@ -395,7 +395,7 @@ concepts:
       property: symbol
       area: "classical mechanics"
       comments:
-        - "<math><mi>ω</mi></math>"
+       - "<math><mi>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngularVelocity.html"
        - "https://en.wikipedia.org/wiki/Angular_velocity"
@@ -419,7 +419,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-        - "<math><mrow><mi>Ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Annihilator.html"
        - "https://en.wikipedia.org/wiki/Annihilator_(ring_theory)"
@@ -431,7 +431,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Annulus_(mathematics)"
        - "https://ncatlab.org/nlab/show/annulus"
@@ -505,7 +505,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-        - "<math><mi>A</mi></math>"
+       - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Area.html"
        - "https://en.wikipedia.org/wiki/Area"
@@ -517,7 +517,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>Arf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Arf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ArfInvariant.html"
        - "https://en.wikipedia.org/wiki/Arf_invariant"
@@ -529,7 +529,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>Arg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Arg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Argument_(complex_analysis)"
     
@@ -575,7 +575,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Aut</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Aut</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Automorphism"
@@ -586,7 +586,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>∇</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>∇</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BackwardDifference.html"
        - "https://en.wikipedia.org/wiki/Finite_difference"
@@ -917,7 +917,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlaschkeProduct.html"
        - "https://en.wikipedia.org/wiki/Blaschke_product"
@@ -929,7 +929,7 @@ concepts:
       property: symbol
       area: "complex analysis"
       comments:
-        - "<math><mi>B</mi></math>"
+       - "<math><mi>B</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlochConstant.html"
        - "https://www.encyclopediaofmath.org/index.php/Bloch_constant"
@@ -940,7 +940,7 @@ concepts:
       property: symbol
       area: "abstract algebra"
       comments:
-        - "<math><mi>𝔹</mi></math>"
+       - "<math><mi>𝔹</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Boolean_domain"
        - "https://ncatlab.org/nlab/show/boolean+domain"
@@ -951,7 +951,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-        - "<math><mi>⊥</mi></math>"
+       - "<math><mi>⊥</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/bottom"
        - "https://en.wikipedia.org/wiki/Bottom_type"
@@ -965,7 +965,7 @@ concepts:
       property: symbol
       area: "order theory"
       comments:
-        - "<math><mi>⊥</mi></math>"
+       - "<math><mi>⊥</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Greatest_element_and_least_element"
       alias:
@@ -992,7 +992,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>BV</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>BV</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BoundedVariation.html"
        - "https://en.wikipedia.org/wiki/Bounded_variation"
@@ -1014,7 +1014,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Br</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Br</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrauerGroup.html"
        - "https://en.wikipedia.org/wiki/Brauer_group"
@@ -1027,7 +1027,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><msub><mi>B</mi><mn>4</mn></msub></math>"
+       - "<math><msub><mi>B</mi><mn>4</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrunsConstant.html"
        - "https://en.wikipedia.org/wiki/Brun%27s_theorem"
@@ -1038,7 +1038,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Burnside_group"
     
@@ -1048,7 +1048,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>C</mi></math>"
+       - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CahensConstant.html"
        - "https://en.wikipedia.org/wiki/Cahen%27s_constant"
@@ -1100,7 +1100,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
        - "https://en.wikipedia.org/wiki/Carmichael_function"
@@ -1124,7 +1124,7 @@ concepts:
       property: symbol
       area: "lie algebra"
       comments:
-        - "<math><mi>Ω</mi></math>"
+       - "<math><mi>Ω</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Casimir_element"
     
@@ -1134,7 +1134,7 @@ concepts:
       property: symbol
       area: "combinatorics"
       comments:
-        - "<math><mi>G</mi></math>"
+       - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CatalansConstant.html"
        - "https://en.wikipedia.org/wiki/Catalan%27s_constant"
@@ -1157,7 +1157,7 @@ concepts:
       property: symbol
       area: "universal algebra"
       comments:
-        - "<math><mi>AlgCat</mi></math>"
+       - "<math><mi>AlgCat</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/algebraic+lattice"
     
@@ -1209,7 +1209,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>Ca</mi></math>"
+       - "<math><mi>Ca</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)#Cavitation_number"
     
@@ -1240,7 +1240,7 @@ concepts:
       property: function
       area: "algebra"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(group_theory)"
        - "https://en.wikipedia.org/wiki/Center_(algebra)"
@@ -1285,7 +1285,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Character.html"
        - "https://en.wikipedia.org/wiki/Character_(mathematics)"
@@ -1300,7 +1300,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-        - "<math><mrow><mi>char</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>char</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Characteristic.html"
        - "https://en.wikipedia.org/wiki/Characteristic_(algebra)"
@@ -1378,7 +1378,7 @@ concepts:
       property: function
       area: "Riemannian geometry"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant"
     
@@ -1388,7 +1388,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant_(graph_theory)"
       alias:
@@ -1423,7 +1423,7 @@ concepts:
       property: function
       area: "geometry"
       comments:
-        - "<math><mrow><mi>crd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>crd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chord_(geometry)"
     
@@ -1501,7 +1501,7 @@ concepts:
       property: function
       area: "universal algebra"
       comments:
-        - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clifford_algebra"
     
@@ -1511,7 +1511,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-        - "<math><mi>C</mi></math>"
+       - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Clique.html"
        - "https://en.wikipedia.org/wiki/Clique_(graph_theory)"
@@ -1523,7 +1523,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clique_number"
     
@@ -1577,7 +1577,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>codim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>codim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Codimension.html"
        - "https://en.wikipedia.org/wiki/Codimension"
@@ -1590,7 +1590,7 @@ concepts:
       property: function
       area: "order theory"
       comments:
-        - "<math><mrow><mi>cf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>cf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cofinality"
        - "https://ncatlab.org/nlab/show/cofinality"
@@ -1601,7 +1601,7 @@ concepts:
       property: symbol
       area: "order theory"
       comments:
-        - "<math><mi>F</mi></math>"
+       - "<math><mi>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CofiniteFilter.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_filter"
@@ -1624,7 +1624,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>coim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>coim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coimage"
        - "https://ncatlab.org/nlab/show/coimage"
@@ -1635,7 +1635,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>coker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>coker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cokernel.html"
        - "https://en.wikipedia.org/wiki/Cokernel"
@@ -1818,7 +1818,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Condition_number"
        - "https://dlmf.nist.gov/3.2#SS5.p1"
@@ -1851,7 +1851,7 @@ concepts:
       property: function
       area: "algebraic number theory"
       comments:
-        - "<math><mrow><mi>𝔣⁢</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>𝔣⁢</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Conductor_(class_field_theory)"
     
@@ -1912,7 +1912,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugacyClass.html"
        - "https://en.wikipedia.org/wiki/Conjugacy_class"
@@ -1945,7 +1945,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Connectivity.html"
        - "https://en.wikipedia.org/wiki/Connectivity_(graph_theory)"
@@ -1957,7 +1957,7 @@ concepts:
       property: constant
       area: "calculus"
       comments:
-        - "<math><mi>C</mi></math>"
+       - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConstantofIntegration.html"
        - "https://en.wikipedia.org/wiki/Constant_of_integration"
@@ -2010,7 +2010,7 @@ concepts:
       property: constant
       area: "set theory"
       comments:
-        - "<math><mi>𝔠</mi></math>"
+       - "<math><mi>𝔠</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Continuum.html"
        - "https://en.wikipedia.org/wiki/List_of_continuity-related_topics"
@@ -2026,7 +2026,7 @@ concepts:
       property: constant
       area: "logic"
       comments:
-        - "<math><mo>⊥</mo></math>"
+       - "<math><mo>⊥</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2125,7 +2125,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>corr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>corr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Correlation_and_dependence"
     
@@ -2135,7 +2135,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-        - "<math><mi>η</mi></math>"
+       - "<math><mi>η</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CorrelationRatio.html"
        - "https://en.wikipedia.org/wiki/Correlation_ratio"
@@ -2147,7 +2147,7 @@ concepts:
       property: operator
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>Ci</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ci</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -2160,7 +2160,7 @@ concepts:
       property: symbol
       area: "gauge theory"
       comments:
-        - "<math><mi>g</mi></math>"
+       - "<math><mi>g</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coupling_constant"
       alias:
@@ -2173,7 +2173,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>cov</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>cov</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Covariance.html"
        - "https://en.wikipedia.org/wiki/Covariance_operator"
@@ -2248,7 +2248,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Cr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Cr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Crossing_number_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Crossing_number_(knot_theory)"
@@ -2329,7 +2329,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Curvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"
@@ -2354,7 +2354,7 @@ concepts:
       property: symbol
       area: "genetics"
       comments:
-        - "<math><mi>cyc</mi></math>"
+       - "<math><mi>cyc</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cycle_(gene)"
     
@@ -2401,7 +2401,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DavenportConstant.html"
        - "https://en.wikipedia.org/wiki/Davenport_constant"
@@ -2446,7 +2446,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DedekindEtaFunction.html"
        - "https://en.wikipedia.org/wiki/Dedekind_eta_function"
@@ -2458,7 +2458,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dedekind_zeta_function"
     
@@ -2503,7 +2503,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
       alias:
@@ -2516,7 +2516,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-        - "<math><mi>ν</mi></math>"
+       - "<math><mi>ν</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DegreeofFreedom.html"
        - "https://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)#Notation"
@@ -2527,7 +2527,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_continuous_mapping"
       alias:
@@ -2539,7 +2539,7 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_polynomial"
       alias:
@@ -2578,7 +2578,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derived_category"
        - "https://ncatlab.org/nlab/show/derived+category"
@@ -2590,7 +2590,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-        - "<math><mi>Δ</mi></math>"
+       - "<math><mi>Δ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_functor"
        - "https://ncatlab.org/nlab/show/diagonal+functor"
@@ -2601,7 +2601,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_intersection"
     
@@ -2611,7 +2611,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>diag</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>diag</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_matrix"
     
@@ -2630,7 +2630,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DickmanFunction.html"
        - "https://en.wikipedia.org/wiki/Dickman_function"
@@ -2655,7 +2655,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialEntropy.html"
        - "https://en.wikipedia.org/wiki/Differential_entropy"
@@ -2751,7 +2751,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracDeltaFunction.html"
        - "https://en.wikipedia.org/wiki/Dirac_delta_function"
@@ -2777,7 +2777,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirac_measure"
     
@@ -2787,7 +2787,7 @@ concepts:
       property: function
       area: "differential operators"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracOperator.html"
        - "https://en.wikipedia.org/wiki/Dirac_operator"
@@ -2850,7 +2850,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletCharacter.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_character"
@@ -2873,7 +2873,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-        - "<math><mi>Dir</mi></math>"
+       - "<math><mi>Dir</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletDistribution.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_distribution"
@@ -2885,7 +2885,7 @@ concepts:
       property: function
       area: "analytic number theory"
       comments:
-        - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletEtaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%97(x)"
@@ -2908,7 +2908,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletL-Function.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_L-function"
@@ -2921,7 +2921,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>ν</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ν</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Discrete_valuation"
        - "https://ncatlab.org/nlab/show/discrete+valuation"
@@ -3017,7 +3017,7 @@ concepts:
       property: indexed
       area: "number theory"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DivisorFunction.html"
        - "https://en.wikipedia.org/wiki/D(n)"
@@ -3032,7 +3032,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_a_function"
     
@@ -3042,7 +3042,7 @@ concepts:
       property: symbol
       area: "formal semantics"
       comments:
-        - "<math><mi>𝔻</mi></math>"
+       - "<math><mi>𝔻</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_discourse"
       alias:
@@ -3054,7 +3054,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DominationNumber.html"
        - "https://en.wikipedia.org/wiki/Dominating_set"
@@ -3124,7 +3124,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-        - "<math><mrow><mi>𝒵</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>𝒵</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(category_theory)"
       alias:
@@ -3190,7 +3190,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/E-Function.html"
        - "https://en.wikipedia.org/wiki/E-function"
@@ -3214,7 +3214,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EdgeCoverNumber.html"
        - "https://en.wikipedia.org/wiki/Edge_covering_number"
@@ -3225,7 +3225,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-        - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Effective_domain"
     
@@ -3235,7 +3235,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Antenna_efficiency"
        - "https://en.wikipedia.org/wiki/Efficiency_(statistics)"
@@ -3247,7 +3247,7 @@ concepts:
       property: symbol
       area: "general relativity"
       comments:
-        - "<math><mi>G</mi></math>"
+       - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EinsteinTensor.html"
        - "https://en.wikipedia.org/wiki/Einstein_tensor"
@@ -3272,7 +3272,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-        - "<math><mi>e</mi></math>"
+       - "<math><mi>e</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/End_(category_theory)"
        - "https://ncatlab.org/nlab/show/end"
@@ -3283,7 +3283,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>End</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>End</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Endomorphism.html"
        - "https://en.wikipedia.org/wiki/Endomorphism"
@@ -3296,7 +3296,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>E</mi></math>"
+       - "<math><mi>E</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/energy"
     
@@ -3316,7 +3316,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Entropy"
        - "https://en.wikipedia.org/wiki/Entropy_(arrow_of_time)"
@@ -3330,7 +3330,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>epi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>epi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epigraph_(mathematics)"
     
@@ -3340,7 +3340,7 @@ concepts:
       property: symbol
       area: "ordinal numbers"
       comments:
-        - "<math><mi>ε</mi></math>"
+       - "<math><mi>ε</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epsilon_numbers_(mathematics)"
     
@@ -3350,7 +3350,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>Eq</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Eq</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Equalizer.html"
        - "https://en.wikipedia.org/wiki/Equaliser_(mathematics)"
@@ -3403,7 +3403,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>E</mi></math>"
+       - "<math><mi>E</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Erdos-BorweinConstant.html"
        - "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Borwein_constant"
@@ -3460,7 +3460,7 @@ concepts:
       property: symbol
       area: "symbols"
       comments:
-        - "<math><mi>℮</mi></math>"
+       - "<math><mi>℮</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Estimation"
       alias:
@@ -3516,7 +3516,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerCharacteristic.html"
        - "https://en.wikipedia.org/wiki/Euler_characteristic"
@@ -3529,7 +3529,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_class"
        - "https://ncatlab.org/nlab/show/Euler+class"
@@ -3597,7 +3597,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-        - "<math><mi>γ</mi></math>"
+       - "<math><mi>γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3609,7 +3609,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerianNumber.html"
        - "https://en.wikipedia.org/wiki/Eulerian_number"
@@ -3672,7 +3672,7 @@ concepts:
       property: 
       area: 
       comments:
-        - "<math><mrow><mi>Ei</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ei</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialIntegral.html"
        - "https://en.wikipedia.org/wiki/Exponential_integral"
@@ -3698,7 +3698,7 @@ concepts:
       property: operator
       area: "differential forms"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorDerivative.html"
        - "https://en.wikipedia.org/wiki/Exterior_derivative"
@@ -3709,7 +3709,7 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-        - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Exterior_algebra"
     
@@ -3768,7 +3768,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Julia_set"
     
@@ -3778,7 +3778,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>F</mi></math>"
+       - "<math><mi>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FareySequence.html"
        - "https://en.wikipedia.org/wiki/Farey_sequence"
@@ -3798,7 +3798,7 @@ concepts:
       property: symbol
       area: "chaos theory"
       comments:
-        - "<math><mi>δ</mi></math>"
+       - "<math><mi>δ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FeigenbaumConstant.html"
        - "https://en.wikipedia.org/wiki/Feigenbaum_constants"
@@ -3919,7 +3919,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FisherInformation.html"
        - "https://en.wikipedia.org/wiki/Fisher_information"
@@ -3932,7 +3932,7 @@ concepts:
       property: symbol
       area: "celestial mechanics"
       comments:
-        - "<math><mi>f</mi></math>"
+       - "<math><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Flattening.html"
        - "https://en.wikipedia.org/wiki/Flattening"
@@ -3957,7 +3957,7 @@ concepts:
       property: function
       area: "quantum mechanics"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fock_space"
        - "https://ncatlab.org/nlab/show/Fock+space"
@@ -4073,7 +4073,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>Fr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Fr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FranelNumber.html"
     
@@ -4094,7 +4094,7 @@ concepts:
       property: operator
       area: "banach spaces"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrechetDerivative.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_derivative"
@@ -4119,7 +4119,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-        - "<math><mrow><mi>det</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>det</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fredholm_determinant"
        - "https://ncatlab.org/nlab/show/Fredholm+determinant"
@@ -4236,7 +4236,7 @@ concepts:
       property: symbol
       area: "computer vision"
       comments:
-        - "<math><mi>F</mi></math>"
+       - "<math><mi>F</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fundamental_matrix_(computer_vision)"
     
@@ -4246,7 +4246,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/G-Function.html"
        - "https://en.wikipedia.org/wiki/Meijer_G-function"
@@ -4259,7 +4259,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gabor_transform"
        - "https://en.wikipedia.org/wiki/Gabor%E2%80%93Wigner_transform"
@@ -4271,7 +4271,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>φ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>φ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gain_graph"
        - "https://en.wikipedia.org/wiki/Gain_group"
@@ -4283,7 +4283,7 @@ concepts:
       property: function
       area: "physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GalileanTransformation.html"
        - "https://en.wikipedia.org/wiki/Galilean_transformation"
@@ -4308,7 +4308,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mi>Gal</mi></math>"
+       - "<math><mi>Gal</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -4321,7 +4321,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-        - "<math><mi>Γ</mi></math>"
+       - "<math><mi>Γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaDistribution.html"
        - "https://en.wikipedia.org/wiki/Gamma_distribution"
@@ -4332,7 +4332,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%93(x)"
@@ -4362,7 +4362,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gauss_(unit)"
     
@@ -4372,7 +4372,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-        - "<math><mi>𝒩</mi></math>"
+       - "<math><mi>𝒩</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Normal_distribution"
       alias:
@@ -4386,7 +4386,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianCurvature.html"
        - "https://en.wikipedia.org/wiki/Gaussian_curvature"
@@ -4451,7 +4451,7 @@ concepts:
       property: symbol
       area: "particle physics"
       comments:
-        - "<math><mi>λ</mi></math>"
+       - "<math><mi>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Gell-MannMatrix.html"
        - "https://en.wikipedia.org/wiki/Gell-Mann_matrices"
@@ -4532,7 +4532,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Diameter_(graph_theory)"
@@ -4567,7 +4567,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>GM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>GM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Geometric_mean"
@@ -4599,7 +4599,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-        - "<math><mi>A</mi></math>"
+       - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GlaisherConstant.html"
        - "https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant"
@@ -4667,7 +4667,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-        - "<math><mi>G</mi></math>"
+       - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramMatrix.html"
        - "https://en.wikipedia.org/wiki/Gramian_matrix"
@@ -4682,7 +4682,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Gr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Gr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Grassmannian.html"
        - "https://en.wikipedia.org/wiki/Grassmannian"
@@ -4694,7 +4694,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GreensFunction.html"
        - "https://en.wikipedia.org/wiki/Green%27s_function_(many-body_theory)"
@@ -4708,7 +4708,7 @@ concepts:
       property: symbol
       area: "computer algebra"
       comments:
-        - "<math><mi>G</mi></math>"
+       - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GroebnerBasis.html"
        - "https://en.wikipedia.org/wiki/Gr%C3%B6bner_basis"
@@ -4752,7 +4752,7 @@ concepts:
       property: function
       area: "trigonometry"
       comments:
-        - "<math><mrow><mi>gd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>gd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GudermannianFunction.html"
        - "https://en.wikipedia.org/wiki/Gudermannian_function"
@@ -4805,7 +4805,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HankelFunction.html"
        - "https://dlmf.nist.gov/10.1"
@@ -4840,7 +4840,7 @@ concepts:
       property: operator
       area: "real analysis"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function"
       alias:
@@ -4852,7 +4852,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HarmonicMean.html"
        - "https://en.wikipedia.org/wiki/Harmonic_mean"
@@ -4897,7 +4897,7 @@ concepts:
       property: function
       area: "engineering"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HazardFunction.html"
       alias:
@@ -4909,7 +4909,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/1.16#E13)[https://en.wikipedia.org/wiki/Heaviside_step_function"
        - "https://en.wikipedia.org/wiki/Heaviside_step_function"
@@ -4924,7 +4924,7 @@ concepts:
       property: function
       area: "topological graph theory"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heawood_number"
     
@@ -4962,7 +4962,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>ht</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ht</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Krull_dimension#height"
       alias:
@@ -4976,7 +4976,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeisenbergGroup.html"
        - "https://en.wikipedia.org/wiki/Heisenberg_group"
@@ -5024,7 +5024,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeronianMean.html"
        - "https://en.wikipedia.org/wiki/Heronian_mean"
@@ -5035,7 +5035,7 @@ concepts:
       property: operator
       area: "differential operators"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hessian.html"
        - "https://en.wikipedia.org/wiki/Hessian_matrix"
@@ -5061,7 +5061,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.5#p1"
@@ -5124,7 +5124,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Holomorph_(mathematics)"
        - "https://ncatlab.org/nlab/show/holomorph"
@@ -5135,7 +5135,7 @@ concepts:
       property: "indexed symbol"
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Holonomy.html"
        - "https://en.wikipedia.org/wiki/Holonomy"
@@ -5147,7 +5147,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>HP</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>HP</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomePrime.html"
        - "https://en.wikipedia.org/wiki/Home_prime"
@@ -5178,7 +5178,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>Ho</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ho</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/homotopy+category"
     
@@ -5188,7 +5188,7 @@ concepts:
       property: unit
       area: "imperial unit"
       comments:
-        - "<math><mrow><mi>hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
       alias:
@@ -5211,7 +5211,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HurwitzZetaFunction.html"
        - "https://en.wikipedia.org/wiki/Hurwitz_zeta_function"
@@ -5224,7 +5224,7 @@ concepts:
       property: unit
       area: "customary units"
       comments:
-        - "<math><mrow><mi>hvat</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>hvat</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kubni_hvat"
        - "https://en.wikipedia.org/wiki/%C4%8Cetvorni_hvat"
@@ -5248,7 +5248,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Chi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Chi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicCosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E16"
@@ -5269,7 +5269,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Shi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Shi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicSineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E15"
@@ -5363,7 +5363,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-        - "<math><mi>I</mi></math>"
+       - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/IdentityMatrix.html"
        - "https://en.wikipedia.org/wiki/Identity_matrix"
@@ -5390,7 +5390,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-        - "<math><mi>I</mi></math>"
+       - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Incenter.html"
        - "https://en.wikipedia.org/wiki/Incircle_and_excircles_of_a_triangle"
@@ -5424,7 +5424,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>ι</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ι</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Inclusion_map"
       alias:
@@ -5449,7 +5449,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteBetaFunction.html"
        - "https://dlmf.nist.gov/8.17"
@@ -5462,7 +5462,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5474,7 +5474,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-        - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5486,7 +5486,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteGammaFunction.html"
        - "https://en.wikipedia.org/wiki/Incomplete_gamma_function"
@@ -5541,7 +5541,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>ind</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ind</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_Lie_algebra"
     
@@ -5611,7 +5611,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>Inn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Inn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerAutomorphism.html"
        - "https://en.wikipedia.org/wiki/Inner_automorphism"
@@ -5810,7 +5810,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>j</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>j</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/j-Invariant.html"
        - "https://ncatlab.org/nlab/show/j-invariant"
@@ -5821,7 +5821,7 @@ concepts:
       property: function
       area: "operator theory"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiMatrix.html"
        - "https://en.wikipedia.org/wiki/Jacobi_operator"
@@ -5861,7 +5861,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>ϑ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ϑ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiThetaFunctions.html"
        - "https://en.wikipedia.org/wiki/Jacobi_theta_functions_(notational_variations)"
@@ -5911,7 +5911,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>J</mi></math>"
+       - "<math><mi>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsthalNumber.html"
        - "https://en.wikipedia.org/wiki/Jacobsthal_number"
@@ -5955,7 +5955,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JonesPolynomial.html"
        - "https://en.wikipedia.org/wiki/Jones_polynomial"
@@ -5979,7 +5979,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
        - "https://en.wikipedia.org/wiki/Jordan_measure"
@@ -6000,7 +6000,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JuliaSet.html"
        - "https://en.wikipedia.org/wiki/Julia_set"
@@ -6051,7 +6051,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>ker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Kernel.html"
        - "https://en.wikipedia.org/wiki/Kernel_(algebra)"
@@ -6082,7 +6082,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KillingForm.html"
        - "https://en.wikipedia.org/wiki/Killing_form"
@@ -6143,7 +6143,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KnoedelNumbers.html"
        - "https://en.wikipedia.org/wiki/Kn%C3%B6del_number"
@@ -6154,7 +6154,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kodaira_dimension"
        - "https://www.encyclopediaofmath.org/index.php/Kodaira_dimension"
@@ -6165,7 +6165,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KolmogorovComplexity.html"
        - "https://en.wikipedia.org/wiki/Kolmogorov_complexity"
@@ -6185,7 +6185,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KontsevichIntegral.html"
        - "https://en.wikipedia.org/wiki/Kontsevich_invariant"
@@ -6257,7 +6257,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>dim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>dim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrullDimension.html"
        - "https://en.wikipedia.org/wiki/Krull_dimension"
@@ -6305,7 +6305,7 @@ concepts:
       property: symbol
       area: "mathematical optimization"
       comments:
-        - "<math><mi>λ</mi></math>"
+       - "<math><mi>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeMultiplier.html"
        - "https://en.wikipedia.org/wiki/Lagrange_multiplier"
@@ -6333,7 +6333,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaguerrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Laguerre_polynomials"
@@ -6369,7 +6369,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>ℒ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ℒ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplaceTransform.html"
        - "https://en.wikipedia.org/wiki/Laplace_transform"
@@ -6382,7 +6382,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-        - "<math><mi>L</mi></math>"
+       - "<math><mi>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplacianMatrix.html"
        - "https://en.wikipedia.org/wiki/Laplacian_matrix"
@@ -6417,7 +6417,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>lpf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>lpf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeastPrimeFactor.html"
     
@@ -6571,7 +6571,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Prokhorov_metric"
        - "https://encyclopediaofmath.org/wiki/L%C3%A9vy-Prokhorov_metric"
@@ -6637,7 +6637,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LineGraph.html"
        - "https://en.wikipedia.org/wiki/Line_graph"
@@ -6664,7 +6664,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LinearSpan.html"
        - "https://en.wikipedia.org/wiki/Linear_span"
@@ -6678,7 +6678,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Lk</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Lk</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Link.html"
     
@@ -6697,7 +6697,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-        - "<math><mi>L</mi></math>"
+       - "<math><mi>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvillesConstant.html"
       alias:
@@ -6709,7 +6709,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvilleFunction.html"
        - "https://en.wikipedia.org/wiki/Liouville_function"
@@ -6734,7 +6734,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>li</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>li</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LogarithmicIntegral.html"
        - "https://dlmf.nist.gov/6.2#i"
@@ -6757,7 +6757,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>logit</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>logit</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Logit"
     
@@ -6790,7 +6790,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>Ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LoopSpace.html"
        - "https://en.wikipedia.org/wiki/Loop_space"
@@ -6865,7 +6865,7 @@ concepts:
       property: function
       area: "stability theory"
       comments:
-        - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LyapunovFunction.html"
        - "https://en.wikipedia.org/wiki/Lyapunov_function"
@@ -6889,7 +6889,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MahlerMeasure.html"
        - "https://en.wikipedia.org/wiki/Mahler_measure"
@@ -6901,7 +6901,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MangoldtFunction.html"
        - "https://dlmf.nist.gov/27.2#E14"
@@ -6915,7 +6915,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>MCG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>MCG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_class_group"
        - "https://ncatlab.org/nlab/show/mapping+class+group"
@@ -7039,7 +7039,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MaximumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7051,7 +7051,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MeanCurvature.html"
        - "https://en.wikipedia.org/wiki/Mean_curvature"
@@ -7063,7 +7063,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>MSE</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>MSE</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mean_squared_error"
     
@@ -7073,7 +7073,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meixner-PollaczekPolynomial.html"
        - "https://en.wikipedia.org/wiki/Meixner%E2%80%93Pollaczek_polynomials"
@@ -7085,7 +7085,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>ℳ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ℳ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MellinTransform.html"
        - "https://en.wikipedia.org/wiki/Mellin_transform"
@@ -7098,7 +7098,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Meridian_arc"
        - "https://en.wikipedia.org/wiki/Meridian_arc"
@@ -7109,7 +7109,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-        - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meridian.html"
     
@@ -7140,7 +7140,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MertensFunction.html"
        - "https://en.wikipedia.org/wiki/Mertens_function"
@@ -7171,7 +7171,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-        - "<math><mi>A</mi></math>"
+       - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsConstant.html"
        - "https://en.wikipedia.org/wiki/Mills%27_constant"
@@ -7194,7 +7194,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinimumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7241,7 +7241,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MoebiusFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%9C(n)"
@@ -7319,7 +7319,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModularDiscriminant.html"
        - "https://en.wikipedia.org/wiki/Modular_form#The_modular_discriminant"
@@ -7344,7 +7344,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Moebius_function"
        - "https://en.wikipedia.org/wiki/M%C3%B6bius_function"
@@ -7366,7 +7366,7 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-        - "<math><mi>M</mi></math>"
+       - "<math><mi>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Moment.html"
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -7380,7 +7380,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>I</mi></math>"
+       - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MomentofInertia.html"
        - "https://en.wikipedia.org/wiki/Moment_of_inertia"
@@ -7396,8 +7396,8 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-        - "<math><mi>p</mi></math>"
-        - "<math><mi>mip</mi></math>"
+       - "<math><mi>p</mi></math>"
+       - "<math><mi>mip</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Momentum"
        - "https://ncatlab.org/nlab/show/momentum"
@@ -7411,7 +7411,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-        - "<math><mi>M</mi></math>"
+       - "<math><mi>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MonsterGroup.html"
        - "https://en.wikipedia.org/wiki/Monster_group"
@@ -7557,7 +7557,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MutualInformation.html"
        - "https://en.wikipedia.org/wiki/Mutual_information"
@@ -7594,7 +7594,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-        - "<math><mi>NB</mi></math>"
+       - "<math><mi>NB</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/NegativeBinomialDistribution.html"
        - "https://en.wikipedia.org/wiki/Negative_binomial_distribution"
@@ -7606,7 +7606,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-        - "<math><mrow><mi>NHG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>NHG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution"
        - "https://www.encyclopediaofmath.org/index.php/Negative_hypergeometric_distribution"
@@ -7628,7 +7628,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_system"
       alias:
@@ -7641,7 +7641,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>NS</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>NS</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Neron-SeveriGroup.html"
        - "https://encyclopediaofmath.org/wiki/N%C3%A9ron-Severi_group"
@@ -7663,7 +7663,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>N</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>N</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nerve.html"
        - "https://en.wikipedia.org/wiki/Nerve_(category_theory)"
@@ -7675,7 +7675,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>q</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>q</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
        - "https://en.wikipedia.org/wiki/Nome_(mathematics)"
@@ -7765,7 +7765,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-        - "<math><mrow><mi>Obj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Obj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Object.html"
        - "https://en.wikipedia.org/wiki/Lattice-based_access_control"
@@ -7804,7 +7804,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-        - "<math><mi>OR</mi></math>"
+       - "<math><mi>OR</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Odds_ratio"
     
@@ -7814,7 +7814,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Onsager%E2%80%93Machlup_function"
        - "https://www.encyclopediaofmath.org/index.php/Onsager-Machlup_function"
@@ -7926,7 +7926,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>O</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>O</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OrthogonalGroup.html"
        - "https://en.wikipedia.org/wiki/Orthogonal_group"
@@ -7940,7 +7940,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>Out</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Out</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterAutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Outer_automorphism_group"
@@ -7999,7 +7999,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PadovanSequence.html"
        - "https://en.wikipedia.org/wiki/Padovan_sequence"
@@ -8075,7 +8075,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>p</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>p</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partition_(number_theory)"
     
@@ -8147,7 +8147,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>perm</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>perm</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Permanent.html"
        - "https://en.wikipedia.org/wiki/Permanent"
@@ -8182,7 +8182,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PerrinNumber.html"
        - "https://en.wikipedia.org/wiki/Perrin_number"
@@ -8206,7 +8206,7 @@ concepts:
       property: symbol
       area: "chemistry"
       comments:
-        - "<math><mi>pH</mi></math>"
+       - "<math><mi>pH</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/PH"
       alias:
@@ -8242,7 +8242,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Pic</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Pic</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PicardGroup.html"
        - "https://en.wikipedia.org/wiki/Picard_group"
@@ -8338,7 +8338,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-        - "<math><mi>Pois</mi></math>"
+       - "<math><mi>Pois</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PoissonDistribution.html"
        - "https://en.wikipedia.org/wiki/Poisson_distribution"
@@ -8373,7 +8373,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ψ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ψ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PolygammaFunction.html"
        - "https://en.wikipedia.org/wiki/Polygamma_function"
@@ -8505,7 +8505,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeCountingFunction.html"
     
@@ -8515,7 +8515,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeDifferenceFunction.html"
     
@@ -8545,7 +8545,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>Log</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Log</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complex_logarithm#Principal_value"
     
@@ -8555,7 +8555,7 @@ concepts:
       property: "indexed function"
       area: "probability theory"
       comments:
-        - "<math><mrow><mi>plim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>plim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Convergence_of_random_variables#Convergence_in_probability"
       alias:
@@ -8588,7 +8588,7 @@ concepts:
       property: function
       area: "projective geometry"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Projective_line"
        - "https://ncatlab.org/nlab/show/projective+line"
@@ -8636,7 +8636,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-        - "<math><mi>τ</mi></math>"
+       - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Prouhet%E2%80%93Thue%E2%80%93Morse_constant"
     
@@ -8802,7 +8802,7 @@ concepts:
       property: symbol
       area: "complexity theory"
       comments:
-        - "<math><mi>R</mi></math>"
+       - "<math><mi>R</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/R.html"
        - "https://en.wikipedia.org/wiki/R_(complexity)"
@@ -8836,7 +8836,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>rad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>rad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Radical.html"
        - "https://en.wikipedia.org/wiki/Radical_of_a_Lie_algebra"
@@ -8877,7 +8877,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansTauFunction.html"
        - "https://en.wikipedia.org/wiki/Ramanujan_tau_function"
@@ -8889,7 +8889,7 @@ concepts:
       property: constant
       area: "special functions"
       comments:
-        - "<math><mi>μ</mi></math>"
+       - "<math><mi>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ramanujan-SoldnerConstant.html"
        - "https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant"
@@ -8913,7 +8913,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamseyNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Ramsey_number"
@@ -8982,7 +8982,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-        - "<math><mrow><mi>recc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>recc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Recession_cone"
     
@@ -9004,7 +9004,7 @@ concepts:
       property: function
       area: "euclidean geometry"
       comments:
-        - "<math><mrow><mi>r</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>r</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rectification.html"
        - "https://en.wikipedia.org/wiki/Rectification_(geometry)"
@@ -9016,7 +9016,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>Σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
     
@@ -9026,7 +9026,7 @@ concepts:
       property: "indexed function"
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relative_homology"
        - "https://ncatlab.org/nlab/show/relative+homology"
@@ -9038,7 +9038,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Repunit.html"
        - "https://en.wikipedia.org/wiki/Repunit"
@@ -9072,7 +9072,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Resolvent_set"
        - "https://www.encyclopediaofmath.org/index.php/Resolvent_set"
@@ -9142,7 +9142,7 @@ concepts:
       property: symbol
       area: "fluid dynamics"
       comments:
-        - "<math><mi>Re</mi></math>"
+       - "<math><mi>Re</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Reynolds_number"
     
@@ -9164,7 +9164,7 @@ concepts:
       property: "indexed symbol"
       area: "riemannian geometry"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciTensor.html"
        - "https://www.encyclopediaofmath.org/index.php/Ricci_tensor"
@@ -9205,7 +9205,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>θ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>θ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannThetaFunction.html"
        - "https://dlmf.nist.gov/21.2#i"
@@ -9217,7 +9217,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannZetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%96(x)"
@@ -9233,7 +9233,7 @@ concepts:
       property: "indexed function"
       area: "riemannian geometry"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-ChristoffelTensor.html"
        - "https://en.wikipedia.org/wiki/Riemann_curvature_tensor"
@@ -9343,7 +9343,7 @@ concepts:
       property: symbol
       area: "complex numbers"
       comments:
-        - "<math><mi>ω</mi></math>"
+       - "<math><mi>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RootofUnity.html"
        - "https://en.wikipedia.org/wiki/Root_of_unity"
@@ -9376,7 +9376,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>Ru</mi></math>"
+       - "<math><mi>Ru</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)"
     
@@ -9468,7 +9468,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchurMultiplier.html"
        - "https://en.wikipedia.org/wiki/Schur_multiplier"
@@ -9526,7 +9526,7 @@ concepts:
       property: symbol
       area: "abstract algebra"
       comments:
-        - "<math><mi>𝕊</mi></math>"
+       - "<math><mi>𝕊</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sedenion"
        - "https://ncatlab.org/nlab/show/sedenion"
@@ -9568,7 +9568,7 @@ concepts:
       property: symbol
       area: "information theory"
       comments:
-        - "<math><mi>H</mi></math>"
+       - "<math><mi>H</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShannonEntropy.html"
        - "https://en.wikipedia.org/wiki/Entropy_(information_theory)"
@@ -9597,7 +9597,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-        - "<math><mrow><mi>Sh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Sh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Shimura_variety"
        - "https://ncatlab.org/nlab/show/Shimura+variety"
@@ -9632,7 +9632,7 @@ concepts:
       property: symbol
       area: "combinatorics"
       comments:
-        - "<math><mi>A</mi></math>"
+       - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SidonSequence.html"
        - "https://en.wikipedia.org/wiki/Sidon_sequence"
@@ -9645,7 +9645,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>sgn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>sgn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sign_function"
       alias:
@@ -9657,7 +9657,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>sign</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>sign</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/signature+of+a+permutation"
       alias:
@@ -9714,7 +9714,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Si</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Si</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -9727,7 +9727,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-        - "<math><mi>α</mi></math>"
+       - "<math><mi>α</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Size_(statistics)"
     
@@ -9747,7 +9747,7 @@ concepts:
       property: prefix
       area: "complexity"
       comments:
-        - "<math><mrow><mi>o</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>o</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
        - "https://mathworld.wolfram.com/o.html"
@@ -9758,7 +9758,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SmithNumber.html"
        - "https://en.wikipedia.org/wiki/Smith_number"
@@ -9781,7 +9781,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>soc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>soc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Socle.html"
        - "https://en.wikipedia.org/wiki/Socle_(mathematics)"
@@ -9794,7 +9794,7 @@ concepts:
       property: symbol
       area: "complexity theory"
       comments:
-        - "<math><mi>Õ</mi></math>"
+       - "<math><mi>Õ</mi></math>"
       urls: 
       alias:
        - Extensions_to_the_Bachmann–Landau_notations
@@ -9805,7 +9805,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-        - "<math><mi>Ω</mi></math>"
+       - "<math><mi>Ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SolidAngle.html"
        - "https://en.wikipedia.org/wiki/Solid_angle"
@@ -9817,7 +9817,7 @@ concepts:
       property: unit
       area: "imperial units"
       comments:
-        - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(unit)"
     
@@ -9839,7 +9839,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-        - "<math><mrow><mi>SO</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>SO</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialOrthogonalGroup.html"
        - "https://ncatlab.org/nlab/show/special+orthogonal+group"
@@ -9850,7 +9850,7 @@ concepts:
       property: function
       area: "lie groups"
       comments:
-        - "<math><mrow><mi>SU</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>SU</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialUnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Special_unitary_group"
@@ -9862,7 +9862,7 @@ concepts:
       property: function
       area: "spectral theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpectralRadius.html"
        - "https://en.wikipedia.org/wiki/Spectral_radius"
@@ -9874,7 +9874,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_(functional_analysis)"
     
@@ -9884,7 +9884,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-        - "<math><mi>Sp</mi></math>"
+       - "<math><mi>Sp</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Spectrum"
     
@@ -9912,7 +9912,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Spec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Spec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_ring"
     
@@ -9944,7 +9944,7 @@ concepts:
       property: symbol
       area: "quantum mechanics"
       comments:
-        - "<math><mi>S</mi></math>"
+       - "<math><mi>S</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -9954,7 +9954,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-        - "<math><mi>Spin</mi></math>"
+       - "<math><mi>Spin</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpinGroup.html"
        - "https://en.wikipedia.org/wiki/Spin_group"
@@ -9967,7 +9967,7 @@ concepts:
       property: symbol
       area: "quantum mechanics"
       comments:
-        - "<math><mi>s</mi></math>"
+       - "<math><mi>s</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -10008,7 +10008,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-        - "<math><mi>σ</mi></math>"
+       - "<math><mi>σ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/StandardDeviation.html"
        - "https://en.wikipedia.org/wiki/Standard_deviation"
@@ -10068,7 +10068,7 @@ concepts:
       property: function
       area: "formal languages"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_height"
     
@@ -10078,7 +10078,7 @@ concepts:
       property: function
       area: "k-theory"
       comments:
-        - "<math><mrow><mi>St</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>St</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Group_of_Lie_type"
        - "https://en.wikipedia.org/wiki/Steinberg_group_(K-theory)"
@@ -10101,7 +10101,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stiefel-WhitneyClass.html"
        - "https://en.wikipedia.org/wiki/Stiefel%E2%80%93Whitney_class"
@@ -10126,7 +10126,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind"
@@ -10138,7 +10138,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind"
@@ -10150,7 +10150,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Strength_of_a_graph"
       alias:
@@ -10184,7 +10184,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StruveFunction.html"
        - "https://en.wikipedia.org/wiki/Struve_function"
@@ -10198,7 +10198,7 @@ concepts:
       property: function
       area: "field theory"
       comments:
-        - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stufe_(algebra)"
     
@@ -10293,7 +10293,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>supp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>supp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Support.html"
        - "https://en.wikipedia.org/wiki/Support_(mathematics)"
@@ -10361,7 +10361,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Suspension.html"
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
@@ -10416,7 +10416,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Sp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Sp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymplecticGroup.html"
        - "https://en.wikipedia.org/wiki/Symplectic_group"
@@ -10441,7 +10441,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentBundle.html"
        - "https://en.wikipedia.org/wiki/Tangent_bundle"
@@ -10487,7 +10487,7 @@ concepts:
       property: symbol
       area: "particle physics"
       comments:
-        - "<math><mi>τ</mi></math>"
+       - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tau_(particle)"
     
@@ -10497,7 +10497,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaxicabNumber.html"
        - "https://en.wikipedia.org/wiki/Taxicab_number"
@@ -10508,7 +10508,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaylorPolynomial.html"
        - "https://en.wikipedia.org/wiki/Taylor%27s_theorem"
@@ -10520,7 +10520,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TeichmuellerSpace.html"
        - "https://en.wikipedia.org/wiki/Teichm%C3%BCller_space"
@@ -10532,7 +10532,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>T</mi></math>"
+       - "<math><mi>T</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Temperature.html"
        - "https://en.wikipedia.org/wiki/Temperature"
@@ -10603,7 +10603,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Thom_space"
        - "https://ncatlab.org/nlab/show/Thom+space"
@@ -10615,7 +10615,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-        - "<math><mi>Th</mi></math>"
+       - "<math><mi>Th</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ThompsonGroup.html"
        - "https://en.wikipedia.org/wiki/Thompson_groups"
@@ -10647,7 +10647,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TopologicalEntropy.html"
        - "https://en.wikipedia.org/wiki/Topological_entropy"
@@ -10670,7 +10670,7 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-        - "<math><mi>τ</mi></math>"
+       - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torque"
     
@@ -10680,7 +10680,7 @@ concepts:
       property: symbol
       area: "differential geometry"
       comments:
-        - "<math><mi>τ</mi></math>"
+       - "<math><mi>τ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Torsion.html"
        - "https://en.wikipedia.org/wiki/Torsion_of_a_curve"
@@ -10693,7 +10693,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_(algebra)"
     
@@ -10713,7 +10713,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_tensor"
     
@@ -10747,7 +10747,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>tr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>tr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trace_(linear_algebra)"
     
@@ -10815,7 +10815,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>TM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>TM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trimean"
       alias:
@@ -10859,7 +10859,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-        - "<math><mrow><mi>trunc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>trunc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Truncation.html"
        - "https://en.wikipedia.org/wiki/Truncation"
@@ -11032,7 +11032,7 @@ concepts:
       property: constant
       area: "geometry"
       comments:
-        - "<math><mi>P</mi></math>"
+       - "<math><mi>P</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/UniversalParabolicConstant.html"
        - "https://en.wikipedia.org/wiki/Universal_parabolic_constant"
@@ -11137,7 +11137,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>Var</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Var</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Variance"
       alias:
@@ -11168,7 +11168,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>proj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>proj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vector_projection"
       alias:
@@ -11181,7 +11181,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>vec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>vec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vectorization_(mathematics)"
        - "https://en.wikipedia.org/wiki/Vectorization_(parallel_computing)"
@@ -11234,7 +11234,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-        - "<math><mi>V</mi></math>"
+       - "<math><mi>V</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Volume.html"
        - "https://en.wikipedia.org/wiki/Volume_(compression)"
@@ -11260,7 +11260,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WalshFunction.html"
        - "https://en.wikipedia.org/wiki/Walsh_function"
@@ -11319,7 +11319,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>℘</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>℘</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassEllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Weierstrass%27s_elliptic_functions"
@@ -11333,7 +11333,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassSigmaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11346,7 +11346,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassZetaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11359,7 +11359,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>wt</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>wt</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Weight_(strings)"
        - "https://ncatlab.org/nlab/show/weight"
@@ -11404,7 +11404,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Wh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Wh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadGroup.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11427,7 +11427,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadTorsion.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11495,7 +11495,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonQuotient.html"
        - "https://en.wikipedia.org/wiki/Wilson_quotient"
@@ -11519,7 +11519,7 @@ concepts:
       property: function
       area: "fourier analysis"
       comments:
-        - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WindowFunction.html"
        - "https://en.wikipedia.org/wiki/Window_function"
@@ -11573,7 +11573,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ϕ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ϕ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WrightFunction.html"
     
@@ -11583,7 +11583,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Wright_Omega_function"
       alias:
@@ -11595,7 +11595,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>Wr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Wr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Writhe.html"
        - "https://en.wikipedia.org/wiki/Writhe"
@@ -11620,7 +11620,7 @@ concepts:
       property: function
       area: "gauge theory"
       comments:
-        - "<math><mrow><mi>ℒ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ℒ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Yang-MillsFunctional.html"
        - "https://www.encyclopediaofmath.org/index.php/Yang-Mills_functional"
@@ -11632,7 +11632,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-        - "<math><mi>Z</mi></math>"
+       - "<math><mi>Z</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(mathematics)"
     
@@ -11651,7 +11651,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/z-Transform.html"
        - "https://mathworld.wolfram.com/Z-Transform.html"
@@ -11733,7 +11733,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZetaFunction.html"
        - "https://en.wikipedia.org/wiki/List_of_zeta_functions"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -453,7 +453,8 @@ concepts:
       en: apery constant
       property: symbol
       area: "special functions"
-      notation: "mrow ζ(3"
+      comments:
+       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mn>3</mn><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AperysConstant.html"
        - "https://en.wikipedia.org/wiki/Zeta(3)"
@@ -911,7 +912,8 @@ concepts:
       en: bloch constant
       property: symbol
       area: "complex analysis"
-      notation: "miB"
+      comments:
+        - "<math><mi>B</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlochConstant.html"
        - "https://www.encyclopediaofmath.org/index.php/Bloch_constant"
@@ -1006,7 +1008,8 @@ concepts:
       en: brun constant
       property: symbol
       area: "number theory"
-      notation: "msub B 4"
+      comments:
+        - "<math><msub><mi>B</mi><mn>4</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrunsConstant.html"
        - "https://en.wikipedia.org/wiki/Brun%27s_theorem"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2162,7 +2162,8 @@ concepts:
       en: "cross ratio of $1, $2, $3, $4"
       property: fenced
       area: "geometry"
-      notation: "mrow ( $1, $2 ; $3, $4"
+      comments:
+       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi>,</mo><mi>D</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -6094,7 +6095,8 @@ concepts:
       en: "lagrange bracket of $1, $2, canonical coordinates $3, $4"
       property: indexed fenced
       area: "classical mechanics"
-      notation: "msub<br/>mrow [ $1, $2] /mrow<br/>mrow $3, $4 /mrow"
+      comments:
+       - "<math><msub><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi><mo></msub><mrow><mi>p</mi>,</mo><mi>q</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeBracket.html"
        - "https://en.wikipedia.org/wiki/Lagrange_bracket"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1399,7 +1399,7 @@ concepts:
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:
-       - "<math><multiscripts><mi>&Gamma;</mi><mrow/><mi>k</mi><mi>i</mi><mrow/><mi>j</mi><mrow/></multiscripts></math>"
+       - "<math><mmultiscripts><mi>&Gamma;</mi><mrow/><mi>k</mi><mi>i</mi><mrow/><mi>j</mi><mrow/></mmultiscripts></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -7230,7 +7230,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinimumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7357,7 +7357,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModularDiscriminant.html"
        - "https://en.wikipedia.org/wiki/Modular_form#The_modular_discriminant"
@@ -10455,7 +10455,7 @@ concepts:
     - concept: symmetric-group
       arity: 1
       en: symmetric group of $1
-      property: "msub<br/>function, postfix"
+      property: "msub, function, postfix"
       area: "group theory"
       notation: "msub S $1<br/>msub 𝔖 $1<br/>msub Σ $1<br/>mrow Σ ( $1 )<br/>mrow Sym ( $1 )<br/>mrow $1 !<br/>"
       urls: 
@@ -11534,11 +11534,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Wiener_process"
     
     - concept: wiener-sausage
-      arity: 1
-      en: wiener sausage of $1
+      arity: 2
+      en: wiener sausage of radius $1 and length $2
       property: "indexed symbol"
       area: "mathematical physics"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>&delta;</mi></msub><mrow><mo>(</mo><mi>t</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerSausage.html"
        - "https://en.wikipedia.org/wiki/Wiener_sausage"
@@ -11549,7 +11550,8 @@ concepts:
       en: wilson polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonPolynomial.html"
        - "https://en.wikipedia.org/wiki/Wilson_polynomials"
@@ -11622,7 +11624,8 @@ concepts:
       en: witt vector of $1
       property: fenced
       area: "ring theory"
-      notation: "mrow ( $1, ... , $n"
+      comments:
+       - "<math><mi>W</mi><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
@@ -11757,7 +11760,8 @@ concepts:
       en: zero matrix of $1
       property: "indexed symbol"
       area: "linear algebra"
-      notation: "msub mn 0 mrow m,n"
+      comments:
+       - "<math><msub><mn>0</mn>><mrow><mi>i</mi><mi>j</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_matrix"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2131,7 +2131,8 @@ concepts:
       en: covariation of $1 and $2 over $3
       property: indexed fenced
       area: "stochastic processes"
-      notation: "msub mrow [ $1, $2 ] /mrow $3"
+      comments:
+       - "<math><msub><mrow><mo>[</mo><mi>X</mi><mo>,</mo><mi>Y</mi><mo>]</mo></mrow><mi>t</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_variation"
       alias:
@@ -4086,7 +4087,8 @@ concepts:
       en: functional congruence of $1 and $2 mod $3
       property: mixfix
       area: "number theory"
-      notation: "mrow $1 ≡ $2 (mod $3"
+      comments:
+       - "<math><mrow><mi>f</mi><mo>≡</mo><mi>g</mi></mrow><mrow><mo>(</mo><mi>mod</mi><mi>n</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FunctionalCongruence.html"
       alias:
@@ -4217,7 +4219,6 @@ concepts:
        - "https://mathworld.wolfram.com/GateauxDerivative.html"
        - "https://en.wikipedia.org/wiki/G%C3%A2teaux_derivative"
        - "https://www.encyclopediaofmath.org/index.php/Gateaux_derivative"
-       - "https://www.encyclopediaofmath.org/index.php/GÃ¢teaux_derivative"
       alias:
        - gateaux-differential
     
@@ -4282,7 +4283,8 @@ concepts:
       en: gelfand triple of $1, $2 and $3
       property: fenced
       area: "functional analysis"
-      notation: "mrow ( $1, $2, $3"
+      comments:
+       - "<math><mo>(</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>)</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Rigged_Hilbert_space#Formal_definition_(Gelfand_triple)"
     
@@ -5424,7 +5426,8 @@ concepts:
       en: injection $1, from $2 to $3
       property: mixfix<br/>
       area: "set theory"
-      notation: "mrow $1 : $2 ↣ $3"
+      comments:
+       - "<math><mi>f</mi><mo>:</mo><mi>X</mi><mo>↣</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -6359,7 +6362,8 @@ concepts:
       en: levi civita symbol  of $1, $2 and $3
       property: "indexed symbol"
       area: "combinatorics"
-      notation: "msub ϵ mrow $1$2$3 /mrow"
+      comments:
+       - "<math><msub><mi>&#x03f5;</mi><mrow><mi>i</mi><mi>j</mi><mi>k</mi></mrow></msub></math>
       urls: 
        - "https://mathworld.wolfram.com/Levi-CivitaSymbol.html"
        - "https://en.wikipedia.org/wiki/Levi-Civita_symbol"
@@ -7539,7 +7543,8 @@ concepts:
       en: octant  of $1, $2 and $3
       property: fenced
       area: "euclidean solid geometry"
-      notation: "mrow (±,±,±)<br/>mrow (+,+,+)<br/>mrow ($1, $2, $3"
+      comments:
+       - "<math><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octant.html"
        - "https://en.wikipedia.org/wiki/Octant_(plane_geometry)"
@@ -7744,7 +7749,8 @@ concepts:
       en: pade approximant  of $1, $2 and $3
       property: mixfix
       area: "numerical analysis"
-      notation: "msub mrow [ $1 / $2 ] /mrow $3"
+      comments:
+       - "<math><msub><mrow><mo>[</mo><mi>X</mi><mo>/</mo><mi>Y</mi><mo>]</mo></mrow><mi>f</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/3.11#SS4.p1"
        - "https://mathworld.wolfram.com/PadeApproximant.html"
@@ -7765,7 +7771,8 @@ concepts:
       en: paraboloidal coordinate of $1, $2 and $3
       property: fenced
       area: "geometry"
-      notation: "mrow ( $1, $2 , $3"
+      comments:
+       - "<math><mo>(</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ParaboloidalCoordinates.html"
        - "https://en.wikipedia.org/wiki/Paraboloidal_coordinates"
@@ -8452,7 +8459,8 @@ concepts:
       en: pythagorean triple  $1, $2 and $3
       property: fenced
       area: "geometry"
-      notation: "mrow ($1, $2, $3"
+      comments:
+       - "<math><mo>(</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/PythagoreanTriple.html"
        - "https://en.wikipedia.org/wiki/Pythagorean_triple"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1678,8 +1678,7 @@ concepts:
        - "https://mathworld.wolfram.com/CompleteGraph.html"
        - "https://en.wikipedia.org/wiki/Complete_graph"
       alias:
-       - Also complete bipartite graph: K_{n
-       - m}
+       - Also complete bipartite graph: K_{n,m}
     
     - concept: complex-conjugate
       arity: 1

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -632,10 +632,11 @@ concepts:
     
     - concept: barrel
       arity: 1
-      en: barrel of $1
+      en: $1 barrels
       property: unit
       area: "imperial units"
-      notation: "mi bbl"
+      comments:
+       - "<math><mi>x</mi><mo>&#x2009;</mo><mi>bbl</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Barrel.html"
        - "https://en.wikipedia.org/wiki/Barrelled_space"
@@ -1331,11 +1332,11 @@ concepts:
     
     - concept: chain
       arity: 1
-      en: chain of $1
+      en: $1 chains
       property: unit
       area: "imperial units"
       comments:
-       - "<math><mi>chain</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>x</mi><mo>&#x2009;</mo><mi>chain</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chain_(unit)"
     
@@ -5530,11 +5531,11 @@ concepts:
     
     - concept: horsepower-mechanical
       arity: 1
-      en: horsepower mechanical of $1
+      en: $1 horsepower
       property: unit
       area: "imperial unit"
       comments:
-       - "<math><mrow><mi>hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mi>x</mi><mo>&#x2009;</mo><mi>hp</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
       alias:
@@ -10474,7 +10475,7 @@ concepts:
     
     - concept: span
       arity: 1
-      en: span of $1
+      en: $1 span
       property: unit
       area: "imperial units"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -421,7 +421,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi><mo>,</mo><mi>D</mi><mo>]</mo></math>"
+       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi><mo>,</mo><mi>D</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6096,7 +6096,7 @@ concepts:
       property: indexed fenced
       area: "classical mechanics"
       comments:
-       - "<math><msub><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi></msub><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
+       - "<math><msub><mrow><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi></mrow><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeBracket.html"
        - "https://en.wikipedia.org/wiki/Lagrange_bracket"
@@ -9666,7 +9666,8 @@ concepts:
       en: "square $1 $2 $3 $4"
       property: prefix
       area: "geometry"
-      notation: "mrow ◻ $1 $2 $3 $4y"
+      comments:
+       - "<math><mo>&squ;</mo><mrow><mi>A</mi><mo>&thinsp;</mo><mi>B</mi><mo>&thinsp;</mo><mi>C</mi><mo>&thinsp;</mo><mi>D</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Square.html"
        - "https://en.wikipedia.org/wiki/Square"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -388,7 +388,8 @@ concepts:
       en: "anharmonic ratio of $1 , $2 , $3 , $4"
       property: fenced
       area: "geometry"
-      notation: "mrow ($1 , $2 ; $3 , $4"
+      comments:
+       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi>,</mo><mi>D</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -1818,7 +1819,8 @@ concepts:
       en: "configuration $1 sub $2, $3 sub $4"
       property: mixfix
       area: "geometry"
-      notation: "(msub $1 $2 msub $3 $4"
+      comments:
+       - "<math><mo>(</mo><msub><mi>a</mi><mi>b</mi></msub><mo>,</mo><msub><mi>c</mi><mi>d</mi></msub><mo>)</mo></math>"     
       urls: 
        - "https://mathworld.wolfram.com/Configuration.html"
        - "https://en.wikipedia.org/wiki/Configuration_(geometry)"
@@ -9135,7 +9137,7 @@ concepts:
     
     - concept: scalar-triple-product
       arity: 3
-      en: scalar-triple product  of $1, $2 and $3
+      en: scalar triple product  of $1, $2 and $3
       property: mixfix<br/>fenced
       area: "vector algebra"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -62,10 +62,11 @@ concepts:
     
     - concept: ad
       arity: 1
-      en: $1 a d
+      en: a d $1
       property: postfix. prefix
       area: "calendar units"
-      notation: "mi AD"
+      comments:
+       - "<math><mi>AD</mi><mo>&#x2009;</mo><mn>2024</mn></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -664,7 +665,8 @@ concepts:
       en: $1 b c
       property: postfix
       area: "calendar units"
-      notation: "mi BC"
+      comments:
+       - "<math><mn>2024</mn><mo>&#x2009;</mo><mi>BC</mi></math>"      
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -673,7 +675,8 @@ concepts:
       en: beatty sequence of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub 𝓑 $1"
+      comments:
+       - "<math><msub><mi>𝓑</mi><mi>r</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BeattySequence.html"
        - "https://en.wikipedia.org/wiki/Beatty_sequence"
@@ -683,7 +686,8 @@ concepts:
       en: bell number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub B $1"
+      comments:
+       - "<math><msub><mi>B</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BellNumber.html"
        - "https://en.wikipedia.org/wiki/Bell_number"
@@ -3237,7 +3241,8 @@ concepts:
       en: double factorial of $1
       property: postfix
       area: "combinatorics"
-      notation: "mo !!"
+      comments:
+       - "<math><mn>10</mn><mo>&#x203c;</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleFactorial.html"
        - "https://en.wikipedia.org/wiki/Double_factorial"
@@ -3250,7 +3255,8 @@ concepts:
       en: double mersenne number
       property: symbol
       area: "number theory"
-      notation: "msub M msub M $1"
+      comments:
+       - "<math><msub><mi>M</mi><msub><mi>M</mi><mi>p</mi></msub></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleMersenneNumber.html"
        - "https://en.wikipedia.org/wiki/Double_Mersenne_number"
@@ -3453,7 +3459,8 @@ concepts:
       en: energy of signal
       property: symbol
       area: "signal processing"
-      notation: "msub E s"
+      comments:
+       - "<math><msub><mi>E</mi><mi>s</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Energy_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Energy_(signal_processing)"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9734,7 +9734,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi mathvariant="normal">i</mi></math>"
+       - "<math><mi mathvariant='normal'>i</mi></math>"
        - "<math><mi>ii</mi></math>"
        - "<math><mi>iii</mi></math>"
        - "<math><mi>iv</mi></math>"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -9,7 +9,8 @@ concepts:
       en: abelian category
       property: symbol
       area: "category theory"
-      notation: "mi Ab"
+      comments:
+        - "<math><mi>Ab</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AbelianCategory.html"
        - "https://en.wikipedia.org/wiki/Abelian_category"
@@ -84,7 +85,8 @@ concepts:
       en: adiabatic invariant first
       property: symbol
       area: "plasma physics"
-      notation: "mi μ"
+      comments:
+        - "<math><mi>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -95,7 +97,8 @@ concepts:
       en: adiabatic invariant second
       property: symbol
       area: "plasma physics"
-      notation: "mi J"
+      comments:
+        - "<math><mi>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -106,7 +109,8 @@ concepts:
       en: adiabatic invariant third
       property: symbol
       area: "plasma physics"
-      notation: "mi Φ"
+      comments:
+        - "<math><mi>Φ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -184,7 +188,8 @@ concepts:
       en: affine line
       property: symbol
       area: "universal algebra?"
-      notation: "mi 𝔸"
+      comments:
+        - "<math><mi>𝔸</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/affine+line"
     
@@ -220,7 +225,8 @@ concepts:
       en: aleph
       property: symbol
       area: "set theory"
-      notation: "mi ℵ"
+      comments:
+        - "<math><mi>ℵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Aleph.html"
        - "https://ncatlab.org/nlab/show/aleph"
@@ -231,7 +237,8 @@ concepts:
       en: algebraics
       property: symbol
       area: "number theory"
-      notation: "mi 𝔸"
+      comments:
+        - "<math><mi>𝔸</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Algebraics.html"
     
@@ -366,7 +373,8 @@ concepts:
       en: angular momentum
       property: symbol
       area: "classical mechanics"
-      notation: "mi L"
+      comments:
+        - "<math><mi>L</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Angular_momentum"
        - "https://en.wikipedia.org/wiki/Introduction_to_angular_momentum"
@@ -377,7 +385,8 @@ concepts:
       en: angular velocity
       property: symbol
       area: "classical mechanics"
-      notation: "mi ω"
+      comments:
+        - "<math><mi>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngularVelocity.html"
        - "https://en.wikipedia.org/wiki/Angular_velocity"
@@ -483,7 +492,8 @@ concepts:
       en: area
       property: symbol
       area: "geometry"
-      notation: "mi A"
+      comments:
+        - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Area.html"
        - "https://en.wikipedia.org/wiki/Area"
@@ -911,7 +921,8 @@ concepts:
       en: boolean domain
       property: symbol
       area: "abstract algebra"
-      notation: "mi 𝔹"
+      comments:
+        - "<math><mi>𝔹</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Boolean_domain"
        - "https://ncatlab.org/nlab/show/boolean+domain"
@@ -921,7 +932,8 @@ concepts:
       en: bottom type
       property: symbol
       area: "category theory"
-      notation: "mi ⊥"
+      comments:
+        - "<math><mi>⊥</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/bottom"
        - "https://en.wikipedia.org/wiki/Bottom_type"
@@ -934,7 +946,8 @@ concepts:
       en: bottom element
       property: symbol
       area: "order theory"
-      notation: "mi ⊥"
+      comments:
+        - "<math><mi>⊥</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Greatest_element_and_least_element"
       alias:
@@ -1012,7 +1025,8 @@ concepts:
       en: cahen constant
       property: symbol
       area: "number theory"
-      notation: "mi C"
+      comments:
+        - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CahensConstant.html"
        - "https://en.wikipedia.org/wiki/Cahen%27s_constant"
@@ -1086,7 +1100,8 @@ concepts:
       en: casimir element
       property: symbol
       area: "lie algebra"
-      notation: "mi Ω"
+      comments:
+        - "<math><mi>Ω</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Casimir_element"
     
@@ -1095,7 +1110,8 @@ concepts:
       en: catalan constant
       property: symbol
       area: "combinatorics"
-      notation: "mi G"
+      comments:
+        - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CatalansConstant.html"
        - "https://en.wikipedia.org/wiki/Catalan%27s_constant"
@@ -1117,7 +1133,8 @@ concepts:
       en: category of algebraic lattices
       property: symbol
       area: "universal algebra"
-      notation: "mi AlgCat"
+      comments:
+        - "<math><mi>AlgCat</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/algebraic+lattice"
     
@@ -1168,7 +1185,8 @@ concepts:
       en: cavitation number
       property: symbol
       area: "physics"
-      notation: "mi Ca"
+      comments:
+        - "<math><mi>Ca</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)#Cavitation_number"
     
@@ -1462,7 +1480,8 @@ concepts:
       en: clique
       property: symbol
       area: "graph theory"
-      notation: "mi C"
+      comments:
+        - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Clique.html"
        - "https://en.wikipedia.org/wiki/Clique_(graph_theory)"
@@ -1548,7 +1567,8 @@ concepts:
       en: cofinite filter
       property: symbol
       area: "order theory"
-      notation: "mi F"
+      comments:
+        - "<math><mi>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CofiniteFilter.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_filter"
@@ -1897,7 +1917,8 @@ concepts:
       en: constant of integration
       property: constant
       area: "calculus"
-      notation: "mi C"
+      comments:
+        - "<math><mi>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConstantofIntegration.html"
        - "https://en.wikipedia.org/wiki/Constant_of_integration"
@@ -1949,7 +1970,8 @@ concepts:
       en: continuum
       property: constant
       area: "set theory"
-      notation: "mi 𝔠"
+      comments:
+        - "<math><mi>𝔠</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Continuum.html"
        - "https://en.wikipedia.org/wiki/List_of_continuity-related_topics"
@@ -1964,7 +1986,8 @@ concepts:
       en: contradiction
       property: constant
       area: "logic"
-      notation: "mo ⊥"
+      comments:
+        - "<math><mo>⊥</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2071,7 +2094,8 @@ concepts:
       en: correlation ratio
       property: symbol
       area: "statistics"
-      notation: "mi η"
+      comments:
+        - "<math><mi>η</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CorrelationRatio.html"
        - "https://en.wikipedia.org/wiki/Correlation_ratio"
@@ -2094,7 +2118,8 @@ concepts:
       en: coupling constant
       property: symbol
       area: "gauge theory"
-      notation: "mi g"
+      comments:
+        - "<math><mi>g</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coupling_constant"
       alias:
@@ -2284,7 +2309,8 @@ concepts:
       en: cycle gene
       property: symbol
       area: "genetics"
-      notation: "mi cyc"
+      comments:
+        - "<math><mi>cyc</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cycle_(gene)"
     
@@ -2441,7 +2467,8 @@ concepts:
       en: degree of freedom
       property: symbol
       area: "statistics"
-      notation: "mi ν"
+      comments:
+        - "<math><mi>ν</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DegreeofFreedom.html"
        - "https://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)#Notation"
@@ -2511,7 +2538,8 @@ concepts:
       en: diagonal functor
       property: symbol
       area: "category theory"
-      notation: "mi Δ"
+      comments:
+        - "<math><mi>Δ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_functor"
        - "https://ncatlab.org/nlab/show/diagonal+functor"
@@ -2785,7 +2813,8 @@ concepts:
       en: dirichlet distribution
       property: symbol
       area: "statistics"
-      notation: "mi Dir"
+      comments:
+        - "<math><mi>Dir</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletDistribution.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_distribution"
@@ -2948,7 +2977,8 @@ concepts:
       en: domain of discourse
       property: symbol
       area: "formal semantics"
-      notation: "mi 𝔻"
+      comments:
+        - "<math><mi>𝔻</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_discourse"
       alias:
@@ -3146,7 +3176,8 @@ concepts:
       en: einstein tensor
       property: symbol
       area: "general relativity"
-      notation: "mi G"
+      comments:
+        - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EinsteinTensor.html"
        - "https://en.wikipedia.org/wiki/Einstein_tensor"
@@ -3170,7 +3201,8 @@ concepts:
       en: end
       property: symbol
       area: "category theory"
-      notation: "mi e"
+      comments:
+        - "<math><mi>e</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/End_(category_theory)"
        - "https://ncatlab.org/nlab/show/end"
@@ -3192,7 +3224,8 @@ concepts:
       en: energy
       property: symbol
       area: "physics"
-      notation: "mi E"
+      comments:
+        - "<math><mi>E</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/energy"
     
@@ -3233,7 +3266,8 @@ concepts:
       en: epsilon number
       property: symbol
       area: "ordinal numbers"
-      notation: "mi ε"
+      comments:
+        - "<math><mi>ε</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epsilon_numbers_(mathematics)"
     
@@ -3294,7 +3328,8 @@ concepts:
       en: erdos borwein constant
       property: symbol
       area: "number theory"
-      notation: "mi E"
+      comments:
+        - "<math><mi>E</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Erdos-BorweinConstant.html"
        - "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Borwein_constant"
@@ -3350,7 +3385,8 @@ concepts:
       en: estimated
       property: symbol
       area: "symbols"
-      notation: "mi ℮"
+      comments:
+        - "<math><mi>℮</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Estimation"
       alias:
@@ -3484,7 +3520,8 @@ concepts:
       en: euler mascheroni constant
       property: constant
       area: "number theory"
-      notation: "mi γ"
+      comments:
+        - "<math><mi>γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3659,7 +3696,8 @@ concepts:
       en: farey sequence
       property: symbol
       area: "number theory"
-      notation: "mi F"
+      comments:
+        - "<math><mi>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FareySequence.html"
        - "https://en.wikipedia.org/wiki/Farey_sequence"
@@ -3678,7 +3716,8 @@ concepts:
       en: feigenbaum constant
       property: symbol
       area: "chaos theory"
-      notation: "mi δ"
+      comments:
+        - "<math><mi>δ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FeigenbaumConstant.html"
        - "https://en.wikipedia.org/wiki/Feigenbaum_constants"
@@ -3810,7 +3849,8 @@ concepts:
       en: flattening
       property: symbol
       area: "celestial mechanics"
-      notation: "mi f"
+      comments:
+        - "<math><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Flattening.html"
        - "https://en.wikipedia.org/wiki/Flattening"
@@ -4109,7 +4149,8 @@ concepts:
       en: fundamental matrix
       property: symbol
       area: "computer vision"
-      notation: "mi F"
+      comments:
+        - "<math><mi>F</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fundamental_matrix_(computer_vision)"
     
@@ -4176,7 +4217,8 @@ concepts:
       en: galois group of $1
       property: function
       area: "abstract algebra"
-      notation: "mi Gal"
+      comments:
+        - "<math><mi>Gal</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -4188,7 +4230,8 @@ concepts:
       en: gamma distribution
       property: symbol
       area: "probability theory"
-      notation: "mi Γ"
+      comments:
+        - "<math><mi>Γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaDistribution.html"
        - "https://en.wikipedia.org/wiki/Gamma_distribution"
@@ -4236,7 +4279,8 @@ concepts:
       en: gaussian distribution
       property: symbol
       area: "probability theory"
-      notation: "mi 𝒩"
+      comments:
+        - "<math><mi>𝒩</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Normal_distribution"
       alias:
@@ -4313,7 +4357,8 @@ concepts:
       en: gell mann matrix
       property: symbol
       area: "particle physics"
-      notation: "mi λ"
+      comments:
+        - "<math><mi>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Gell-MannMatrix.html"
        - "https://en.wikipedia.org/wiki/Gell-Mann_matrices"
@@ -4458,7 +4503,8 @@ concepts:
       en: glaisher constant
       property: constant
       area: "number theory"
-      notation: "mi A"
+      comments:
+        - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GlaisherConstant.html"
        - "https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant"
@@ -4525,7 +4571,8 @@ concepts:
       en: gram matrix
       property: symbol
       area: "linear algebra"
-      notation: "mi G"
+      comments:
+        - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramMatrix.html"
        - "https://en.wikipedia.org/wiki/Gramian_matrix"
@@ -4563,7 +4610,8 @@ concepts:
       en: grobner basis
       property: symbol
       area: "computer algebra"
-      notation: "mi G"
+      comments:
+        - "<math><mi>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GroebnerBasis.html"
        - "https://en.wikipedia.org/wiki/Gr%C3%B6bner_basis"
@@ -5196,7 +5244,8 @@ concepts:
       en: identity matrix
       property: symbol
       area: "linear algebra"
-      notation: "mi I"
+      comments:
+        - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/IdentityMatrix.html"
        - "https://en.wikipedia.org/wiki/Identity_matrix"
@@ -5222,7 +5271,8 @@ concepts:
       en: incenter
       property: symbol
       area: "geometry"
-      notation: "mi I"
+      comments:
+        - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Incenter.html"
        - "https://en.wikipedia.org/wiki/Incircle_and_excircles_of_a_triangle"
@@ -5732,7 +5782,8 @@ concepts:
       en: jacobsthal number
       property: symbol
       area: "number theory"
-      notation: "mi J"
+      comments:
+        - "<math><mi>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsthalNumber.html"
        - "https://en.wikipedia.org/wiki/Jacobsthal_number"
@@ -6115,7 +6166,8 @@ concepts:
       en: lagrange multiplier
       property: symbol
       area: "mathematical optimization"
-      notation: "mi λ"
+      comments:
+        - "<math><mi>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeMultiplier.html"
        - "https://en.wikipedia.org/wiki/Lagrange_multiplier"
@@ -6189,7 +6241,8 @@ concepts:
       en: laplacian matrix
       property: symbol
       area: "graph theory"
-      notation: "mi L"
+      comments:
+        - "<math><mi>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplacianMatrix.html"
        - "https://en.wikipedia.org/wiki/Laplacian_matrix"
@@ -6498,7 +6551,8 @@ concepts:
       en: liouville constant
       property: constant
       area: "number theory"
-      notation: "mi L"
+      comments:
+        - "<math><mi>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvillesConstant.html"
       alias:
@@ -6955,7 +7009,8 @@ concepts:
       en: mills constant
       property: symbol
       area: "number theory"
-      notation: "mi A"
+      comments:
+        - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsConstant.html"
        - "https://en.wikipedia.org/wiki/Mills%27_constant"
@@ -7145,7 +7200,8 @@ concepts:
       en: moment
       property: symbol
       area: "mechanics"
-      notation: "mi M"
+      comments:
+        - "<math><mi>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Moment.html"
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -7158,7 +7214,8 @@ concepts:
       en: moment of inertia
       property: symbol
       area: "physics"
-      notation: "mi I"
+      comments:
+        - "<math><mi>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MomentofInertia.html"
        - "https://en.wikipedia.org/wiki/Moment_of_inertia"
@@ -7173,7 +7230,9 @@ concepts:
       en: momentum
       property: symbol
       area: "mechanics"
-      notation: "mi p<br/>mip"
+      comments:
+        - "<math><mi>p</mi></math>"
+        - "<math><mi>mip</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Momentum"
        - "https://ncatlab.org/nlab/show/momentum"
@@ -7186,7 +7245,8 @@ concepts:
       en: monster group
       property: symbol
       area: "group theory"
-      notation: "mi M"
+      comments:
+        - "<math><mi>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MonsterGroup.html"
        - "https://en.wikipedia.org/wiki/Monster_group"
@@ -7367,7 +7427,8 @@ concepts:
       en: negative binomial distribution
       property: symbol
       area: "probability theory"
-      notation: "mi NB"
+      comments:
+        - "<math><mi>NB</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/NegativeBinomialDistribution.html"
        - "https://en.wikipedia.org/wiki/Negative_binomial_distribution"
@@ -7570,7 +7631,8 @@ concepts:
       en: odds ratio
       property: symbol
       area: "statistics"
-      notation: "mi OR"
+      comments:
+        - "<math><mi>OR</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Odds_ratio"
     
@@ -7964,7 +8026,8 @@ concepts:
       en: p h
       property: symbol
       area: "chemistry"
-      notation: "mi pH"
+      comments:
+        - "<math><mi>pH</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/PH"
       alias:
@@ -8094,7 +8157,8 @@ concepts:
       en: poisson distribution
       property: symbol
       area: "probability theory"
-      notation: "mi Pois"
+      comments:
+        - "<math><mi>Pois</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PoissonDistribution.html"
        - "https://en.wikipedia.org/wiki/Poisson_distribution"
@@ -8385,7 +8449,8 @@ concepts:
       en: prouhet thue morse constant
       property: constant
       area: "number theory"
-      notation: "mi τ"
+      comments:
+        - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Prouhet%E2%80%93Thue%E2%80%93Morse_constant"
     
@@ -8550,7 +8615,8 @@ concepts:
       en: r complexity class
       property: symbol
       area: "complexity theory"
-      notation: "mi R"
+      comments:
+        - "<math><mi>R</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/R.html"
        - "https://en.wikipedia.org/wiki/R_(complexity)"
@@ -8634,7 +8700,8 @@ concepts:
       en: ramanujan soldner constant
       property: constant
       area: "special functions"
-      notation: "mi μ"
+      comments:
+        - "<math><mi>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ramanujan-SoldnerConstant.html"
        - "https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant"
@@ -8879,7 +8946,8 @@ concepts:
       en: reynolds number
       property: symbol
       area: "fluid dynamics"
-      notation: "mi Re"
+      comments:
+        - "<math><mi>Re</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Reynolds_number"
     
@@ -9075,7 +9143,8 @@ concepts:
       en: root of unity
       property: symbol
       area: "complex numbers"
-      notation: "mi ω"
+      comments:
+        - "<math><mi>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RootofUnity.html"
        - "https://en.wikipedia.org/wiki/Root_of_unity"
@@ -9107,7 +9176,8 @@ concepts:
       en: ruark number
       property: symbol
       area: "physics"
-      notation: "mi Ru"
+      comments:
+        - "<math><mi>Ru</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)"
     
@@ -9255,7 +9325,8 @@ concepts:
       en: sedenion
       property: symbol
       area: "abstract algebra"
-      notation: "mi 𝕊"
+      comments:
+        - "<math><mi>𝕊</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sedenion"
        - "https://ncatlab.org/nlab/show/sedenion"
@@ -9296,7 +9367,8 @@ concepts:
       en: shannon entropy
       property: symbol
       area: "information theory"
-      notation: "mi H"
+      comments:
+        - "<math><mi>H</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShannonEntropy.html"
        - "https://en.wikipedia.org/wiki/Entropy_(information_theory)"
@@ -9358,7 +9430,8 @@ concepts:
       en: sidon sequence
       property: symbol
       area: "combinatorics"
-      notation: "mi A"
+      comments:
+        - "<math><mi>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SidonSequence.html"
        - "https://en.wikipedia.org/wiki/Sidon_sequence"
@@ -9449,7 +9522,8 @@ concepts:
       en: size of test
       property: symbol
       area: "statistics"
-      notation: "mi α"
+      comments:
+        - "<math><mi>α</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Size_(statistics)"
     
@@ -9512,7 +9586,8 @@ concepts:
       en: soft o
       property: symbol
       area: "complexity theory"
-      notation: "mi Õ"
+      comments:
+        - "<math><mi>Õ</mi></math>"
       urls: 
       alias:
        - Extensions_to_the_Bachmann–Landau_notations
@@ -9522,7 +9597,8 @@ concepts:
       en: solid angle
       property: symbol
       area: "geometry"
-      notation: "mi Ω"
+      comments:
+        - "<math><mi>Ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SolidAngle.html"
        - "https://en.wikipedia.org/wiki/Solid_angle"
@@ -9595,7 +9671,8 @@ concepts:
       en: spectrum category
       property: symbol
       area: "category theory"
-      notation: "mi Sp"
+      comments:
+        - "<math><mi>Sp</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Spectrum"
     
@@ -9653,7 +9730,8 @@ concepts:
       en: spin angular momentum
       property: symbol
       area: "quantum mechanics"
-      notation: "mi S"
+      comments:
+        - "<math><mi>S</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -9662,7 +9740,8 @@ concepts:
       en: spin group
       property: symbol
       area: "group theory"
-      notation: "mi Spin"
+      comments:
+        - "<math><mi>Spin</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpinGroup.html"
        - "https://en.wikipedia.org/wiki/Spin_group"
@@ -9674,7 +9753,8 @@ concepts:
       en: spin quantum number
       property: symbol
       area: "quantum mechanics"
-      notation: "mi s"
+      comments:
+        - "<math><mi>s</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -9714,7 +9794,8 @@ concepts:
       en: standard deviation
       property: symbol
       area: "probability theory"
-      notation: "mi σ"
+      comments:
+        - "<math><mi>σ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/StandardDeviation.html"
        - "https://en.wikipedia.org/wiki/Standard_deviation"
@@ -10180,7 +10261,8 @@ concepts:
       en: tau particle
       property: symbol
       area: "particle physics"
-      notation: "mi τ"
+      comments:
+        - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tau_(particle)"
     
@@ -10221,7 +10303,8 @@ concepts:
       en: temperature
       property: symbol
       area: "physics"
-      notation: "mi T"
+      comments:
+        - "<math><mi>T</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Temperature.html"
        - "https://en.wikipedia.org/wiki/Temperature"
@@ -10302,7 +10385,8 @@ concepts:
       en: thompson group
       property: symbol
       area: "group theory"
-      notation: "mi Th"
+      comments:
+        - "<math><mi>Th</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ThompsonGroup.html"
        - "https://en.wikipedia.org/wiki/Thompson_groups"
@@ -10355,7 +10439,8 @@ concepts:
       en: torque
       property: symbol
       area: "mechanics"
-      notation: "mi τ"
+      comments:
+        - "<math><mi>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torque"
     
@@ -10364,7 +10449,8 @@ concepts:
       en: torsion
       property: symbol
       area: "differential geometry"
-      notation: "mi τ"
+      comments:
+        - "<math><mi>τ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Torsion.html"
        - "https://en.wikipedia.org/wiki/Torsion_of_a_curve"
@@ -10710,7 +10796,8 @@ concepts:
       en: universal parabolic constant
       property: constant
       area: "geometry"
-      notation: "mi P"
+      comments:
+        - "<math><mi>P</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/UniversalParabolicConstant.html"
        - "https://en.wikipedia.org/wiki/Universal_parabolic_constant"
@@ -10908,7 +10995,8 @@ concepts:
       en: volume
       property: symbol
       area: "physics"
-      notation: "mi V"
+      comments:
+        - "<math><mi>V</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Volume.html"
        - "https://en.wikipedia.org/wiki/Volume_(compression)"
@@ -11292,7 +11380,8 @@ concepts:
       en: z matrix
       property: symbol
       area: "linear algebra"
-      notation: "mi Z"
+      comments:
+        - "<math><mi>Z</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(mathematics)"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -11572,8 +11572,10 @@ concepts:
       en: winding number of $1
       property: "function, symbol"
       area: "algebraic topology"
-      notation: "mi 𝒩<br/>mi w"
-      urls: 
+      comments:
+       - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       urls: 
        - "https://en.wikipedia.org/wiki/Winding_number"
        - "https://dlmf.nist.gov/1.9#E32"
        - "https://ncatlab.org/nlab/show/winding+number"
@@ -11597,7 +11599,8 @@ concepts:
       en: wishart distribution
       property: symbol
       area: "probability theory"
-      notation: "msub W p"
+      comments:
+       - "<math><msub><mi>W</mi><mi>p</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WishartDistribution.html"
        - "https://en.wikipedia.org/wiki/Wishart_distribution"
@@ -11608,13 +11611,14 @@ concepts:
       en: witt polynomials of $1
       property: "indexed function"
       area: "ring theory"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
     
     - concept: witt-vector
-      arity: 1
+      arity: n
       en: witt vector of $1
       property: fenced
       area: "ring theory"
@@ -11628,7 +11632,8 @@ concepts:
       en: woodall number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "msub W $1"
+      comments:
+       - "<math><msub><mi>W</mi><mi>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WoodallNumber.html"
        - "https://en.wikipedia.org/wiki/Woodall_number"
@@ -11741,7 +11746,8 @@ concepts:
       en: zero ideal
       property: symbol
       area: "ring theory"
-      notation: "mrow {0}"
+      comments:
+       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroIdeal.html"
        - "https://ncatlab.org/nlab/show/zero+ideal"
@@ -11770,7 +11776,8 @@ concepts:
       en: zero object
       property: symbol
       area: "algebra"
-      notation: "mrow {0}"
+      comments:
+       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_object_(algebra)"
        - "https://ncatlab.org/nlab/show/zero+object"
@@ -11780,7 +11787,9 @@ concepts:
       en: zero ring
       property: symbol
       area: "ring theory"
-      notation: "mrow {0}<br/>mn 0"
+      comments:
+       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mn>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroRing.html"
        - "https://en.wikipedia.org/wiki/Zero_ring"
@@ -11790,7 +11799,8 @@ concepts:
       en: zero vector
       property: constant
       area: "linear algebra"
-      notation: "mn 0"
+      comments:
+       - "<math><mn>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroVector.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1678,7 +1678,7 @@ concepts:
        - "https://mathworld.wolfram.com/CompleteGraph.html"
        - "https://en.wikipedia.org/wiki/Complete_graph"
       alias:
-       - Also complete bipartite graph: K_{n,m}
+       - "Also complete bipartite graph: `K_{n,m}`"
     
     - concept: complex-conjugate
       arity: 1
@@ -6919,7 +6919,6 @@ concepts:
       arity: 1
       en: meson of $1
       property: 
-      area: "notation: "
       urls: 
        - "https://en.wikipedia.org/wiki/Meson"
        - "https://en.wikipedia.org/wiki/List_of_mesons"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1473,7 +1473,7 @@ concepts:
     
     - concept: closed-ball
       arity: 2
-      en: closed ball
+      en: closed ball $1 $2
       property: mixfix
       area: "topology"
       notation: "mrow msub B $1 /msub [ $2 ]"
@@ -1593,7 +1593,7 @@ concepts:
     
     - concept: comma-category
       arity: 2
-      en: comma category
+      en: comma category $1 $2
       property: mixfix
       area: "category theory"
       notation: "mrow ( $1 ↓ $2"
@@ -1765,7 +1765,7 @@ concepts:
     
     - concept: conditional-expectation
       arity: 2
-      en: conditional expectation
+      en: conditional expectation $1 $2
       property: mixfix
       area: "probability theory"
       notation: "mrow E ( $1 | $2 )"
@@ -1775,7 +1775,7 @@ concepts:
     
     - concept: conditional-probability
       arity: 2
-      en: conditional probability
+      en: conditional probability $1 $2
       property: mixfix
       area: "probability theory"
       notation: "mrow P ( $1 | $2 )"
@@ -1804,7 +1804,7 @@ concepts:
     
     - concept: contrast-function
       arity: 2
-      en: contrast function
+      en: contrast function $1 $2
       property: mixfix
       area: "statistics"
       notation: "D ( $1 | $2)"
@@ -3623,7 +3623,7 @@ concepts:
     
     - concept: falling-factorial
       arity: 2
-      en: falling factorial
+      en: falling factorial $1 $2
       property: mixfix
       area: "combinatorics"
       notation: "msup $1 mover $2 ¯<br/>msup $1 munder $2 ¯<br/>msub mrow ( $1 ) /mrow $2"
@@ -3992,7 +3992,7 @@ concepts:
     
     - concept: free-algebra
       arity: 2
-      en: free algebra
+      en: free algebra $1 $2
       property: mixfix
       area: "ring theory"
       notation: "mrow $1⟨$2⟩"
@@ -4003,7 +4003,7 @@ concepts:
     
     - concept: free-module
       arity: 2
-      en: free module
+      en: free module $1 $2
       property: mixfix<br/>msup
       area: "module theory"
       notation: "mrow $1 { $2 }<br/>msup $1 ($2"
@@ -4434,7 +4434,7 @@ concepts:
     
     - concept: germ
       arity: 2
-      en: germ
+      en: germ of $1 at $2
       property: mixfix
       area: "topology"
       notation: "mrow [ # 1 ] _ $2"
@@ -4561,7 +4561,7 @@ concepts:
     
     - concept: group-algebra
       arity: 2
-      en: group algebra
+      en: group algebra $1 $2
       property: mixfix
       area: "ring theory"
       notation: "mrow $1[$2]<br/>mrow $1$2"
@@ -4583,7 +4583,7 @@ concepts:
     
     - concept: group-ring
       arity: 2
-      en: group ring
+      en: group ring $1 $2
       property: mixfix<br/>infix
       area: "ring theory"
       notation: "mrow $1 [ $2 ]<br/>mrow $1 $2"
@@ -5195,7 +5195,7 @@ concepts:
     
     - concept: image
       arity: 2
-      en: image
+      en: image $1 $2
       property: mixfix
       area: "set theory"
       notation: "$1 [ $2 ]<br/>msub $1 *<br/>msup $1 →<br/>$1 '' $2"
@@ -5459,7 +5459,7 @@ concepts:
     
     - concept: instantaneous-activity
       arity: 2
-      en: instantaneous activity
+      en: instantaneous activity $1 $2
       property: mixfix
       area: "chemistry"
       notation: "msub mrow { $1 } /mrow $2"
@@ -5509,7 +5509,7 @@ concepts:
     
     - concept: inverse-image
       arity: 2
-      en: inverse image
+      en: inverse image $1 $2
       property: mixfix
       area: "set theory"
       notation: "mrow msup $1 -1 /msup [ $2 ]"
@@ -5534,7 +5534,7 @@ concepts:
     
     - concept: inverse-moment-of-function
       arity: 2
-      en: inverse moment of function
+      en: inverse moment of function $1 $2
       property: "<br/>msub<br/>mixfix"
       area: "mathematics"
       notation: "msub μ mrow - $1 /mrow<br/>mrow E [ msup $1 mrow - $2 /mrow ]"
@@ -5657,7 +5657,7 @@ concepts:
     - concept: jacobi-symbol
       arity: 2
       en: jacobi symbol
-      property: mixfix
+      property: mixfix$1 $2
       area: "number theory"
       notation: "mrow ( $1 | $2"
       urls: 
@@ -6503,7 +6503,7 @@ concepts:
     
     - concept: localization
       arity: 2
-      en: localization
+      en: localization $1 $2
       property: mixfix
       area: "module theory"
       notation: "msup $1 -1 /msup $2"
@@ -6527,7 +6527,7 @@ concepts:
     
     - concept: logarithmic-moment-of-function
       arity: 2
-      en: logarithmic moment of function
+      en: logarithmic moment of function $1 $2
       property: "<br/><br/>mixfix"
       area: "mathematics"
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
@@ -7118,7 +7118,7 @@ concepts:
     
     - concept: moment-of-function
       arity: 2
-      en: moment of function
+      en: moment of function $1 $2
       property: "<br/>msub<br/>mixfix"
       area: "mathematics"
       notation: "msub μ $1<br/>mrow E [ msup $1 $2 ]"
@@ -7573,7 +7573,7 @@ concepts:
     
     - concept: open-ball
       arity: 2
-      en: open ball
+      en: open ball $1 $2
       property: mixfix
       area: "topology"
       notation: "mrow msub B $1 /msub ( $2"
@@ -8031,7 +8031,7 @@ concepts:
     
     - concept: plethysm
       arity: 2
-      en: plethysm
+      en: plethysm $1 $2
       property: mixfix
       area: "algebra"
       notation: "mrow { $1 } ⊗ { $2 }"
@@ -8121,7 +8121,7 @@ concepts:
     
     - concept: polynomial-ring
       arity: 2
-      en: polynomial ring
+      en: polynomial ring $1 $2
       property: mixfix
       area: "ring theory"
       notation: "mrow $1 [ $2 ]"
@@ -8386,7 +8386,7 @@ concepts:
     
     - concept: pseudovector
       arity: 2
-      en: pseudovector
+      en: pseudovector $1 $2
       property: mixfix
       area: "vector calculus"
       notation: "mrow (det $1) ($1 $2"
@@ -8800,7 +8800,7 @@ concepts:
     
     - concept: restricted-quantifier
       arity: 2
-      en: restricted quantifier
+      en: restricted quantifier $1 $2
       property: mixfix
       area: "formal logic"
       notation: "msub mrow ( Ǝ $1 ) /mrow $2<br/>msub mrow ( ∀ $1 ) /mrow $2"
@@ -9004,7 +9004,7 @@ concepts:
     
     - concept: ring-of-formal-power-series
       arity: 2
-      en: ring of formal power series
+      en: ring of formal power series $1 $2
       property: mixfix
       area: "ring theory"
       notation: "mrow $1 [[ $2 ]]"
@@ -9013,7 +9013,7 @@ concepts:
     
     - concept: rising-factorial
       arity: 2
-      en: rising factorial
+      en: rising factorial $1 $2
       property: mixfix
       area: "combinatorics"
       notation: "msup $1 mover $2 ¯<br/>msup $1 mrow ( $2 ) /mrow"
@@ -9199,7 +9199,7 @@ concepts:
     
     - concept: schwarzian-derivative
       arity: 2
-      en: schwarzian derivative
+      en: schwarzian derivative $1 $2
       property: fenced<br/>mixfix
       area: "complex analysis"
       notation: "mrow { $1, $2 }<br/>mrow ( S $1 ) ($2"
@@ -9311,7 +9311,7 @@ concepts:
     
     - concept: short-exact-sequence
       arity: 3
-      en: short exact sequence
+      en: short exact sequence $1 $2 $3
       property: mixfix
       area: "group theory"
       notation: "mrow 0 →$1 → $2 → $3 → 0"
@@ -10019,7 +10019,7 @@ concepts:
     
     - concept: surjection
       arity: 3
-      en: surjection
+      en: surjection  $1 $2 $3
       property: mixfix<br/>infix
       area: "set theory"
       notation: "mrow $1 : $2 ↠ $3<br/>msup mo ≤ mo * /msup"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -34,7 +34,7 @@ concepts:
       property: prefix
       area: "number theory"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Abundance.html"
     
@@ -54,7 +54,7 @@ concepts:
       property: function
       area: "computability theory"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ackermann_function"
        - "https://www.encyclopediaofmath.org/index.php/Ackermann_function"
@@ -149,7 +149,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>Ad</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdjointRepresentation.html"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -161,7 +161,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>adj</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>adj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjugate_matrix"
     
@@ -171,7 +171,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Aff</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineGroup.html"
        - "https://en.wikipedia.org/wiki/Affine_group"
@@ -183,7 +183,7 @@ concepts:
       property: function
       area: "affine geometry"
       comments:
-        - "<math><mrow><mi>aff</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>aff</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineHull.html"
        - "https://en.wikipedia.org/wiki/Affine_hull"
@@ -274,7 +274,7 @@ concepts:
       property: function
       area: "functions"
       comments:
-        - "<math><mrow><mi>af</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>af</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Alternating_factorial"
     
@@ -359,7 +359,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngerFunction.html"
        - "https://en.wikipedia.org/wiki/Anger_function"
@@ -372,7 +372,7 @@ concepts:
       property: function
       area: "hyperbolic geometry"
       comments:
-        - "<math><mrow><mi>Π</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngleofParallelism.html"
        - "https://en.wikipedia.org/wiki/Angle_of_parallelism"
@@ -419,7 +419,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-        - "<math><mrow><mi>Ann</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Annihilator.html"
        - "https://en.wikipedia.org/wiki/Annihilator_(ring_theory)"
@@ -431,7 +431,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>ann</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ann</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Annulus_(mathematics)"
        - "https://ncatlab.org/nlab/show/annulus"
@@ -517,7 +517,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>Arf</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Arf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ArfInvariant.html"
        - "https://en.wikipedia.org/wiki/Arf_invariant"
@@ -529,7 +529,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>Arg</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Arg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Argument_(complex_analysis)"
     
@@ -575,7 +575,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Aut</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Aut</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Automorphism"
@@ -586,7 +586,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>∇</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>∇</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BackwardDifference.html"
        - "https://en.wikipedia.org/wiki/Finite_difference"
@@ -917,7 +917,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlaschkeProduct.html"
        - "https://en.wikipedia.org/wiki/Blaschke_product"
@@ -992,7 +992,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>BV</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>BV</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BoundedVariation.html"
        - "https://en.wikipedia.org/wiki/Bounded_variation"
@@ -1014,7 +1014,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Br</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Br</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrauerGroup.html"
        - "https://en.wikipedia.org/wiki/Brauer_group"
@@ -1038,7 +1038,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Burnside_group"
     
@@ -1100,7 +1100,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
        - "https://en.wikipedia.org/wiki/Carmichael_function"
@@ -1240,7 +1240,7 @@ concepts:
       property: function
       area: "algebra"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(group_theory)"
        - "https://en.wikipedia.org/wiki/Center_(algebra)"
@@ -1285,7 +1285,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Character.html"
        - "https://en.wikipedia.org/wiki/Character_(mathematics)"
@@ -1300,7 +1300,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-        - "<math><mrow><mi>char</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>char</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Characteristic.html"
        - "https://en.wikipedia.org/wiki/Characteristic_(algebra)"
@@ -1378,7 +1378,7 @@ concepts:
       property: function
       area: "Riemannian geometry"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant"
     
@@ -1388,7 +1388,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant_(graph_theory)"
       alias:
@@ -1423,7 +1423,7 @@ concepts:
       property: function
       area: "geometry"
       comments:
-        - "<math><mrow><mi>crd</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>crd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chord_(geometry)"
     
@@ -1501,7 +1501,7 @@ concepts:
       property: function
       area: "universal algebra"
       comments:
-        - "<math><mrow><mi>Cl</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clifford_algebra"
     
@@ -1523,7 +1523,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clique_number"
     
@@ -1577,7 +1577,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>codim</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>codim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Codimension.html"
        - "https://en.wikipedia.org/wiki/Codimension"
@@ -1590,7 +1590,7 @@ concepts:
       property: function
       area: "order theory"
       comments:
-        - "<math><mrow><mi>cf</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>cf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cofinality"
        - "https://ncatlab.org/nlab/show/cofinality"
@@ -1624,7 +1624,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>coim</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>coim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coimage"
        - "https://ncatlab.org/nlab/show/coimage"
@@ -1635,7 +1635,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>coker</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>coker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cokernel.html"
        - "https://en.wikipedia.org/wiki/Cokernel"
@@ -1818,7 +1818,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Condition_number"
        - "https://dlmf.nist.gov/3.2#SS5.p1"
@@ -1851,7 +1851,7 @@ concepts:
       property: function
       area: "algebraic number theory"
       comments:
-        - "<math><mrow><mi>𝔣⁢</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>𝔣⁢</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Conductor_(class_field_theory)"
     
@@ -1912,7 +1912,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Cl</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugacyClass.html"
        - "https://en.wikipedia.org/wiki/Conjugacy_class"
@@ -1945,7 +1945,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Connectivity.html"
        - "https://en.wikipedia.org/wiki/Connectivity_(graph_theory)"
@@ -2125,7 +2125,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>corr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>corr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Correlation_and_dependence"
     
@@ -2147,7 +2147,7 @@ concepts:
       property: operator
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>Ci</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ci</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -2173,7 +2173,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>cov</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>cov</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Covariance.html"
        - "https://en.wikipedia.org/wiki/Covariance_operator"
@@ -2248,7 +2248,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Cr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Cr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Crossing_number_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Crossing_number_(knot_theory)"
@@ -2329,7 +2329,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Curvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"
@@ -2401,7 +2401,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DavenportConstant.html"
        - "https://en.wikipedia.org/wiki/Davenport_constant"
@@ -2446,7 +2446,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>η</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DedekindEtaFunction.html"
        - "https://en.wikipedia.org/wiki/Dedekind_eta_function"
@@ -2458,7 +2458,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dedekind_zeta_function"
     
@@ -2503,7 +2503,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
       alias:
@@ -2527,7 +2527,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_continuous_mapping"
       alias:
@@ -2539,7 +2539,7 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_polynomial"
       alias:
@@ -2578,7 +2578,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derived_category"
        - "https://ncatlab.org/nlab/show/derived+category"
@@ -2601,7 +2601,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>Δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_intersection"
     
@@ -2611,7 +2611,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>diag</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>diag</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_matrix"
     
@@ -2630,7 +2630,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DickmanFunction.html"
        - "https://en.wikipedia.org/wiki/Dickman_function"
@@ -2655,7 +2655,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialEntropy.html"
        - "https://en.wikipedia.org/wiki/Differential_entropy"
@@ -2751,7 +2751,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracDeltaFunction.html"
        - "https://en.wikipedia.org/wiki/Dirac_delta_function"
@@ -2777,7 +2777,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirac_measure"
     
@@ -2787,7 +2787,7 @@ concepts:
       property: function
       area: "differential operators"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracOperator.html"
        - "https://en.wikipedia.org/wiki/Dirac_operator"
@@ -2850,7 +2850,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletCharacter.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_character"
@@ -2885,7 +2885,7 @@ concepts:
       property: function
       area: "analytic number theory"
       comments:
-        - "<math><mrow><mi>η</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletEtaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%97(x)"
@@ -2908,7 +2908,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletL-Function.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_L-function"
@@ -2921,7 +2921,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>ν</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ν</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Discrete_valuation"
        - "https://ncatlab.org/nlab/show/discrete+valuation"
@@ -3017,7 +3017,7 @@ concepts:
       property: indexed
       area: "number theory"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DivisorFunction.html"
        - "https://en.wikipedia.org/wiki/D(n)"
@@ -3032,7 +3032,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>dom</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_a_function"
     
@@ -3054,7 +3054,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DominationNumber.html"
        - "https://en.wikipedia.org/wiki/Dominating_set"
@@ -3124,7 +3124,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-        - "<math><mrow><mi>𝒵</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>𝒵</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(category_theory)"
       alias:
@@ -3190,7 +3190,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>E</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/E-Function.html"
        - "https://en.wikipedia.org/wiki/E-function"
@@ -3214,7 +3214,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EdgeCoverNumber.html"
        - "https://en.wikipedia.org/wiki/Edge_covering_number"
@@ -3225,7 +3225,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-        - "<math><mrow><mi>dom</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Effective_domain"
     
@@ -3235,7 +3235,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>e</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Antenna_efficiency"
        - "https://en.wikipedia.org/wiki/Efficiency_(statistics)"
@@ -3283,7 +3283,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>End</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>End</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Endomorphism.html"
        - "https://en.wikipedia.org/wiki/Endomorphism"
@@ -3316,7 +3316,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Entropy"
        - "https://en.wikipedia.org/wiki/Entropy_(arrow_of_time)"
@@ -3330,7 +3330,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>epi</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>epi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epigraph_(mathematics)"
     
@@ -3350,7 +3350,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>Eq</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Eq</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Equalizer.html"
        - "https://en.wikipedia.org/wiki/Equaliser_(mathematics)"
@@ -3516,7 +3516,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerCharacteristic.html"
        - "https://en.wikipedia.org/wiki/Euler_characteristic"
@@ -3529,7 +3529,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>e</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_class"
        - "https://ncatlab.org/nlab/show/Euler+class"
@@ -3609,7 +3609,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerianNumber.html"
        - "https://en.wikipedia.org/wiki/Eulerian_number"
@@ -3672,7 +3672,7 @@ concepts:
       property: 
       area: 
       comments:
-        - "<math><mrow><mi>Ei</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ei</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialIntegral.html"
        - "https://en.wikipedia.org/wiki/Exponential_integral"
@@ -3698,7 +3698,7 @@ concepts:
       property: operator
       area: "differential forms"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorDerivative.html"
        - "https://en.wikipedia.org/wiki/Exterior_derivative"
@@ -3709,7 +3709,7 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-        - "<math><mrow><mi>Λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Exterior_algebra"
     
@@ -3768,7 +3768,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Julia_set"
     
@@ -3919,7 +3919,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>I</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FisherInformation.html"
        - "https://en.wikipedia.org/wiki/Fisher_information"
@@ -3957,7 +3957,7 @@ concepts:
       property: function
       area: "quantum mechanics"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fock_space"
        - "https://ncatlab.org/nlab/show/Fock+space"
@@ -4073,7 +4073,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>Fr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Fr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FranelNumber.html"
     
@@ -4094,7 +4094,7 @@ concepts:
       property: operator
       area: "banach spaces"
       comments:
-        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrechetDerivative.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_derivative"
@@ -4119,7 +4119,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-        - "<math><mrow><mi>det</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>det</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fredholm_determinant"
        - "https://ncatlab.org/nlab/show/Fredholm+determinant"
@@ -4246,7 +4246,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/G-Function.html"
        - "https://en.wikipedia.org/wiki/Meijer_G-function"
@@ -4259,7 +4259,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gabor_transform"
        - "https://en.wikipedia.org/wiki/Gabor%E2%80%93Wigner_transform"
@@ -4271,7 +4271,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>φ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>φ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gain_graph"
        - "https://en.wikipedia.org/wiki/Gain_group"
@@ -4283,7 +4283,7 @@ concepts:
       property: function
       area: "physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GalileanTransformation.html"
        - "https://en.wikipedia.org/wiki/Galilean_transformation"
@@ -4332,7 +4332,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%93(x)"
@@ -4362,7 +4362,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gauss_(unit)"
     
@@ -4386,7 +4386,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianCurvature.html"
        - "https://en.wikipedia.org/wiki/Gaussian_curvature"
@@ -4532,7 +4532,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Diameter_(graph_theory)"
@@ -4567,7 +4567,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>GM</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>GM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Geometric_mean"
@@ -4682,7 +4682,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Gr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Gr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Grassmannian.html"
        - "https://en.wikipedia.org/wiki/Grassmannian"
@@ -4694,7 +4694,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GreensFunction.html"
        - "https://en.wikipedia.org/wiki/Green%27s_function_(many-body_theory)"
@@ -4752,7 +4752,7 @@ concepts:
       property: function
       area: "trigonometry"
       comments:
-        - "<math><mrow><mi>gd</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>gd</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GudermannianFunction.html"
        - "https://en.wikipedia.org/wiki/Gudermannian_function"
@@ -4805,7 +4805,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HankelFunction.html"
        - "https://dlmf.nist.gov/10.1"
@@ -4840,7 +4840,7 @@ concepts:
       property: operator
       area: "real analysis"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function"
       alias:
@@ -4852,7 +4852,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HarmonicMean.html"
        - "https://en.wikipedia.org/wiki/Harmonic_mean"
@@ -4897,7 +4897,7 @@ concepts:
       property: function
       area: "engineering"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HazardFunction.html"
       alias:
@@ -4909,7 +4909,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/1.16#E13)[https://en.wikipedia.org/wiki/Heaviside_step_function"
        - "https://en.wikipedia.org/wiki/Heaviside_step_function"
@@ -4924,7 +4924,7 @@ concepts:
       property: function
       area: "topological graph theory"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heawood_number"
     
@@ -4962,7 +4962,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>ht</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ht</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Krull_dimension#height"
       alias:
@@ -4976,7 +4976,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeisenbergGroup.html"
        - "https://en.wikipedia.org/wiki/Heisenberg_group"
@@ -5024,7 +5024,7 @@ concepts:
       property: function
       area: "means"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeronianMean.html"
        - "https://en.wikipedia.org/wiki/Heronian_mean"
@@ -5035,7 +5035,7 @@ concepts:
       property: operator
       area: "differential operators"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hessian.html"
        - "https://en.wikipedia.org/wiki/Hessian_matrix"
@@ -5061,7 +5061,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Hp</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.5#p1"
@@ -5124,7 +5124,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Hol</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Holomorph_(mathematics)"
        - "https://ncatlab.org/nlab/show/holomorph"
@@ -5135,7 +5135,7 @@ concepts:
       property: "indexed symbol"
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>Hol</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Holonomy.html"
        - "https://en.wikipedia.org/wiki/Holonomy"
@@ -5147,7 +5147,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>HP</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>HP</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomePrime.html"
        - "https://en.wikipedia.org/wiki/Home_prime"
@@ -5178,7 +5178,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>Ho</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ho</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/homotopy+category"
     
@@ -5188,7 +5188,7 @@ concepts:
       property: unit
       area: "imperial unit"
       comments:
-        - "<math><mrow><mi>hp</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>hp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
       alias:
@@ -5211,7 +5211,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HurwitzZetaFunction.html"
        - "https://en.wikipedia.org/wiki/Hurwitz_zeta_function"
@@ -5224,7 +5224,7 @@ concepts:
       property: unit
       area: "customary units"
       comments:
-        - "<math><mrow><mi>hvat</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>hvat</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kubni_hvat"
        - "https://en.wikipedia.org/wiki/%C4%8Cetvorni_hvat"
@@ -5248,7 +5248,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Chi</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Chi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicCosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E16"
@@ -5269,7 +5269,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Shi</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Shi</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicSineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E15"
@@ -5424,7 +5424,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>ι</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ι</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Inclusion_map"
       alias:
@@ -5449,7 +5449,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteBetaFunction.html"
        - "https://dlmf.nist.gov/8.17"
@@ -5462,7 +5462,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5474,7 +5474,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-        - "<math><mrow><mi>E</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5486,7 +5486,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteGammaFunction.html"
        - "https://en.wikipedia.org/wiki/Incomplete_gamma_function"
@@ -5541,7 +5541,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>ind</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ind</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_Lie_algebra"
     
@@ -5611,7 +5611,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>Inn</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Inn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerAutomorphism.html"
        - "https://en.wikipedia.org/wiki/Inner_automorphism"
@@ -5810,7 +5810,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>j</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>j</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/j-Invariant.html"
        - "https://ncatlab.org/nlab/show/j-invariant"
@@ -5821,7 +5821,7 @@ concepts:
       property: function
       area: "operator theory"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiMatrix.html"
        - "https://en.wikipedia.org/wiki/Jacobi_operator"
@@ -5861,7 +5861,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>ϑ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ϑ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiThetaFunctions.html"
        - "https://en.wikipedia.org/wiki/Jacobi_theta_functions_(notational_variations)"
@@ -5955,7 +5955,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>V</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JonesPolynomial.html"
        - "https://en.wikipedia.org/wiki/Jones_polynomial"
@@ -5979,7 +5979,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>m</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
        - "https://en.wikipedia.org/wiki/Jordan_measure"
@@ -6000,7 +6000,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JuliaSet.html"
        - "https://en.wikipedia.org/wiki/Julia_set"
@@ -6051,7 +6051,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>ker</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ker</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Kernel.html"
        - "https://en.wikipedia.org/wiki/Kernel_(algebra)"
@@ -6082,7 +6082,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KillingForm.html"
        - "https://en.wikipedia.org/wiki/Killing_form"
@@ -6143,7 +6143,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>K</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KnoedelNumbers.html"
        - "https://en.wikipedia.org/wiki/Kn%C3%B6del_number"
@@ -6154,7 +6154,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kodaira_dimension"
        - "https://www.encyclopediaofmath.org/index.php/Kodaira_dimension"
@@ -6165,7 +6165,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>K</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KolmogorovComplexity.html"
        - "https://en.wikipedia.org/wiki/Kolmogorov_complexity"
@@ -6185,7 +6185,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KontsevichIntegral.html"
        - "https://en.wikipedia.org/wiki/Kontsevich_invariant"
@@ -6257,7 +6257,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-        - "<math><mrow><mi>dim</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>dim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrullDimension.html"
        - "https://en.wikipedia.org/wiki/Krull_dimension"
@@ -6333,7 +6333,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaguerrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Laguerre_polynomials"
@@ -6369,7 +6369,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>ℒ⁡</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ℒ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplaceTransform.html"
        - "https://en.wikipedia.org/wiki/Laplace_transform"
@@ -6417,7 +6417,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>lpf</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>lpf</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeastPrimeFactor.html"
     
@@ -6571,7 +6571,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-        - "<math><mrow><mi>π</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Prokhorov_metric"
        - "https://encyclopediaofmath.org/wiki/L%C3%A9vy-Prokhorov_metric"
@@ -6637,7 +6637,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LineGraph.html"
        - "https://en.wikipedia.org/wiki/Line_graph"
@@ -6664,7 +6664,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>span</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LinearSpan.html"
        - "https://en.wikipedia.org/wiki/Linear_span"
@@ -6678,7 +6678,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Lk</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Lk</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Link.html"
     
@@ -6709,7 +6709,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvilleFunction.html"
        - "https://en.wikipedia.org/wiki/Liouville_function"
@@ -6734,7 +6734,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>li</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>li</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LogarithmicIntegral.html"
        - "https://dlmf.nist.gov/6.2#i"
@@ -6757,7 +6757,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>logit</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>logit</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Logit"
     
@@ -6790,7 +6790,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>Ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LoopSpace.html"
        - "https://en.wikipedia.org/wiki/Loop_space"
@@ -6865,7 +6865,7 @@ concepts:
       property: function
       area: "stability theory"
       comments:
-        - "<math><mrow><mi>V</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LyapunovFunction.html"
        - "https://en.wikipedia.org/wiki/Lyapunov_function"
@@ -6889,7 +6889,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MahlerMeasure.html"
        - "https://en.wikipedia.org/wiki/Mahler_measure"
@@ -6901,7 +6901,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MangoldtFunction.html"
        - "https://dlmf.nist.gov/27.2#E14"
@@ -6915,7 +6915,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>MCG</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>MCG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_class_group"
        - "https://ncatlab.org/nlab/show/mapping+class+group"
@@ -7039,7 +7039,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>Δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MaximumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7051,7 +7051,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MeanCurvature.html"
        - "https://en.wikipedia.org/wiki/Mean_curvature"
@@ -7063,7 +7063,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>MSE</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>MSE</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mean_squared_error"
     
@@ -7073,7 +7073,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meixner-PollaczekPolynomial.html"
        - "https://en.wikipedia.org/wiki/Meixner%E2%80%93Pollaczek_polynomials"
@@ -7085,7 +7085,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-        - "<math><mrow><mi>ℳ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ℳ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MellinTransform.html"
        - "https://en.wikipedia.org/wiki/Mellin_transform"
@@ -7098,7 +7098,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Meridian_arc"
        - "https://en.wikipedia.org/wiki/Meridian_arc"
@@ -7109,7 +7109,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-        - "<math><mrow><mi>m</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meridian.html"
     
@@ -7140,7 +7140,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MertensFunction.html"
        - "https://en.wikipedia.org/wiki/Mertens_function"
@@ -7194,7 +7194,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>δ<br/></mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinimumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7241,7 +7241,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>μ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MoebiusFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%9C(n)"
@@ -7319,7 +7319,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Δ<br/></mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Δ<br/></mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModularDiscriminant.html"
        - "https://en.wikipedia.org/wiki/Modular_form#The_modular_discriminant"
@@ -7344,7 +7344,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>μ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Moebius_function"
        - "https://en.wikipedia.org/wiki/M%C3%B6bius_function"
@@ -7557,7 +7557,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-        - "<math><mrow><mi>I</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MutualInformation.html"
        - "https://en.wikipedia.org/wiki/Mutual_information"
@@ -7606,7 +7606,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-        - "<math><mrow><mi>NHG</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>NHG</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution"
        - "https://www.encyclopediaofmath.org/index.php/Negative_hypergeometric_distribution"
@@ -7628,7 +7628,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>𝒩</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_system"
       alias:
@@ -7641,7 +7641,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>NS</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>NS</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Neron-SeveriGroup.html"
        - "https://encyclopediaofmath.org/wiki/N%C3%A9ron-Severi_group"
@@ -7663,7 +7663,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-        - "<math><mrow><mi>N</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>N</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nerve.html"
        - "https://en.wikipedia.org/wiki/Nerve_(category_theory)"
@@ -7675,7 +7675,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>q</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>q</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
        - "https://en.wikipedia.org/wiki/Nome_(mathematics)"
@@ -7765,7 +7765,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-        - "<math><mrow><mi>Obj</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Obj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Object.html"
        - "https://en.wikipedia.org/wiki/Lattice-based_access_control"
@@ -7814,7 +7814,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Onsager%E2%80%93Machlup_function"
        - "https://www.encyclopediaofmath.org/index.php/Onsager-Machlup_function"
@@ -7926,7 +7926,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>O</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>O</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OrthogonalGroup.html"
        - "https://en.wikipedia.org/wiki/Orthogonal_group"
@@ -7940,7 +7940,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>Out</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Out</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterAutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Outer_automorphism_group"
@@ -7999,7 +7999,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PadovanSequence.html"
        - "https://en.wikipedia.org/wiki/Padovan_sequence"
@@ -8075,7 +8075,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>p</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>p</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partition_(number_theory)"
     
@@ -8147,7 +8147,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>perm</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>perm</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Permanent.html"
        - "https://en.wikipedia.org/wiki/Permanent"
@@ -8182,7 +8182,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PerrinNumber.html"
        - "https://en.wikipedia.org/wiki/Perrin_number"
@@ -8242,7 +8242,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Pic</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Pic</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PicardGroup.html"
        - "https://en.wikipedia.org/wiki/Picard_group"
@@ -8373,7 +8373,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ψ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ψ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PolygammaFunction.html"
        - "https://en.wikipedia.org/wiki/Polygamma_function"
@@ -8505,7 +8505,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>π</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeCountingFunction.html"
     
@@ -8515,7 +8515,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeDifferenceFunction.html"
     
@@ -8545,7 +8545,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-        - "<math><mrow><mi>Log</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Log</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complex_logarithm#Principal_value"
     
@@ -8555,7 +8555,7 @@ concepts:
       property: "indexed function"
       area: "probability theory"
       comments:
-        - "<math><mrow><mi>plim</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>plim</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Convergence_of_random_variables#Convergence_in_probability"
       alias:
@@ -8588,7 +8588,7 @@ concepts:
       property: function
       area: "projective geometry"
       comments:
-        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Projective_line"
        - "https://ncatlab.org/nlab/show/projective+line"
@@ -8836,7 +8836,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>rad</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>rad</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Radical.html"
        - "https://en.wikipedia.org/wiki/Radical_of_a_Lie_algebra"
@@ -8877,7 +8877,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>τ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansTauFunction.html"
        - "https://en.wikipedia.org/wiki/Ramanujan_tau_function"
@@ -8913,7 +8913,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamseyNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Ramsey_number"
@@ -8982,7 +8982,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-        - "<math><mrow><mi>recc</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>recc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Recession_cone"
     
@@ -9004,7 +9004,7 @@ concepts:
       property: function
       area: "euclidean geometry"
       comments:
-        - "<math><mrow><mi>r</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>r</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rectification.html"
        - "https://en.wikipedia.org/wiki/Rectification_(geometry)"
@@ -9016,7 +9016,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>Σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
     
@@ -9026,7 +9026,7 @@ concepts:
       property: "indexed function"
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relative_homology"
        - "https://ncatlab.org/nlab/show/relative+homology"
@@ -9038,7 +9038,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Repunit.html"
        - "https://en.wikipedia.org/wiki/Repunit"
@@ -9072,7 +9072,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Resolvent_set"
        - "https://www.encyclopediaofmath.org/index.php/Resolvent_set"
@@ -9164,7 +9164,7 @@ concepts:
       property: "indexed symbol"
       area: "riemannian geometry"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciTensor.html"
        - "https://www.encyclopediaofmath.org/index.php/Ricci_tensor"
@@ -9205,7 +9205,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>θ⁡</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>θ⁡</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannThetaFunction.html"
        - "https://dlmf.nist.gov/21.2#i"
@@ -9217,7 +9217,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannZetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%96(x)"
@@ -9233,7 +9233,7 @@ concepts:
       property: "indexed function"
       area: "riemannian geometry"
       comments:
-        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-ChristoffelTensor.html"
        - "https://en.wikipedia.org/wiki/Riemann_curvature_tensor"
@@ -9468,7 +9468,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchurMultiplier.html"
        - "https://en.wikipedia.org/wiki/Schur_multiplier"
@@ -9597,7 +9597,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-        - "<math><mrow><mi>Sh</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Sh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Shimura_variety"
        - "https://ncatlab.org/nlab/show/Shimura+variety"
@@ -9645,7 +9645,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-        - "<math><mrow><mi>sgn</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>sgn</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sign_function"
       alias:
@@ -9657,7 +9657,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>sign</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>sign</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/signature+of+a+permutation"
       alias:
@@ -9714,7 +9714,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-        - "<math><mrow><mi>Si</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Si</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -9747,7 +9747,7 @@ concepts:
       property: prefix
       area: "complexity"
       comments:
-        - "<math><mrow><mi>o</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>o</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
        - "https://mathworld.wolfram.com/o.html"
@@ -9758,7 +9758,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SmithNumber.html"
        - "https://en.wikipedia.org/wiki/Smith_number"
@@ -9781,7 +9781,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>soc</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>soc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Socle.html"
        - "https://en.wikipedia.org/wiki/Socle_(mathematics)"
@@ -9817,7 +9817,7 @@ concepts:
       property: unit
       area: "imperial units"
       comments:
-        - "<math><mrow><mi>span</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(unit)"
     
@@ -9839,7 +9839,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-        - "<math><mrow><mi>SO</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>SO</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialOrthogonalGroup.html"
        - "https://ncatlab.org/nlab/show/special+orthogonal+group"
@@ -9850,7 +9850,7 @@ concepts:
       property: function
       area: "lie groups"
       comments:
-        - "<math><mrow><mi>SU</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>SU</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialUnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Special_unitary_group"
@@ -9862,7 +9862,7 @@ concepts:
       property: function
       area: "spectral theory"
       comments:
-        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpectralRadius.html"
        - "https://en.wikipedia.org/wiki/Spectral_radius"
@@ -9874,7 +9874,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_(functional_analysis)"
     
@@ -9912,7 +9912,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Spec</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Spec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_ring"
     
@@ -10068,7 +10068,7 @@ concepts:
       property: function
       area: "formal languages"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_height"
     
@@ -10078,7 +10078,7 @@ concepts:
       property: function
       area: "k-theory"
       comments:
-        - "<math><mrow><mi>St</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>St</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Group_of_Lie_type"
        - "https://en.wikipedia.org/wiki/Steinberg_group_(K-theory)"
@@ -10101,7 +10101,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>w</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stiefel-WhitneyClass.html"
        - "https://en.wikipedia.org/wiki/Stiefel%E2%80%93Whitney_class"
@@ -10126,7 +10126,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>s</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind"
@@ -10138,7 +10138,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind"
@@ -10150,7 +10150,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Strength_of_a_graph"
       alias:
@@ -10184,7 +10184,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StruveFunction.html"
        - "https://en.wikipedia.org/wiki/Struve_function"
@@ -10198,7 +10198,7 @@ concepts:
       property: function
       area: "field theory"
       comments:
-        - "<math><mrow><mi>s</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stufe_(algebra)"
     
@@ -10293,7 +10293,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-        - "<math><mrow><mi>supp</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>supp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Support.html"
        - "https://en.wikipedia.org/wiki/Support_(mathematics)"
@@ -10361,7 +10361,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Suspension.html"
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
@@ -10416,7 +10416,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Sp</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Sp</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymplecticGroup.html"
        - "https://en.wikipedia.org/wiki/Symplectic_group"
@@ -10441,7 +10441,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentBundle.html"
        - "https://en.wikipedia.org/wiki/Tangent_bundle"
@@ -10497,7 +10497,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>Ta</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaxicabNumber.html"
        - "https://en.wikipedia.org/wiki/Taxicab_number"
@@ -10508,7 +10508,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>Ta</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaylorPolynomial.html"
        - "https://en.wikipedia.org/wiki/Taylor%27s_theorem"
@@ -10520,7 +10520,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TeichmuellerSpace.html"
        - "https://en.wikipedia.org/wiki/Teichm%C3%BCller_space"
@@ -10603,7 +10603,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Thom_space"
        - "https://ncatlab.org/nlab/show/Thom+space"
@@ -10647,7 +10647,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TopologicalEntropy.html"
        - "https://en.wikipedia.org/wiki/Topological_entropy"
@@ -10693,7 +10693,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_(algebra)"
     
@@ -10713,7 +10713,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_tensor"
     
@@ -10747,7 +10747,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>tr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>tr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trace_(linear_algebra)"
     
@@ -10815,7 +10815,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>TM</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>TM</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trimean"
       alias:
@@ -10859,7 +10859,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-        - "<math><mrow><mi>trunc</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>trunc</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Truncation.html"
        - "https://en.wikipedia.org/wiki/Truncation"
@@ -11137,7 +11137,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-        - "<math><mrow><mi>Var</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Var</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Variance"
       alias:
@@ -11168,7 +11168,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>proj</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>proj</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vector_projection"
       alias:
@@ -11181,7 +11181,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-        - "<math><mrow><mi>vec</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>vec</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vectorization_(mathematics)"
        - "https://en.wikipedia.org/wiki/Vectorization_(parallel_computing)"
@@ -11260,7 +11260,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-        - "<math><mrow><mi>W</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WalshFunction.html"
        - "https://en.wikipedia.org/wiki/Walsh_function"
@@ -11319,7 +11319,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>℘</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>℘</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassEllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Weierstrass%27s_elliptic_functions"
@@ -11333,7 +11333,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassSigmaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11346,7 +11346,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassZetaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11359,7 +11359,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>wt</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>wt</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Weight_(strings)"
        - "https://ncatlab.org/nlab/show/weight"
@@ -11404,7 +11404,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-        - "<math><mrow><mi>Wh</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Wh</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadGroup.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11427,7 +11427,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-        - "<math><mrow><mi>τ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadTorsion.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11495,7 +11495,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>W</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonQuotient.html"
        - "https://en.wikipedia.org/wiki/Wilson_quotient"
@@ -11519,7 +11519,7 @@ concepts:
       property: function
       area: "fourier analysis"
       comments:
-        - "<math><mrow><mi>w</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WindowFunction.html"
        - "https://en.wikipedia.org/wiki/Window_function"
@@ -11573,7 +11573,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ϕ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ϕ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WrightFunction.html"
     
@@ -11583,7 +11583,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-        - "<math><mrow><mi>ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Wright_Omega_function"
       alias:
@@ -11595,7 +11595,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-        - "<math><mrow><mi>Wr</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Wr</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Writhe.html"
        - "https://en.wikipedia.org/wiki/Writhe"
@@ -11620,7 +11620,7 @@ concepts:
       property: function
       area: "gauge theory"
       comments:
-        - "<math><mrow><mi>ℒ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ℒ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Yang-MillsFunctional.html"
        - "https://www.encyclopediaofmath.org/index.php/Yang-Mills_functional"
@@ -11651,7 +11651,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/z-Transform.html"
        - "https://mathworld.wolfram.com/Z-Transform.html"
@@ -11733,7 +11733,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
+        - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZetaFunction.html"
        - "https://en.wikipedia.org/wiki/List_of_zeta_functions"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6,7 +6,7 @@ concepts:
   
     - concept: abelian-category
       arity: 0
-      en: abelian-category
+      en: abelian category
       property: symbol
       area: "category theory"
       notation: "mi Ab"
@@ -18,7 +18,7 @@ concepts:
     
     - concept: abelian-integral
       arity: 1
-      en: abelian-integral of $1
+      en: abelian integral of $1
       property: indexed
       area: "complex analysis"
       notation: "mo ∫"
@@ -48,7 +48,7 @@ concepts:
     
     - concept: ackermann-function
       arity: 1
-      en: ackermann-function of $1
+      en: ackermann function of $1
       property: function
       area: "computability theory"
       notation: "mi A"
@@ -68,7 +68,7 @@ concepts:
     
     - concept: additive-inverse
       arity: 1
-      en: additive-inverse of $1
+      en: additive inverse of $1
       property: prefix
       area: "abstract algebra"
       notation: "mo -"
@@ -81,7 +81,7 @@ concepts:
     
     - concept: adiabatic-invariant-first
       arity: 0
-      en: adiabatic-invariant-first
+      en: adiabatic invariant first
       property: symbol
       area: "plasma physics"
       notation: "mi μ"
@@ -92,7 +92,7 @@ concepts:
     
     - concept: adiabatic-invariant-second
       arity: 0
-      en: adiabatic-invariant-second
+      en: adiabatic invariant second
       property: symbol
       area: "plasma physics"
       notation: "mi J"
@@ -103,7 +103,7 @@ concepts:
     
     - concept: adiabatic-invariant-third
       arity: 0
-      en: adiabatic-invariant-third
+      en: adiabatic invariant third
       property: symbol
       area: "plasma physics"
       notation: "mi Φ"
@@ -125,7 +125,7 @@ concepts:
     
     - concept: adjoint-action
       arity: 1
-      en: adjoint-action of $1
+      en: adjoint action of $1
       property: "function/msub"
       area: "lie algebra"
       notation: "mi ad<br/>msub ad $1"
@@ -139,7 +139,7 @@ concepts:
     
     - concept: adjoint-representation
       arity: 1
-      en: adjoint-representation of $1
+      en: adjoint representation of $1
       property: function
       area: "lie algebra"
       notation: "mi Ad"
@@ -159,7 +159,7 @@ concepts:
     
     - concept: affine-group
       arity: 1
-      en: affine-group of $1
+      en: affine group of $1
       property: function
       area: "group theory"
       notation: "mi Aff"
@@ -170,7 +170,7 @@ concepts:
     
     - concept: affine-hull
       arity: 1
-      en: affine-hull of $1
+      en: affine hull of $1
       property: function
       area: "affine geometry"
       notation: "mi aff"
@@ -181,7 +181,7 @@ concepts:
     
     - concept: affine-line
       arity: 0
-      en: affine-line
+      en: affine line
       property: symbol
       area: "universal algebra?"
       notation: "mi 𝔸"
@@ -190,7 +190,7 @@ concepts:
     
     - concept: airy-function
       arity: 1
-      en: airy-function of $1
+      en: airy function of $1
       property: function
       area: "special functions"
       notation: "mi Ai<br/>mi Bi"
@@ -205,7 +205,7 @@ concepts:
     
     - concept: albanese-variety
       arity: 1
-      en: albanese-variety of $1
+      en: albanese variety of $1
       property: function
       area: "algebraic geometry"
       notation: "mi A<br/>mi Alb"
@@ -237,7 +237,7 @@ concepts:
     
     - concept: algebraic-closure
       arity: 1
-      en: algebraic-closure of $1
+      en: algebraic closure of $1
       property: mover/msup
       area: "algebra"
       notation: "mover ¯<br/>msup alg"
@@ -248,7 +248,7 @@ concepts:
     
     - concept: almost-surely
       arity: 1
-      en: almost-surely of $1
+      en: almost surely of $1
       property: 
       area: "probability theory"
       notation: "mtext a.s."
@@ -257,7 +257,7 @@ concepts:
     
     - concept: alternating-factorial
       arity: 1
-      en: alternating-factorial of $1
+      en: alternating factorial of $1
       property: function
       area: "functions"
       notation: "mi af"
@@ -266,7 +266,7 @@ concepts:
     
     - concept: alternating-group
       arity: 1
-      en: alternating-group of $1
+      en: alternating group of $1
       property: function
       area: "group theory"
       notation: "mi A<br/>mi Alt"
@@ -292,7 +292,7 @@ concepts:
     
     - concept: alternative-denial
       arity: 2
-      en: $1 alternative-denial $2
+      en: $1 alternative denial $2
       property: infix<br/>prefix
       area: "propositional calculus"
       notation: "mo | <br/>mo ↑<br/>mrow D $1 $2"
@@ -329,7 +329,7 @@ concepts:
     
     - concept: analytic-manifold
       arity: 0
-      en: analytic-manifold
+      en: analytic manifold
       property: symbol
       area: "topology"
       notation: "msup C w"
@@ -340,7 +340,7 @@ concepts:
     
     - concept: anger-function
       arity: 1
-      en: anger-function of $1
+      en: anger function of $1
       property: function
       area: "special functions"
       notation: "mi J"
@@ -352,7 +352,7 @@ concepts:
     
     - concept: angle-of-parallelism
       arity: 1
-      en: angle-of-parallelism of $1
+      en: angle of parallelism of $1
       property: function
       area: "hyperbolic geometry"
       notation: "mi Π"
@@ -362,7 +362,7 @@ concepts:
     
     - concept: angular-momentum
       arity: 0
-      en: angular-momentum
+      en: angular momentum
       property: symbol
       area: "classical mechanics"
       notation: "mi L"
@@ -373,7 +373,7 @@ concepts:
     
     - concept: angular-velocity
       arity: 0
-      en: angular-velocity
+      en: angular velocity
       property: symbol
       area: "classical mechanics"
       notation: "mi ω"
@@ -384,7 +384,7 @@ concepts:
     
     - concept: anharmonic-ratio
       arity: 4
-      en: "anharmonic-ratio of $1 , $2 , $3 , $4"
+      en: "anharmonic ratio of $1 , $2 , $3 , $4"
       property: fenced
       area: "geometry"
       notation: "mrow ($1 , $2 ; $3 , $4"
@@ -429,7 +429,7 @@ concepts:
     
     - concept: apartness-relation
       arity: 2
-      en: $1 apartness-relation $2
+      en: $1 apartness relation $2
       property: infix
       area: "constructive mathematics"
       notation: "mo #"
@@ -439,7 +439,7 @@ concepts:
     
     - concept: apery-constant
       arity: 0
-      en: apery-constant
+      en: apery constant
       property: symbol
       area: "special functions"
       notation: "mrow ζ(3"
@@ -489,7 +489,7 @@ concepts:
     
     - concept: arf-invariant
       arity: 1
-      en: arf-invariant of $1
+      en: arf invariant of $1
       property: function
       area: "geometric topology"
       notation: "mi Arf"
@@ -509,7 +509,7 @@ concepts:
     
     - concept: arithmetic-geometric-mean
       arity: 1
-      en: arithmetic-geometric-mean of $1
+      en: arithmetic geometric mean of $1
       property: function
       area: "special functions"
       notation: "mi agm<br/>mi AGM"
@@ -521,7 +521,7 @@ concepts:
     
     - concept: associated-legendre-polynomial
       arity: 1
-      en: associated-legendre-polynomial of $1
+      en: associated legendre polynomial of $1
       property: function
       area: "special functions"
       notation: "msubsup P l m"
@@ -544,7 +544,7 @@ concepts:
     
     - concept: automorphism-group
       arity: 1
-      en: automorphism-group of $1
+      en: automorphism group of $1
       property: function
       area: "group theory"
       notation: "mi Aut"
@@ -554,7 +554,7 @@ concepts:
     
     - concept: backward-difference
       arity: 1
-      en: backward-difference of $1
+      en: backward difference of $1
       property: operator
       area: "special functions"
       notation: "mi ∇"
@@ -565,7 +565,7 @@ concepts:
     
     - concept: baire-space
       arity: 0
-      en: baire-space
+      en: baire space
       property: symbol
       area: "set theory"
       notation: "msup N N<br/>msup ω ω"
@@ -589,7 +589,7 @@ concepts:
     
     - concept: bateman-function
       arity: 2
-      en: bateman-function
+      en: bateman function
       property: function
       area: "special functions"
       notation: "mrow msub k $1 ( $2"
@@ -600,7 +600,7 @@ concepts:
     
     - concept: baumslag-solitar-group
       arity: 2
-      en: baumslag-solitar-group
+      en: baumslag solitar group
       property: function
       area: "group theory"
       notation: "mrow BS ( $1, $2"
@@ -619,7 +619,7 @@ concepts:
     
     - concept: beatty-sequence
       arity: 1
-      en: beatty-sequence of $1
+      en: beatty sequence of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub 𝓑 $1"
@@ -629,7 +629,7 @@ concepts:
     
     - concept: bell-number
       arity: 1
-      en: bell-number of $1
+      en: bell number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub B $1"
@@ -641,7 +641,7 @@ concepts:
     
     - concept: bell-polynomial
       arity: n
-      en: bell-polynomial
+      en: bell polynomial
       property: "indexed function"
       area: "polynomials"
       notation: "mrow msub B $1 ($2, ... $n"
@@ -652,7 +652,7 @@ concepts:
     
     - concept: berezin-integral
       arity: 1
-      en: berezin-integral of $1
+      en: berezin integral of $1
       property: indexed
       area: "mathematical physics"
       notation: "mo ∫"
@@ -663,7 +663,7 @@ concepts:
     
     - concept: bergman-space
       arity: 2
-      en: bergman-space
+      en: bergman space
       property: "indexed function"
       area: "complex analysis"
       notation: "msup A $1 ($2"
@@ -674,7 +674,7 @@ concepts:
     
     - concept: bernoulli-number
       arity: 1
-      en: bernoulli-number of $1
+      en: bernoulli number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub B $1"
@@ -688,7 +688,7 @@ concepts:
     
     - concept: bernoulli-polynomial
       arity: 2
-      en: bernoulli-polynomial
+      en: bernoulli polynomial
       property: "indexed function"
       area: "number theory"
       notation: "msub B $1 ($2"
@@ -701,7 +701,7 @@ concepts:
     
     - concept: bessel-function
       arity: 2
-      en: bessel-function
+      en: bessel function
       property: "indexed function"
       area: "special functions"
       notation: "msub J $1 ($2"
@@ -713,7 +713,7 @@ concepts:
     
     - concept: bessel-function-of-second-kind
       arity: 2
-      en: bessel-function-of-second-kind
+      en: bessel function of second kind
       property: "indexed function"
       area: "special functions"
       notation: "msub Y $1 ($2"
@@ -724,7 +724,7 @@ concepts:
     
     - concept: bessel-polynomial
       arity: 2
-      en: bessel-polynomial
+      en: bessel polynomial
       property: "indexed function"
       area: "special functions"
       notation: "msub y $1 ($2"
@@ -736,7 +736,7 @@ concepts:
     
     - concept: beta-distribution
       arity: 1
-      en: beta-distribution of $1
+      en: beta distribution of $1
       property: function
       area: "probability theory"
       notation: "mi B<br/>mi Beta<br/>mi 𝓑𝓮<br/>mi β"
@@ -746,7 +746,7 @@ concepts:
     
     - concept: beta-function
       arity: 1
-      en: beta-function of $1
+      en: beta function of $1
       property: function
       area: "special functions"
       notation: "mi B<br/>mi β"
@@ -763,7 +763,7 @@ concepts:
     
     - concept: betti-number
       arity: 1
-      en: betti-number of $1
+      en: betti number of $1
       property: "indexed symbol"
       area: "graph theory"
       notation: "msub b $1"
@@ -788,7 +788,7 @@ concepts:
     
     - concept: big-O
       arity: 1
-      en: big-O of $1
+      en: big O of $1
       property: prefix
       area: "complexity"
       notation: "mi O<br/>"
@@ -798,7 +798,7 @@ concepts:
     
     - concept: bigeometric-integral
       arity: 1
-      en: bigeometric-integral of $1
+      en: bigeometric integral of $1
       property: indexed
       area: "calculus"
       notation: "mo Π"
@@ -816,7 +816,7 @@ concepts:
     
     - concept: binary-golay-code
       arity: 0
-      en: binary-golay-code
+      en: binary golay code
       property: symbol
       area: "coding theory"
       notation: "msub G 23"
@@ -826,7 +826,7 @@ concepts:
     
     - concept: binomial-coefficient
       arity: 1
-      en: binomial-coefficient of $1
+      en: binomial coefficient of $1
       property: "indexed function"
       area: "combinatorics"
       notation: "msubsup C"
@@ -841,7 +841,7 @@ concepts:
     
     - concept: binomial-distribution
       arity: 1
-      en: binomial-distribution of $1
+      en: binomial distribution of $1
       property: function
       area: "probability theory"
       notation: "mrow B(n,p"
@@ -863,7 +863,7 @@ concepts:
     
     - concept: bipolar-set
       arity: 1
-      en: bipolar-set of $1
+      en: bipolar set of $1
       property: msup
       area: "functional analysis"
       notation: "msup $1 °°"
@@ -883,7 +883,7 @@ concepts:
     
     - concept: blaschke-product
       arity: 1
-      en: blaschke-product of $1
+      en: blaschke product of $1
       property: function
       area: "complex analysis"
       notation: "mi B"
@@ -894,7 +894,7 @@ concepts:
     
     - concept: bloch-constant
       arity: 0
-      en: bloch-constant
+      en: bloch constant
       property: symbol
       area: "complex analysis"
       notation: "miB"
@@ -904,7 +904,7 @@ concepts:
     
     - concept: boolean-domain
       arity: 0
-      en: boolean-domain
+      en: boolean domain
       property: symbol
       area: "abstract algebra"
       notation: "mi 𝔹"
@@ -914,7 +914,7 @@ concepts:
     
     - concept: bottom-type
       arity: 0
-      en: bottom-type
+      en: bottom type
       property: symbol
       area: "category theory"
       notation: "mi ⊥"
@@ -927,7 +927,7 @@ concepts:
     
     - concept: bottom-element
       arity: 0
-      en: bottom-element
+      en: bottom element
       property: symbol
       area: "order theory"
       notation: "mi ⊥"
@@ -953,7 +953,7 @@ concepts:
     
     - concept: bounded-variation
       arity: 1
-      en: bounded-variation of $1
+      en: bounded variation of $1
       property: function
       area: "analysis"
       notation: "mi BV"
@@ -963,7 +963,7 @@ concepts:
     
     - concept: box-product
       arity: 2
-      en: $1 box-product $2
+      en: $1 box product $2
       property: infix
       area: "graph theory"
       notation: "mo ☐"
@@ -974,7 +974,7 @@ concepts:
     
     - concept: brauer-group
       arity: 1
-      en: brauer-group of $1
+      en: brauer group of $1
       property: function
       area: "group theory"
       notation: "mi Br"
@@ -986,7 +986,7 @@ concepts:
     
     - concept: brun-constant
       arity: 0
-      en: brun-constant
+      en: brun constant
       property: symbol
       area: "number theory"
       notation: "msub B 4"
@@ -996,7 +996,7 @@ concepts:
     
     - concept: burnside-group
       arity: 1
-      en: burnside-group of $1
+      en: burnside group of $1
       property: function
       area: "group theory"
       notation: "mi B"
@@ -1005,7 +1005,7 @@ concepts:
     
     - concept: cahen-constant
       arity: 0
-      en: cahen-constant
+      en: cahen constant
       property: symbol
       area: "number theory"
       notation: "mi C"
@@ -1015,7 +1015,7 @@ concepts:
     
     - concept: calderon-toeplitz-operator
       arity: 2
-      en: calderon-toeplitz-operator
+      en: calderon toeplitz operator
       property: "indexed symbol"
       area: "operator theory"
       notation: "msub T mrow $1, $2"
@@ -1024,7 +1024,7 @@ concepts:
     
     - concept: canonical-commutation-relation
       arity: 2
-      en: canonical-commutation-relation
+      en: canonical commutation relation
       property: fenced
       area: "quantum mechanics"
       notation: "mrow [ $1 , $2 ]"
@@ -1033,7 +1033,7 @@ concepts:
     
     - concept: cap-product
       arity: 2
-      en: $1 cap-product $2
+      en: $1 cap product $2
       property: infix
       area: "algebraic topology"
       notation: "mo ⌣"
@@ -1056,7 +1056,7 @@ concepts:
     
     - concept: carmichael-function
       arity: 1
-      en: carmichael-function of $1
+      en: carmichael function of $1
       property: function
       area: "number theory"
       notation: "mi λ"
@@ -1066,7 +1066,7 @@ concepts:
     
     - concept: cartesian-product
       arity: 2
-      en: $1 cartesian-product $2
+      en: $1 cartesian product $2
       property: infix
       area: "set theory"
       notation: "mo ×"
@@ -1079,7 +1079,7 @@ concepts:
     
     - concept: casimir-element
       arity: 0
-      en: casimir-element
+      en: casimir element
       property: symbol
       area: "lie algebra"
       notation: "mi Ω"
@@ -1088,7 +1088,7 @@ concepts:
     
     - concept: catalan-constant
       arity: 0
-      en: catalan-constant
+      en: catalan constant
       property: symbol
       area: "combinatorics"
       notation: "mi G"
@@ -1099,7 +1099,7 @@ concepts:
     
     - concept: catalan-number
       arity: 1
-      en: catalan-number of $1
+      en: catalan number of $1
       property: "indexed symbol"
       area: "combinatorics"
       notation: "msub C $1"
@@ -1110,7 +1110,7 @@ concepts:
     
     - concept: category-of-algebraic-lattices
       arity: 0
-      en: category-of-algebraic-lattices
+      en: category of algebraic lattices
       property: symbol
       area: "universal algebra"
       notation: "mi AlgCat"
@@ -1119,7 +1119,7 @@ concepts:
     
     - concept: category-of-sets
       arity: 0
-      en: category-of-sets
+      en: category of sets
       property: symbol
       area: "category theory"
       notation: "miSet"
@@ -1130,7 +1130,7 @@ concepts:
     
     - concept: category-of-small-categories
       arity: 0
-      en: category-of-small-categories
+      en: category of small categories
       property: symbol
       area: "category theory"
       notation: "miCat"
@@ -1139,7 +1139,7 @@ concepts:
     
     - concept: cauchy-principal-value
       arity: 1
-      en: cauchy-principal-value of $1
+      en: cauchy principal value of $1
       property: function
       area: "analysis"
       notation: "mi p.v."
@@ -1151,7 +1151,7 @@ concepts:
     
     - concept: cauchy-product
       arity: 2
-      en: $1 cauchy-product $2
+      en: $1 cauchy product $2
       property: infix
       area: "analysis"
       notation: "mo ⋅"
@@ -1161,7 +1161,7 @@ concepts:
     
     - concept: cavitation-number
       arity: 0
-      en: cavitation-number
+      en: cavitation number
       property: symbol
       area: "physics"
       notation: "mi Ca"
@@ -1170,7 +1170,7 @@ concepts:
     
     - concept: cayley-table
       arity: 1
-      en: cayley-table of $1
+      en: cayley table of $1
       property: mtable
       area: "group theory"
       notation: "mtable"
@@ -1225,7 +1225,7 @@ concepts:
     
     - concept: champernowne-constant
       arity: 0
-      en: champernowne-constant
+      en: champernowne constant
       property: constant
       area: "number theory"
       notation: "mi C<br/>msub C 10"
@@ -1261,7 +1261,7 @@ concepts:
     
     - concept: characteristic-function
       arity: 1
-      en: characteristic-function of $1
+      en: characteristic function of $1
       property: "indexed function<br/>function"
       area: "probability theory"
       notation: "msub 𝟏 $1<br/>mrow 𝟏 { $1 }"
@@ -1278,7 +1278,7 @@ concepts:
     
     - concept: characteristic-subgroup
       arity: 2
-      en: $1 characteristic-subgroup $2
+      en: $1 characteristic subgroup $2
       property: infix
       area: "group theory"
       notation: "mo char"
@@ -1288,7 +1288,7 @@ concepts:
     
     - concept: charlier-polynomial
       arity: 1
-      en: charlier-polynomial of $1
+      en: charlier polynomial of $1
       property: function
       area: "special functions"
       notation: "msub C $1"
@@ -1300,7 +1300,7 @@ concepts:
     
     - concept: chebyshev-polynomial-of-first-kind
       arity: 1
-      en: chebyshev-polynomial-of-first-kind of $1
+      en: chebyshev polynomial of first kind of $1
       property: function
       area: "number theory"
       notation: "mi θ<br/>mi ϑ<br/>mi T"
@@ -1313,7 +1313,7 @@ concepts:
     
     - concept: chebyshev-polynomial-of-second-kind
       arity: 1
-      en: chebyshev-polynomial-of-second-kind of $1
+      en: chebyshev polynomial of second kind of $1
       property: function
       area: "number theory"
       notation: "mi ψ<br/>mi U"
@@ -1326,7 +1326,7 @@ concepts:
     
     - concept: cheeger-constant
       arity: 1
-      en: cheeger-constant of $1
+      en: cheeger constant of $1
       property: function
       area: "Riemannian geometry"
       notation: "mi h"
@@ -1335,7 +1335,7 @@ concepts:
     
     - concept: cheeger-number
       arity: 1
-      en: cheeger-number of $1
+      en: cheeger number of $1
       property: function
       area: "graph theory"
       notation: "mi h"
@@ -1347,7 +1347,7 @@ concepts:
     
     - concept: chemical-equilibrium
       arity: 2
-      en: $1 chemical-equilibrium $2
+      en: $1 chemical equilibrium $2
       property: infix
       area: "chemistry"
       notation: "mo ⇌"
@@ -1358,7 +1358,7 @@ concepts:
     
     - concept: chi-squared-distribution
       arity: 0
-      en: chi-squared-distribution
+      en: chi squared distribution
       property: symbol
       area: "probability theory"
       notation: "msup χ 2"
@@ -1378,7 +1378,7 @@ concepts:
     
     - concept: christoffel-symbol-of-first-kind
       arity: 3
-      en: christoffel-symbol-of-first-kind>mrow msub Δ $1 [$2] ($3" of $1, $2, $3
+      en: christoffel symbol of first kind>mrow msub Δ $1 [$2] ($3" of $1, $2, $3
       property: "indexed symbol"
       area: "Riemannian geometry"
       notation: "msub Γ mrow $1 $2 $3"
@@ -1390,7 +1390,7 @@ concepts:
     
     - concept: christoffel-symbol-of-second-kind
       arity: 1
-      en: christoffel-symbol-of-second-kind of $1
+      en: christoffel symbol of second kind of $1
       property: "indexed symbol"
       area: "Riemannian geometry"
       notation: "msubsup Γ"
@@ -1402,7 +1402,7 @@ concepts:
     
     - concept: chromatic-polynomial
       arity: 1
-      en: chromatic-polynomial of $1
+      en: chromatic polynomial of $1
       property: function
       area: "graph theory"
       notation: "msub P $1<br/>msub π $1<br/>msub χ $1"
@@ -1412,7 +1412,7 @@ concepts:
     
     - concept: classifying-space
       arity: 1
-      en: classifying-space of $1
+      en: classifying space of $1
       property: function
       area: "group theory"
       notation: "mi B<br/>mi ℬ"
@@ -1423,7 +1423,7 @@ concepts:
     
     - concept: clausen-function
       arity: 1
-      en: clausen-function of $1
+      en: clausen function of $1
       property: function
       area: "special functions"
       notation: "msub Cl 2"
@@ -1432,7 +1432,7 @@ concepts:
     
     - concept: clebsch-gordan-coefficient
       arity: 8
-      en: clebsch-gordan-coefficient
+      en: clebsch gordan coefficient
       property: fenced
       area: "special functions"
       notation: "mrow ( $1 $2 $3 $4 | $5 $6 $7 $8 )<br/>mrow ⟨ $1 $2 $3 $4 |  $5 $6 $7 $8 ⟩"
@@ -1444,7 +1444,7 @@ concepts:
     
     - concept: clifford-algebra
       arity: 1
-      en: clifford-algebra of $1
+      en: clifford algebra of $1
       property: function
       area: "universal algebra"
       notation: "mi Cl"
@@ -1464,7 +1464,7 @@ concepts:
     
     - concept: clique-number
       arity: 1
-      en: clique-number of $1
+      en: clique number of $1
       property: function
       area: "graph theory"
       notation: "mi ω"
@@ -1473,7 +1473,7 @@ concepts:
     
     - concept: closed-ball
       arity: 2
-      en: closed-ball
+      en: closed ball
       property: mixfix
       area: "topology"
       notation: "mrow msub B $1 /msub [ $2 ]"
@@ -1485,7 +1485,7 @@ concepts:
     
     - concept: closed-interval
       arity: 2
-      en: closed-interval
+      en: closed interval
       property: fenced
       area: "calculus"
       notation: "mrow [ $1, $2 ]"
@@ -1495,7 +1495,7 @@ concepts:
     
     - concept: closed-neighbourhood
       arity: 2
-      en: closed-neighbourhood
+      en: closed neighbourhood
       property: "indexed function<br/>function"
       area: "graph theory"
       notation: "msub N $1 [ $2 ]<br/>mrow N [ $1 ]"
@@ -1539,7 +1539,7 @@ concepts:
     
     - concept: cofinite-filter
       arity: 0
-      en: cofinite-filter
+      en: cofinite filter
       property: symbol
       area: "order theory"
       notation: "mi F"
@@ -1583,7 +1583,7 @@ concepts:
     
     - concept: column-vector
       arity: 1
-      en: column-vector of $1
+      en: column vector of $1
       property: mtable
       area: "linear algebra"
       notation: "mtable"
@@ -1593,7 +1593,7 @@ concepts:
     
     - concept: comma-category
       arity: 2
-      en: comma-category
+      en: comma category
       property: mixfix
       area: "category theory"
       notation: "mrow ( $1 ↓ $2"
@@ -1614,7 +1614,7 @@ concepts:
     
     - concept: commutator-subgroup
       arity: 1
-      en: commutator-subgroup of $1
+      en: commutator subgroup of $1
       property: msup<br/>fenced
       area: "abstract algebra"
       notation: "msup $1 '<br/>msup $1 (1)<br/>mrow [ $1, $1 ]"
@@ -1629,7 +1629,7 @@ concepts:
     
     - concept: companion-lehmer-number
       arity: 1
-      en: companion-lehmer-number of $1
+      en: companion lehmer number of $1
       property: "indexed function"
       area: "number theory"
       notation: "msub V $1"
@@ -1651,7 +1651,7 @@ concepts:
     
     - concept: complement-of-interval
       arity: 2
-      en: complement-of-interval
+      en: complement of interval
       property: fenced
       area: "order theory"
       notation: "mrow ] $1, $2 ["
@@ -1660,7 +1660,7 @@ concepts:
     
     - concept: complementary-nome
       arity: 1
-      en: complementary-nome of $1
+      en: complementary nome of $1
       property: function
       area: "special functions"
       notation: "msub q 1"
@@ -1670,7 +1670,7 @@ concepts:
     
     - concept: complete-graph
       arity: 0
-      en: complete-graph
+      en: complete graph
       property: symbol
       area: "graph theory"
       notation: "msub K $1"
@@ -1683,7 +1683,7 @@ concepts:
     
     - concept: complex-conjugate
       arity: 1
-      en: complex-conjugate of $1
+      en: complex conjugate of $1
       property: msup
       area: "complex analysis"
       notation: "msup $1 *<br/>mover $1 ¯"
@@ -1694,7 +1694,7 @@ concepts:
     
     - concept: complex-projective-space
       arity: 0
-      en: complex-projective-space
+      en: complex projective space
       property: symbol
       area: "projective geometry"
       notation: "mrow ℂ⁢ ℙ"
@@ -1735,7 +1735,7 @@ concepts:
     
     - concept: compound-interest
       arity: 2
-      en: compound-interest
+      en: compound interest
       property: msup
       area: "finance"
       notation: "msup $1 ($2"
@@ -1754,7 +1754,7 @@ concepts:
     
     - concept: condition-number
       arity: 1
-      en: condition-number of $1
+      en: condition number of $1
       property: function
       area: "numerical analysis"
       notation: "mi κ"
@@ -1765,7 +1765,7 @@ concepts:
     
     - concept: conditional-expectation
       arity: 2
-      en: conditional-expectation
+      en: conditional expectation
       property: mixfix
       area: "probability theory"
       notation: "mrow E ( $1 | $2 )"
@@ -1775,7 +1775,7 @@ concepts:
     
     - concept: conditional-probability
       arity: 2
-      en: conditional-probability
+      en: conditional probability
       property: mixfix
       area: "probability theory"
       notation: "mrow P ( $1 | $2 )"
@@ -1795,7 +1795,7 @@ concepts:
     
     - concept: contraction-operator
       arity: 2
-      en: $1 contraction-operator $2
+      en: $1 contraction operator $2
       property: infix
       area: "algebraic geometry"
       notation: "mo ⌟"
@@ -1804,7 +1804,7 @@ concepts:
     
     - concept: contrast-function
       arity: 2
-      en: contrast-function
+      en: contrast function
       property: mixfix
       area: "statistics"
       notation: "D ( $1 | $2)"
@@ -1826,7 +1826,7 @@ concepts:
     
     - concept: congruence-relation
       arity: 2
-      en: $1 congruence-relation $2
+      en: $1 congruence relation $2
       property: infix
       area: "algebra<br/>geometry"
       notation: "mo ≡<br/>mo ≅"
@@ -1845,7 +1845,7 @@ concepts:
     
     - concept: conjugacy-class
       arity: 1
-      en: conjugacy-class of $1
+      en: conjugacy class of $1
       property: function
       area: "group theory"
       notation: "mi Cl"
@@ -1856,7 +1856,7 @@ concepts:
     
     - concept: conjugate-transpose
       arity: 1
-      en: conjugate-transpose of $1
+      en: conjugate transpose of $1
       property: msup
       area: "linear algebra"
       notation: "msup $1 H<br/>msup $1 *"
@@ -1866,7 +1866,7 @@ concepts:
     
     - concept: connected-sum
       arity: 2
-      en: $1 connected-sum $2
+      en: $1 connected sum $2
       property: infix
       area: "topology"
       notation: "mo #"
@@ -1888,7 +1888,7 @@ concepts:
     
     - concept: constant-of-integration
       arity: 0
-      en: constant-of-integration
+      en: constant of integration
       property: constant
       area: "calculus"
       notation: "mi C"
@@ -1911,7 +1911,7 @@ concepts:
     
     - concept: contingency-table
       arity: 1
-      en: contingency-table of $1
+      en: contingency table of $1
       property: mtable
       area: "statistics"
       notation: "mtable"
@@ -1923,7 +1923,7 @@ concepts:
     
     - concept: continued-fraction
       arity: 1
-      en: continued-fraction of $1
+      en: continued fraction of $1
       property: mixfix
       area: "number theory"
       notation: "mfrac"
@@ -1988,7 +1988,7 @@ concepts:
     
     - concept: converse-graph
       arity: 1
-      en: converse-graph of $1
+      en: converse graph of $1
       property: msup
       area: "graph theory"
       notation: "msup $1 '<br/>msup $1 T<br/>msup $1 R"
@@ -2014,7 +2014,7 @@ concepts:
     
     - concept: conway-group
       arity: 0
-      en: conway-group
+      en: conway group
       property: symbol
       area: "group theory"
       notation: "msub Co 0<br/>msub Co 1<br/>msub Co 2<br/>msub Co 3"
@@ -2062,7 +2062,7 @@ concepts:
     
     - concept: correlation-ratio
       arity: 0
-      en: correlation-ratio
+      en: correlation ratio
       property: symbol
       area: "statistics"
       notation: "mi η"
@@ -2073,7 +2073,7 @@ concepts:
     
     - concept: cosine-integral
       arity: 1
-      en: cosine-integral of $1
+      en: cosine integral of $1
       property: operator
       area: "special-functions"
       notation: "mi Ci"
@@ -2085,7 +2085,7 @@ concepts:
     
     - concept: coupling-constant
       arity: 0
-      en: coupling-constant
+      en: coupling constant
       property: symbol
       area: "gauge theory"
       notation: "mi g"
@@ -2110,7 +2110,7 @@ concepts:
     
     - concept: covariant-derivative
       arity: 1
-      en: covariant-derivative of $1
+      en: covariant derivative of $1
       property: "indexed operator"
       area: "differential geometry"
       notation: "msub ∇ $1"
@@ -2133,7 +2133,7 @@ concepts:
     
     - concept: covering-relation
       arity: 2
-      en: $1 covering-relation $2
+      en: $1 covering relation $2
       property: infix
       area: "order theory"
       notation: "mo ⋖<br/>mo <: "
@@ -2143,7 +2143,7 @@ concepts:
     
     - concept: cross-product
       arity: 2
-      en: $1 cross-product $2
+      en: $1 cross product $2
       property: infix
       area: "linear algebra"
       notation: "mo ×"
@@ -2157,7 +2157,7 @@ concepts:
     
     - concept: cross-ratio
       arity: 4
-      en: "cross-ratio of $1, $2, $3, $4"
+      en: "cross ratio of $1, $2, $3, $4"
       property: fenced
       area: "geometry"
       notation: "mrow ( $1, $2 ; $3, $4"
@@ -2169,7 +2169,7 @@ concepts:
     
     - concept: crossing-number
       arity: 1
-      en: crossing-number of $1
+      en: crossing number of $1
       property: function
       area: "graph theory"
       notation: "mi Cr"
@@ -2180,7 +2180,7 @@ concepts:
     
     - concept: cullen-number
       arity: 1
-      en: cullen-number of $1
+      en: cullen number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub C $1"
@@ -2203,7 +2203,7 @@ concepts:
     
     - concept: cumulative-distribution-function
       arity: 1
-      en: cumulative-distribution-function of $1
+      en: cumulative distribution function of $1
       property: "indexed symbol"
       area: "probability theory"
       notation: "msub F $1"
@@ -2216,7 +2216,7 @@ concepts:
     
     - concept: cup-product
       arity: 2
-      en: $1 cup-product $2
+      en: $1 cup product $2
       property: infix
       area: "algebraic topology"
       notation: "mo ⌣"
@@ -2273,7 +2273,7 @@ concepts:
     
     - concept: cycle-gene
       arity: 0
-      en: cycle-gene
+      en: cycle gene
       property: symbol
       area: "genetics"
       notation: "mi cyc"
@@ -2282,7 +2282,7 @@ concepts:
     
     - concept: cyclotomic-field
       arity: 1
-      en: cyclotomic-field of $1
+      en: cyclotomic field of $1
       property: embellished symbol
       area: "number theory"
       notation: "mrow Q( ζ )<br/>mrow Q( msub ζ $1"
@@ -2294,7 +2294,7 @@ concepts:
     
     - concept: cyclotomic-polynomial
       arity: 1
-      en: cyclotomic-polynomial of $1
+      en: cyclotomic polynomial of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub Φ $1"
@@ -2305,7 +2305,7 @@ concepts:
     
     - concept: dalembert-operator
       arity: 1
-      en: dalembert-operator of $1
+      en: dalembert operator of $1
       property: prefix
       area: "partial differential equations"
       notation: "mo ☐"
@@ -2319,7 +2319,7 @@ concepts:
     
     - concept: davenport-constant
       arity: 1
-      en: davenport-constant of $1
+      en: davenport constant of $1
       property: function
       area: "group theory"
       notation: "mi D"
@@ -2330,7 +2330,7 @@ concepts:
     
     - concept: dawson-function
       arity: 1
-      en: dawson-function of $1
+      en: dawson function of $1
       property: function
       area: "special-functions"
       notation: "mi F<br/>mi D<br/>mi sub D -<br/>mi sub D +"
@@ -2353,7 +2353,7 @@ concepts:
     
     - concept: decrease-tends-to?
       arity: 2
-      en: $1 decrease-tends-to? $2
+      en: $1 decrease tends to? $2
       property: infix
       area: "calculus"
       notation: "mo ↘"
@@ -2363,7 +2363,7 @@ concepts:
     
     - concept: dedekind-eta-function
       arity: 1
-      en: dedekind-eta-function of $1
+      en: dedekind eta function of $1
       property: function
       area: "special functions"
       notation: "mi η"
@@ -2374,7 +2374,7 @@ concepts:
     
     - concept: dedekind-zeta-function
       arity: 1
-      en: dedekind-zeta-function of $1
+      en: dedekind zeta function of $1
       property: function
       area: "special functions"
       notation: "mi ζ"
@@ -2383,7 +2383,7 @@ concepts:
     
     - concept: deductive-closure
       arity: 1
-      en: deductive-closure of $1
+      en: deductive closure of $1
       property: function
       area: "logic"
       notation: "mi Ded<br/>mi Th"
@@ -2392,7 +2392,7 @@ concepts:
     
     - concept: defined-as
       arity: 2
-      en: $1 defined-as $2
+      en: $1 defined as $2
       property: infix
       area: "general"
       notation: "mo ≜<br/>mo ≡<br/>mo : =<br/>mover = def<br/>mo : "
@@ -2418,7 +2418,7 @@ concepts:
     
     - concept: degree-of-graph
       arity: 1
-      en: degree-of-graph of $1
+      en: degree of graph of $1
       property: function
       area: "graph theory"
       notation: "mi deg"
@@ -2430,7 +2430,7 @@ concepts:
     
     - concept: degree-of-freedom
       arity: 0
-      en: degree-of-freedom
+      en: degree of freedom
       property: symbol
       area: "statistics"
       notation: "mi ν"
@@ -2440,7 +2440,7 @@ concepts:
     
     - concept: degree-of-mapping
       arity: 1
-      en: degree-of-mapping of $1
+      en: degree of mapping of $1
       property: function
       area: "topology"
       notation: "mi deg"
@@ -2451,7 +2451,7 @@ concepts:
     
     - concept: degree-of-polynomial
       arity: 1
-      en: degree-of-polynomial of $1
+      en: degree of polynomial of $1
       property: function
       area: "polynomials"
       notation: "mi deg"
@@ -2462,7 +2462,7 @@ concepts:
     
     - concept: dependence-relation
       arity: 2
-      en: $1 dependence-relation $2
+      en: $1 dependence relation $2
       property: infix
       area: "linear algebra"
       notation: "mo ◃"
@@ -2480,7 +2480,7 @@ concepts:
     
     - concept: derivation-tree
       arity: 1
-      en: derivation-tree of $1
+      en: derivation tree of $1
       property: mfrac
       area: "logic"
       notation: "mfrac"
@@ -2489,7 +2489,7 @@ concepts:
     
     - concept: derived-category
       arity: 1
-      en: derived-category of $1
+      en: derived category of $1
       property: function
       area: "category theory"
       notation: "mi D"
@@ -2500,7 +2500,7 @@ concepts:
     
     - concept: diagonal-functor
       arity: 0
-      en: diagonal-functor
+      en: diagonal functor
       property: symbol
       area: "category theory"
       notation: "mi Δ"
@@ -2510,7 +2510,7 @@ concepts:
     
     - concept: diagonal-intersection
       arity: 1
-      en: diagonal-intersection of $1
+      en: diagonal intersection of $1
       property: function
       area: "set theory"
       notation: "mi Δ"
@@ -2519,7 +2519,7 @@ concepts:
     
     - concept: diagonal-matrix
       arity: 1
-      en: diagonal-matrix of $1
+      en: diagonal matrix of $1
       property: function
       area: "linear algebra"
       notation: "mi diag"
@@ -2537,7 +2537,7 @@ concepts:
     
     - concept: dickman-function
       arity: 1
-      en: dickman-function of $1
+      en: dickman function of $1
       property: function
       area: "special functions"
       notation: "mi ρ"
@@ -2550,7 +2550,7 @@ concepts:
     
     - concept: different-ideal
       arity: 1
-      en: different-ideal of $1
+      en: different ideal of $1
       property: function
       area: "algebraic number theory"
       notation: "msub δ $1"
@@ -2561,7 +2561,7 @@ concepts:
     
     - concept: differential-entropy
       arity: 1
-      en: differential-entropy of $1
+      en: differential entropy of $1
       property: function
       area: "information theory"
       notation: "mi h"
@@ -2574,7 +2574,7 @@ concepts:
     
     - concept: differential-operator
       arity: 1
-      en: differential-operator of $1
+      en: differential operator of $1
       property: prefix
       area: "calculus"
       notation: "mi D<br/>mo ∂<br/>mfrac d mrow d $1"
@@ -2590,7 +2590,7 @@ concepts:
     
     - concept: digamma-function
       arity: 0
-      en: digamma-function
+      en: digamma function
       property: symbol
       area: "special functions"
       notation: "msub ψ 0<br/>msup ψ (0)<br/>mi Ϝ"
@@ -2600,7 +2600,7 @@ concepts:
     
     - concept: dihedral-group
       arity: 0
-      en: dihedral-group
+      en: dihedral group
       property: symbol
       area: "group theory"
       notation: "msub D $1<br/>msub Dih $1<br/>msub D 2$1"
@@ -2656,7 +2656,7 @@ concepts:
     
     - concept: dirac-delta-function
       arity: 1
-      en: dirac-delta-function of $1
+      en: dirac delta function of $1
       property: function
       area: "analysis"
       notation: "mi δ"
@@ -2668,7 +2668,7 @@ concepts:
     
     - concept: dirac-matrix
       arity: 0
-      en: dirac-matrix
+      en: dirac matrix
       property: constant
       area: "mathematical physics"
       notation: "msup γ 0<br/>msup γ 1<br/>msup γ 2<br/>msup γ 3"
@@ -2681,7 +2681,7 @@ concepts:
     
     - concept: dirac-measure
       arity: 1
-      en: dirac-measure of $1
+      en: dirac measure of $1
       property: function
       area: "measure theory"
       notation: "mi δ"
@@ -2690,7 +2690,7 @@ concepts:
     
     - concept: dirac-operator
       arity: 1
-      en: dirac-operator of $1
+      en: dirac operator of $1
       property: function
       area: "differential operators"
       notation: "mi D"
@@ -2701,7 +2701,7 @@ concepts:
     
     - concept: direct-limit
       arity: 1
-      en: direct-limit of $1
+      en: direct limit of $1
       property: prefix
       area: "category theory"
       notation: "munder lim →"
@@ -2712,7 +2712,7 @@ concepts:
     
     - concept: direct-product
       arity: 2
-      en: $1 direct-product $2
+      en: $1 direct product $2
       property: infix
       area: "abstract algebra"
       notation: "mo ×"
@@ -2725,7 +2725,7 @@ concepts:
     
     - concept: direct-sum
       arity: 2
-      en: $1 direct-sum $2
+      en: $1 direct sum $2
       property: infix
       area: "abstract algebra"
       notation: "mo ⊕"
@@ -2741,7 +2741,7 @@ concepts:
     
     - concept: directional-derivative
       arity: 1
-      en: directional-derivative of $1
+      en: directional derivative of $1
       property: "function<br/>mixfix"
       area: "differential calculus"
       notation: "msub ∇ v<br/>msub D v<br/>mrow v ⋅ ∇ $1"
@@ -2752,7 +2752,7 @@ concepts:
     
     - concept: dirichlet-character
       arity: 1
-      en: dirichlet-character of $1
+      en: dirichlet character of $1
       property: function
       area: "special-functions"
       notation: "mi χ"
@@ -2764,7 +2764,7 @@ concepts:
     
     - concept: dirichlet-convolution
       arity: 2
-      en: $1 dirichlet-convolution $2
+      en: $1 dirichlet convolution $2
       property: infix
       area: "number theory"
       notation: "mo ∗"
@@ -2774,7 +2774,7 @@ concepts:
     
     - concept: dirichlet-distribution
       arity: 0
-      en: dirichlet-distribution
+      en: dirichlet distribution
       property: symbol
       area: "statistics"
       notation: "mi Dir"
@@ -2785,7 +2785,7 @@ concepts:
     
     - concept: dirichlet-eta-function
       arity: 1
-      en: dirichlet-eta-function of $1
+      en: dirichlet eta function of $1
       property: function
       area: "analytic number theory"
       notation: "mi η"
@@ -2796,7 +2796,7 @@ concepts:
     
     - concept: dirichlet-kernel
       arity: 1
-      en: dirichlet-kernel of $1
+      en: dirichlet kernel of $1
       property: function
       area: "mathematical analysis"
       notation: "msub D n"
@@ -2807,7 +2807,7 @@ concepts:
     
     - concept: dirichlet-l-function
       arity: 1
-      en: dirichlet-l-function of $1
+      en: dirichlet l function of $1
       property: function
       area: "special-functions"
       notation: "mi L"
@@ -2819,7 +2819,7 @@ concepts:
     
     - concept: discrete-valuation
       arity: 1
-      en: discrete-valuation of $1
+      en: discrete valuation of $1
       property: function
       area: "commutative algebra"
       notation: "mi ν"
@@ -2841,7 +2841,7 @@ concepts:
     
     - concept: disjoint-union
       arity: 1
-      en: disjoint-union of $1
+      en: disjoint union of $1
       property: indexed
       area: "set theory"
       notation: "msup ∪ *<br/>mo ⊔"
@@ -2888,7 +2888,7 @@ concepts:
     
     - concept: divided-difference
       arity: 1
-      en: divided-difference of $1
+      en: divided difference of $1
       property: "fenced<br/>mixfix"
       area: "special functions"
       notation: "mrow [ $1, ... $n ]<br/>mrow #f [$1, ..., $n ]<br/>mrow D [ $1, ... $n ] #f"
@@ -2899,7 +2899,7 @@ concepts:
     
     - concept: divisible-by
       arity: 2
-      en: $1 divisible-by $2
+      en: $1 divisible by $2
       property: infix
       area: "number theory"
       notation: "$1 | $2<br/>$2 ⋮ $1<br/>$2 / $1"
@@ -2914,7 +2914,7 @@ concepts:
     
     - concept: divisor-function
       arity: 1
-      en: divisor-function of $1
+      en: divisor function of $1
       property: indexed
       area: "number theory"
       notation: "mi σ"
@@ -2937,7 +2937,7 @@ concepts:
     
     - concept: domain-of-discourse
       arity: 0
-      en: domain-of-discourse
+      en: domain of discourse
       property: symbol
       area: "formal semantics"
       notation: "mi 𝔻"
@@ -2948,7 +2948,7 @@ concepts:
     
     - concept: domination-number
       arity: 1
-      en: domination-number of $1
+      en: domination number of $1
       property: function
       area: "graph theory"
       notation: "mi γ"
@@ -2962,7 +2962,7 @@ concepts:
     
     - concept: dot-product
       arity: 2
-      en: $1 dot-product $2
+      en: $1 dot product $2
       property: infix
       area: "linear algebra"
       notation: "mo ⋅"
@@ -2974,7 +2974,7 @@ concepts:
     
     - concept: double-bond
       arity: 2
-      en: $1 double-bond $2
+      en: $1 double bond $2
       property: infix
       area: "chemistry"
       notation: "mo ="
@@ -2983,7 +2983,7 @@ concepts:
     
     - concept: double-category
       arity: 2
-      en: $1 double-category $2
+      en: $1 double category $2
       property: infix
       area: "category theory"
       notation: "mover → →"
@@ -2992,7 +2992,7 @@ concepts:
     
     - concept: double-factorial
       arity: 1
-      en: double-factorial of $1
+      en: double factorial of $1
       property: postfix
       area: "combinatorics"
       notation: "mo !!"
@@ -3005,7 +3005,7 @@ concepts:
     
     - concept: double-mersenne-number
       arity: 0
-      en: double-mersenne-number
+      en: double mersenne number
       property: symbol
       area: "number theory"
       notation: "msub M msub M $1"
@@ -3017,7 +3017,7 @@ concepts:
     
     - concept: drinfeld-center
       arity: 1
-      en: drinfeld-center of $1
+      en: drinfeld center of $1
       property: prefix
       area: "category theory"
       notation: "mi 𝒵"
@@ -3028,7 +3028,7 @@ concepts:
     
     - concept: dual-basis
       arity: 1
-      en: dual-basis of $1
+      en: dual basis of $1
       property: msup
       area: "linear algebra"
       notation: "msup $1 *"
@@ -3043,7 +3043,7 @@ concepts:
     
     - concept: dual-bundle
       arity: 1
-      en: dual-bundle of $1
+      en: dual bundle of $1
       property: msup
       area: "vector bundles"
       notation: "msup $1 *"
@@ -3056,7 +3056,7 @@ concepts:
     
     - concept: dual-space
       arity: 1
-      en: dual-space of $1
+      en: dual space of $1
       property: msup
       area: "linear algebra"
       notation: "msup $1 *<br/>msup $1 $1<br/>msup $1 '"
@@ -3082,7 +3082,7 @@ concepts:
     
     - concept: e-function
       arity: 1
-      en: e-function of $1
+      en: e function of $1
       property: function
       area: "special functions"
       notation: "mi E"
@@ -3105,7 +3105,7 @@ concepts:
     
     - concept: edge-cover-number
       arity: 1
-      en: edge-cover-number of $1
+      en: edge cover number of $1
       property: function
       area: "graph theory"
       notation: "mi ρ"
@@ -3115,7 +3115,7 @@ concepts:
     
     - concept: effective-domain
       arity: 1
-      en: effective-domain of $1
+      en: effective domain of $1
       property: function
       area: "convex analysis"
       notation: "mi dom"
@@ -3135,7 +3135,7 @@ concepts:
     
     - concept: einstein-tensor
       arity: 0
-      en: einstein-tensor
+      en: einstein tensor
       property: symbol
       area: "general relativity"
       notation: "mi G"
@@ -3146,7 +3146,7 @@ concepts:
     
     - concept: elliptic-function
       arity: 1
-      en: elliptic-function of $1
+      en: elliptic function of $1
       property: function
       area: "special functions"
       notation: "mi cn<br/>mi sn<br/>mi dn"
@@ -3169,7 +3169,7 @@ concepts:
     
     - concept: endomorphism-monoid
       arity: 1
-      en: endomorphism-monoid of $1
+      en: endomorphism monoid of $1
       property: function
       area: "category theory"
       notation: "mi End"
@@ -3190,7 +3190,7 @@ concepts:
     
     - concept: energy-of-signal
       arity: 0
-      en: energy-of-signal
+      en: energy of signal
       property: symbol
       area: "signal processing"
       notation: "msub E s"
@@ -3222,7 +3222,7 @@ concepts:
     
     - concept: epsilon-number
       arity: 0
-      en: epsilon-number
+      en: epsilon number
       property: symbol
       area: "ordinal numbers"
       notation: "mi ε"
@@ -3245,7 +3245,7 @@ concepts:
     
     - concept: equivalence-class
       arity: 1
-      en: equivalence-class of $1
+      en: equivalence class of $1
       property: fenced
       area: "set theory"
       notation: "mrow [ $1 ]"
@@ -3258,7 +3258,7 @@ concepts:
     
     - concept: equivalence-relation
       arity: 2
-      en: $1 equivalence-relation $2
+      en: $1 equivalence relation $2
       property: infix
       area: "set theory"
       notation: "mo ~"
@@ -3272,7 +3272,7 @@ concepts:
     
     - concept: equivariant-cohomology
       arity: 2
-      en: equivariant-cohomology
+      en: equivariant cohomology
       property: function
       area: "algebraic topology"
       notation: "msubsup H $1 $2"
@@ -3283,7 +3283,7 @@ concepts:
     
     - concept: erdos-borwein-constant
       arity: 0
-      en: erdos-borwein-constant
+      en: erdos borwein constant
       property: symbol
       area: "number theory"
       notation: "mi E"
@@ -3293,7 +3293,7 @@ concepts:
     
     - concept: error-function
       arity: 1
-      en: error-function of $1
+      en: error function of $1
       property: function
       area: "special functions"
       notation: "mi erf<br/>mi erfc<br/>mi w"
@@ -3305,7 +3305,7 @@ concepts:
     
     - concept: essential-extension
       arity: 2
-      en: $1 essential-extension $2
+      en: $1 essential extension $2
       property: infix
       area: "abstract algebra"
       notation: "msub ⊆ e<br/>mo ⊴<br/>mo ⊂"
@@ -3317,7 +3317,7 @@ concepts:
     
     - concept: essential-infimum
       arity: 1
-      en: essential-infimum of $1
+      en: essential infimum of $1
       property: function
       area: "measure theory"
       notation: "mi ess inf"
@@ -3328,7 +3328,7 @@ concepts:
     
     - concept: essential-supremum
       arity: 1
-      en: essential-supremum of $1
+      en: essential supremum of $1
       property: function
       area: "measure theory"
       notation: "mi ess sup"
@@ -3351,7 +3351,7 @@ concepts:
     
     - concept: etale-cohomology
       arity: 1
-      en: etale-cohomology of $1
+      en: etale cohomology of $1
       property: function
       area: "algebraic topology"
       notation: "msubsup H et •"
@@ -3362,7 +3362,7 @@ concepts:
     
     - concept: euclid-number
       arity: 0
-      en: euclid-number
+      en: euclid number
       property: symbol
       area: "number theory"
       notation: "msub E $1"
@@ -3372,7 +3372,7 @@ concepts:
     
     - concept: euclidean-distance
       arity: 1
-      en: euclidean-distance of $1
+      en: euclidean distance of $1
       property: function
       area: "geometry"
       notation: "mi d<br/>msub d $1"
@@ -3383,7 +3383,7 @@ concepts:
     
     - concept: euclidean-plane
       arity: 0
-      en: euclidean-plane
+      en: euclidean plane
       property: symbol
       area: "geometry"
       notation: "msup ℝ 2"
@@ -3394,7 +3394,7 @@ concepts:
     
     - concept: euler-characteristic
       arity: 1
-      en: euler-characteristic of $1
+      en: euler characteristic of $1
       property: function
       area: "algebraic topology"
       notation: "mi χ"
@@ -3406,7 +3406,7 @@ concepts:
     
     - concept: euler-class
       arity: 1
-      en: euler-class of $1
+      en: euler class of $1
       property: function
       area: "algebraic topology"
       notation: "mi e"
@@ -3417,7 +3417,7 @@ concepts:
     
     - concept: euler-constant
       arity: 0
-      en: euler-constant
+      en: euler constant
       property: symbol
       area: "analysis"
       notation: "mi γ<br/>mi 𝛾"
@@ -3432,7 +3432,7 @@ concepts:
     
     - concept: euler-number
       arity: 0
-      en: euler-number
+      en: euler number
       property: symbol
       area: "physics"
       notation: "mi Eu<br/>mi e<br/>mi 𝑒"
@@ -3449,7 +3449,7 @@ concepts:
     
     - concept: euler-polynomial
       arity: 1
-      en: euler-polynomial of $1
+      en: euler polynomial of $1
       property: function
       area: "special-functions"
       notation: "msub E $1"
@@ -3461,7 +3461,7 @@ concepts:
     
     - concept: euler-totient-function
       arity: 1
-      en: euler-totient-function of $1
+      en: euler totient function of $1
       property: function
       area: "number theory"
       notation: "mi φ<br/>mi ϕ"
@@ -3473,7 +3473,7 @@ concepts:
     
     - concept: euler-mascheroni-constant
       arity: 0
-      en: euler-mascheroni-constant
+      en: euler mascheroni constant
       property: constant
       area: "number theory"
       notation: "mi γ"
@@ -3484,7 +3484,7 @@ concepts:
     
     - concept: eulerian-number
       arity: 1
-      en: eulerian-number of $1
+      en: eulerian number of $1
       property: function
       area: "combinatorics"
       notation: "mi A"
@@ -3495,7 +3495,7 @@ concepts:
     
     - concept: exclusive-or
       arity: 2
-      en: $1 exclusive-or $2
+      en: $1 exclusive or $2
       property: infix
       area: "logic"
       notation: "mo ⊻<br/>mo ⊕<br/>mo ↮<br/>mo ≢<br/>mi XOR"
@@ -3510,7 +3510,7 @@ concepts:
     
     - concept: expectation-value
       arity: 1
-      en: expectation-value of $1
+      en: expectation value of $1
       property: fenced
       area: "quantum physics"
       notation: "mrow ⟨ $1 ⟩"
@@ -3521,7 +3521,7 @@ concepts:
     
     - concept: expected-value
       arity: 1
-      en: expected-value of $1
+      en: expected value of $1
       property: function
       area: "probability theory"
       notation: "mi E<br/>mi M<br/>msub μ $1<br/>"
@@ -3536,7 +3536,7 @@ concepts:
     
     - concept: exponential-factorial
       arity: 1
-      en: exponential-factorial of $1
+      en: exponential factorial of $1
       property: postfix
       area: "number theory"
       notation: "mo $"
@@ -3546,7 +3546,7 @@ concepts:
     
     - concept: exponential-integral
       arity: 1
-      en: exponential-integral of $1
+      en: exponential integral of $1
       property: 
       area: 
       notation: "mi Ei"
@@ -3571,7 +3571,7 @@ concepts:
     
     - concept: exterior-derivative
       arity: 1
-      en: exterior-derivative of $1
+      en: exterior derivative of $1
       property: operator
       area: "differential forms"
       notation: "mi d"
@@ -3581,7 +3581,7 @@ concepts:
     
     - concept: exterior-algebra
       arity: 1
-      en: exterior-algebra of $1
+      en: exterior algebra of $1
       property: function
       area: "multilinear algebra"
       notation: "mi Λ"
@@ -3590,7 +3590,7 @@ concepts:
     
     - concept: exterior-product
       arity: 2
-      en: $1 exterior-product $2
+      en: $1 exterior product $2
       property: infix
       area: "multilinear algebra"
       notation: "mo ∧"
@@ -3602,7 +3602,7 @@ concepts:
     
     - concept: f-distribution
       arity: 1
-      en: f-distribution of $1
+      en: f distribution of $1
       property: "indexed symbol"
       area: "probability theory"
       notation: "msub F $1"
@@ -3612,7 +3612,7 @@ concepts:
     
     - concept: faber-polynomial
       arity: 1
-      en: faber-polynomial of $1
+      en: faber polynomial of $1
       property: function
       area: "polynomials"
       notation: "msub P m"
@@ -3623,7 +3623,7 @@ concepts:
     
     - concept: falling-factorial
       arity: 2
-      en: falling-factorial
+      en: falling factorial
       property: mixfix
       area: "combinatorics"
       notation: "msup $1 mover $2 ¯<br/>msup $1 munder $2 ¯<br/>msub mrow ( $1 ) /mrow $2"
@@ -3639,7 +3639,7 @@ concepts:
     
     - concept: fatou-set
       arity: 1
-      en: fatou-set of $1
+      en: fatou set of $1
       property: function
       area: "complex dynamics"
       notation: "mi F"
@@ -3648,7 +3648,7 @@ concepts:
     
     - concept: farey-sequence
       arity: 0
-      en: farey-sequence
+      en: farey sequence
       property: symbol
       area: "number theory"
       notation: "mi F"
@@ -3658,7 +3658,7 @@ concepts:
     
     - concept: feferman-schutte-ordinal
       arity: 0
-      en: feferman-schutte-ordinal
+      en: feferman schutte ordinal
       property: symbol
       area: "ordinal numbers"
       notation: "msub Γ 0"
@@ -3667,7 +3667,7 @@ concepts:
     
     - concept: feigenbaum-constant
       arity: 0
-      en: feigenbaum-constant
+      en: feigenbaum constant
       property: symbol
       area: "chaos theory"
       notation: "mi δ"
@@ -3677,7 +3677,7 @@ concepts:
     
     - concept: fermat-number
       arity: 1
-      en: fermat-number of $1
+      en: fermat number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub F $1"
@@ -3687,7 +3687,7 @@ concepts:
     
     - concept: fermat-quotient
       arity: 1
-      en: fermat-quotient of $1
+      en: fermat quotient of $1
       property: function
       area: "number theory"
       notation: "msub q $1"
@@ -3697,7 +3697,7 @@ concepts:
     
     - concept: fermi-dirac-distribution
       arity: 1
-      en: fermi-dirac-distribution of $1
+      en: fermi dirac distribution of $1
       property: function
       area: "quantum statistics"
       notation: "mover n ¯"
@@ -3709,7 +3709,7 @@ concepts:
     
     - concept: feynman-slash
       arity: 1
-      en: feynman-slash of $1
+      en: feynman slash of $1
       property: menclose
       area: "quantum field theory"
       notation: "menclose notation=updiagonalstrike $1"
@@ -3718,7 +3718,7 @@ concepts:
     
     - concept: fibonacci-number
       arity: 1
-      en: fibonacci-number of $1
+      en: fibonacci number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub F $1"
@@ -3731,7 +3731,7 @@ concepts:
     
     - concept: fibonacci-polynomial
       arity: 1
-      en: fibonacci-polynomial of $1
+      en: fibonacci polynomial of $1
       property: "indexed function"
       area: "polynomials"
       notation: "msub F $1"
@@ -3742,7 +3742,7 @@ concepts:
     
     - concept: fibre-product
       arity: 1
-      en: fibre-product of $1
+      en: fibre product of $1
       property: indexed infix
       area: "category theory"
       notation: "msub × $1"
@@ -3756,7 +3756,7 @@ concepts:
     
     - concept: field-extension
       arity: 2
-      en: $1 field-extension $2
+      en: $1 field extension $2
       property: infix
       area: "algebra"
       notation: "mo /"
@@ -3768,7 +3768,7 @@ concepts:
     
     - concept: field-of-sets
       arity: 2
-      en: field-of-sets
+      en: field of sets
       property: fenced
       area: "boolean algebra"
       notation: "⟨$1, $2⟩"
@@ -3778,7 +3778,7 @@ concepts:
     
     - concept: first-isogonic-center
       arity: 0
-      en: first-isogonic-center
+      en: first isogonic center
       property: symbol
       area: "geometry"
       notation: "mrow X(13"
@@ -3787,7 +3787,7 @@ concepts:
     
     - concept: fisher-information
       arity: 1
-      en: fisher-information of $1
+      en: fisher information of $1
       property: function
       area: "statistics"
       notation: "mi I"
@@ -3823,7 +3823,7 @@ concepts:
     
     - concept: fock-space
       arity: 1
-      en: fock-space of $1
+      en: fock space of $1
       property: function
       area: "quantum mechanics"
       notation: "mi F"
@@ -3834,7 +3834,7 @@ concepts:
     
     - concept: forward-difference
       arity: 3
-      en: $1 th forward-difference of $3 over $2
+      en: $1 th forward difference of $3 over $2
       property: operator
       area: "numerical analysis"
       comment: "<math><msubsup><mi>&Delta;</mi><mi>x</mi><mi>n</mi></msubsup><mrow>mi<>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
@@ -3844,7 +3844,7 @@ concepts:
     
     - concept: fourier-cosine-transform
       arity: 1
-      en: fourier-cosine-transform of $1
+      en: fourier cosine transform of $1
       property: operator
       area: "functional analysis"
       notation: "msub ℱ c"
@@ -3855,7 +3855,7 @@ concepts:
     
     - concept: fourier-sine-transform
       arity: 1
-      en: fourier-sine-transform of $1
+      en: fourier sine transform of $1
       property: operator
       area: "functional analysis"
       notation: "msub ℱ s"
@@ -3866,7 +3866,7 @@ concepts:
     
     - concept: fourier-transform
       arity: 1
-      en: fourier-transform of $1
+      en: fourier transform of $1
       property: mover
       area: "fourier analysis"
       notation: "mover $1 ^"
@@ -3880,7 +3880,7 @@ concepts:
     
     - concept: fox-derivative
       arity: 1
-      en: fox-derivative of $1
+      en: fox derivative of $1
       property: mfrac
       area: "geometric topology"
       notation: "mfrac ∂..."
@@ -3891,7 +3891,7 @@ concepts:
     
     - concept: fox-wright-function
       arity: 1
-      en: fox-wright-function of $1
+      en: fox wright function of $1
       property: mmultiscripts
       area: "special functions"
       notation: "mmultiscripts Ψ q none mprescripts p none"
@@ -3902,7 +3902,7 @@ concepts:
     
     - concept: fractional-derivative
       arity: 1
-      en: fractional-derivative of $1
+      en: fractional derivative of $1
       property: operator
       area: "fractional caclulus"
       notation: "msup D $1"
@@ -3912,7 +3912,7 @@ concepts:
     
     - concept: fractional-integral
       arity: 1
-      en: fractional-integral of $1
+      en: fractional integral of $1
       property: operator
       area: "fractional caclulus"
       notation: "msup I $1"
@@ -3923,7 +3923,7 @@ concepts:
     
     - concept: fractional-part
       arity: 1
-      en: fractional-part of $1
+      en: fractional part of $1
       property: "function<br/>fenced"
       area: "arithmetic"
       notation: "mi frac<br/>mrow ⟦ $1 ⟧<br/>mrow { $1 }"
@@ -3937,7 +3937,7 @@ concepts:
     
     - concept: franel-number
       arity: 1
-      en: franel-number of $1
+      en: franel number of $1
       property: "indexed symbol"
       area: "combinatorics"
       notation: "mi Fr"
@@ -3946,7 +3946,7 @@ concepts:
     
     - concept: frattini-subgroup
       arity: 1
-      en: frattini-subgroup of $1
+      en: frattini subgroup of $1
       property: function
       area: "group theory"
       notation: "mi φ<br/>mi ϕ"
@@ -3957,7 +3957,7 @@ concepts:
     
     - concept: frechet-derivative
       arity: 1
-      en: frechet-derivative of $1
+      en: frechet derivative of $1
       property: operator
       area: "banach spaces"
       notation: "mi D"
@@ -3969,7 +3969,7 @@ concepts:
     
     - concept: frechet-topology
       arity: 0
-      en: frechet-topology
+      en: frechet topology
       property: constant
       area: "topology"
       notation: "msub T 1"
@@ -3981,7 +3981,7 @@ concepts:
     
     - concept: fredholm-determinant
       arity: 1
-      en: fredholm-determinant of $1
+      en: fredholm determinant of $1
       property: function
       area: "mathematical physics"
       notation: "mi det"
@@ -3992,7 +3992,7 @@ concepts:
     
     - concept: free-algebra
       arity: 2
-      en: free-algebra
+      en: free algebra
       property: mixfix
       area: "ring theory"
       notation: "mrow $1⟨$2⟩"
@@ -4003,7 +4003,7 @@ concepts:
     
     - concept: free-module
       arity: 2
-      en: free-module
+      en: free module
       property: mixfix<br/>msup
       area: "module theory"
       notation: "mrow $1 { $2 }<br/>msup $1 ($2"
@@ -4015,7 +4015,7 @@ concepts:
     
     - concept: free-monoid
       arity: 1
-      en: free-monoid of $1
+      en: free monoid of $1
       property: msup
       area: "abstract algebra"
       notation: "msup $1 *"
@@ -4026,7 +4026,7 @@ concepts:
     
     - concept: free-product
       arity: 2
-      en: $1 free-product $2
+      en: $1 free product $2
       property: infix
       area: "group theory"
       notation: "mo *"
@@ -4037,7 +4037,7 @@ concepts:
     
     - concept: fresnel-integral
       arity: 1
-      en: fresnel-integral of $1
+      en: fresnel integral of $1
       property: operator
       area: "special functions"
       notation: "mi ℱ<br/>mi C<br/>mi S"
@@ -4052,7 +4052,7 @@ concepts:
     
     - concept: frobenius-norm
       arity: 1
-      en: frobenius-norm of $1
+      en: frobenius norm of $1
       property: indexed fenced
       area: "linear algebra"
       notation: "msub mrow | $1 F"
@@ -4065,7 +4065,7 @@ concepts:
     
     - concept: frolicher-nijenhuis-bracket
       arity: 2
-      en: frolicher-nijenhuis-bracket
+      en: frolicher nijenhuis bracket
       property: fenced
       area: "differntial geometry"
       notation: "mrow [ $1 , $2 ]"
@@ -4075,7 +4075,7 @@ concepts:
     
     - concept: functional-congruence
       arity: 3
-      en: functional-congruence of $1 and $2 mod $3
+      en: functional congruence of $1 and $2 mod $3
       property: mixfix
       area: "number theory"
       notation: "mrow $1 ≡ $2 (mod $3"
@@ -4086,7 +4086,7 @@ concepts:
     
     - concept: functor-category
       arity: 2
-      en: functor-category
+      en: functor category
       property: msup<br/>fenced
       area: "category theory"
       notation: "msup $1 $2<br/>mrow [$1, $2]"
@@ -4096,7 +4096,7 @@ concepts:
     
     - concept: fundamental-matrix
       arity: 0
-      en: fundamental-matrix
+      en: fundamental matrix
       property: symbol
       area: "computer vision"
       notation: "mi F"
@@ -4105,7 +4105,7 @@ concepts:
     
     - concept: g-function
       arity: 1
-      en: g-function of $1
+      en: g function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi G"
@@ -4117,7 +4117,7 @@ concepts:
     
     - concept: gabor-transform
       arity: 1
-      en: gabor-transform of $1
+      en: gabor transform of $1
       property: operator
       area: "integral transforms"
       notation: "mi G"
@@ -4128,7 +4128,7 @@ concepts:
     
     - concept: gain-function
       arity: 1
-      en: gain-function of $1
+      en: gain function of $1
       property: function
       area: "graph theory"
       notation: "mi φ"
@@ -4139,7 +4139,7 @@ concepts:
     
     - concept: galilean-transformation
       arity: 1
-      en: galilean-transformation of $1
+      en: galilean transformation of $1
       property: function
       area: "physics"
       notation: "mi G"
@@ -4150,7 +4150,7 @@ concepts:
     
     - concept: galois-field
       arity: 1
-      en: galois-field of $1
+      en: galois field of $1
       property: function
       area: "finite fields"
       notation: "mrow GF ($1)<br/>msub F $1<br/>msub 𝔽 $1"
@@ -4163,7 +4163,7 @@ concepts:
     
     - concept: galois-group
       arity: 1
-      en: galois-group of $1
+      en: galois group of $1
       property: function
       area: "abstract algebra"
       notation: "mi Gal"
@@ -4175,7 +4175,7 @@ concepts:
     
     - concept: gamma-distribution
       arity: 0
-      en: gamma-distribution
+      en: gamma distribution
       property: symbol
       area: "probability theory"
       notation: "mi Γ"
@@ -4185,7 +4185,7 @@ concepts:
     
     - concept: gamma-function
       arity: 1
-      en: gamma-function of $1
+      en: gamma function of $1
       property: operator
       area: "special functions"
       notation: "mi Γ"
@@ -4201,7 +4201,7 @@ concepts:
     
     - concept: gateaux-derivative
       arity: 3
-      en: gateaux-derivative of $1 at $2 ; £3
+      en: gateaux derivative of $1 at $2 ; £3
       property: mixfix
       area: "differential calculus"
       notation: "mrow d$1($2; $3"
@@ -4224,7 +4224,7 @@ concepts:
     
     - concept: gaussian-distribution
       arity: 0
-      en: gaussian-distribution
+      en: gaussian distribution
       property: symbol
       area: "probability theory"
       notation: "mi 𝒩"
@@ -4237,7 +4237,7 @@ concepts:
     
     - concept: gaussian-curvature
       arity: 1
-      en: gaussian-curvature of $1
+      en: gaussian curvature of $1
       property: function
       area: "differential geometry"
       notation: "mi Κ"
@@ -4248,7 +4248,7 @@ concepts:
     
     - concept: gaussian-integers
       arity: 0
-      en: gaussian-integers
+      en: gaussian integers
       property: constant
       area: "number theory"
       notation: "mrow ℤ [i]"
@@ -4259,7 +4259,7 @@ concepts:
     
     - concept: gegenbauer-polynomial
       arity: 2
-      en: gegenbauer-polynomial
+      en: gegenbauer polynomial
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "msubsup C $1 ($2"
@@ -4271,7 +4271,7 @@ concepts:
     
     - concept: gelfand-triple
       arity: 3
-      en: gelfand-triple of $1, $2 and $3
+      en: gelfand triple of $1, $2 and $3
       property: fenced
       area: "functional analysis"
       notation: "mrow ( $1, $2, $3"
@@ -4280,7 +4280,7 @@ concepts:
     
     - concept: gelfond-constant
       arity: 0
-      en: gelfond-constant
+      en: gelfond constant
       property: constant
       area: "transcendental constants"
       notation: "msup e π"
@@ -4290,7 +4290,7 @@ concepts:
     
     - concept: gelfond-schneider-constant
       arity: 0
-      en: gelfond-schneider-constant
+      en: gelfond schneider constant
       property: constant
       area: "transcendental constants"
       notation: "msup 2 msqrt 2"
@@ -4300,7 +4300,7 @@ concepts:
     
     - concept: gell-mann-matrix
       arity: 0
-      en: gell-mann-matrix
+      en: gell mann matrix
       property: symbol
       area: "particle physics"
       notation: "mi λ"
@@ -4311,7 +4311,7 @@ concepts:
     
     - concept: general-linear-group
       arity: 1
-      en: general-linear-group of $1
+      en: general linear group of $1
       property: function
       area: "group theory"
       notation: "mi GL<br/>mi Aut"
@@ -4324,7 +4324,7 @@ concepts:
     
     - concept: generalized-hypergeometric-function
       arity: 1
-      en: generalized-hypergeometric-function of $1
+      en: generalized hypergeometric function of $1
       property: mmultiscripts
       area: "special functions"
       notation: "mmultiscripts F q none mprescripts p none"
@@ -4343,7 +4343,7 @@ concepts:
     
     - concept: generalized-mean
       arity: 1
-      en: generalized-mean of $1
+      en: generalized mean of $1
       property: function
       area: "means"
       notation: "msub M $1"
@@ -4357,7 +4357,7 @@ concepts:
     
     - concept: genocchi-number
       arity: 0
-      en: genocchi-number
+      en: genocchi number
       property: symbol
       area: "integer sequences"
       notation: "msub G $1"
@@ -4369,7 +4369,7 @@ concepts:
     
     - concept: geodesic-curvature
       arity: 0
-      en: geodesic-curvature
+      en: geodesic curvature
       property: symbol
       area: "riemannian geometry"
       notation: "msub k g"
@@ -4380,7 +4380,7 @@ concepts:
     
     - concept: geodesic-distance
       arity: 1
-      en: geodesic-distance of $1
+      en: geodesic distance of $1
       property: function
       area: "graph theory"
       notation: "mi d"
@@ -4394,7 +4394,7 @@ concepts:
     
     - concept: geometric-genus
       arity: 1
-      en: geometric-genus of $1
+      en: geometric genus of $1
       property: function
       area: "algebraic geometry"
       notation: "msub p g"
@@ -4405,7 +4405,7 @@ concepts:
     
     - concept: geometric-integral
       arity: 1
-      en: geometric-integral of $1
+      en: geometric integral of $1
       property: indexed
       area: "calculus"
       notation: "mo Π"
@@ -4414,7 +4414,7 @@ concepts:
     
     - concept: geometric-mean
       arity: 1
-      en: geometric-mean of $1
+      en: geometric mean of $1
       property: function
       area: "means"
       notation: "mi GM"
@@ -4425,7 +4425,7 @@ concepts:
     
     - concept: geometric-product
       arity: 2
-      en: $1 geometric-product $2
+      en: $1 geometric product $2
       property: infix
       area: "geometric algebra"
       notation: "mo invisible times"
@@ -4445,7 +4445,7 @@ concepts:
     
     - concept: glaisher-constant
       arity: 0
-      en: glaisher-constant
+      en: glaisher constant
       property: constant
       area: "number theory"
       notation: "mi A"
@@ -4458,7 +4458,7 @@ concepts:
     
     - concept: global-dimension
       arity: 1
-      en: global-dimension of $1
+      en: global dimension of $1
       property: function
       area: "ring theory"
       notation: "mi gl dim"
@@ -4470,7 +4470,7 @@ concepts:
     
     - concept: golden-ratio
       arity: 0
-      en: golden-ratio
+      en: golden ratio
       property: constant
       area: "geometry"
       notation: "mi φ<br/>mi ϕ"
@@ -4492,7 +4492,7 @@ concepts:
     
     - concept: graham-number
       arity: 0
-      en: graham-number
+      en: graham number
       property: constant
       area: "ramsey theory"
       notation: "msub g 64"
@@ -4502,7 +4502,7 @@ concepts:
     
     - concept: gram-determinant
       arity: 1
-      en: gram-determinant of $1
+      en: gram determinant of $1
       property: function
       area: "linear algebra"
       notation: "mi G<br/>mi Γ"
@@ -4512,7 +4512,7 @@ concepts:
     
     - concept: gram-matrix
       arity: 0
-      en: gram-matrix
+      en: gram matrix
       property: symbol
       area: "linear algebra"
       notation: "mi G"
@@ -4537,7 +4537,7 @@ concepts:
     
     - concept: green-function
       arity: 1
-      en: green-function of $1
+      en: green function of $1
       property: function
       area: "mathematical physics"
       notation: "mi G"
@@ -4550,7 +4550,7 @@ concepts:
     
     - concept: grobner-basis
       arity: 0
-      en: grobner-basis
+      en: grobner basis
       property: symbol
       area: "computer algebra"
       notation: "mi G"
@@ -4561,7 +4561,7 @@ concepts:
     
     - concept: group-algebra
       arity: 2
-      en: group-algebra
+      en: group algebra
       property: mixfix
       area: "ring theory"
       notation: "mrow $1[$2]<br/>mrow $1$2"
@@ -4573,7 +4573,7 @@ concepts:
     
     - concept: group-of-units
       arity: 1
-      en: group-of-units of $1
+      en: group of units of $1
       property: msup<br/>function
       area: "ring theory"
       notation: "msup $1 *<br/>msup $1 ×<br/>mi U"
@@ -4583,7 +4583,7 @@ concepts:
     
     - concept: group-ring
       arity: 2
-      en: group-ring
+      en: group ring
       property: mixfix<br/>infix
       area: "ring theory"
       notation: "mrow $1 [ $2 ]<br/>mrow $1 $2"
@@ -4593,7 +4593,7 @@ concepts:
     
     - concept: gudermannian-function
       arity: 1
-      en: gudermannian-function of $1
+      en: gudermannian function of $1
       property: function
       area: "trigonometry"
       notation: "mi gd"
@@ -4606,7 +4606,7 @@ concepts:
     
     - concept: hadamard-product
       arity: 2
-      en: $1 hadamard-product $2
+      en: $1 hadamard product $2
       property: infix
       area: "algebra"
       notation: "mo ∘<br/>mo ⊙"
@@ -4621,7 +4621,7 @@ concepts:
     
     - concept: hahn-polynomial
       arity: 1
-      en: hahn-polynomial of $1
+      en: hahn polynomial of $1
       property: function
       area: "orthogonal polynomials"
       notation: "msub q $1"
@@ -4645,7 +4645,7 @@ concepts:
     
     - concept: hankel-function
       arity: 1
-      en: hankel-function of $1
+      en: hankel function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi H"
@@ -4656,7 +4656,7 @@ concepts:
     
     - concept: hardy-class
       arity: 1
-      en: hardy-class of $1
+      en: hardy class of $1
       property: "indexed symbol"
       area: "complex analysis"
       notation: "msup H $1"
@@ -4668,7 +4668,7 @@ concepts:
     
     - concept: hardy-space
       arity: 1
-      en: hardy-space of $1
+      en: hardy space of $1
       property: mixfix
       area: "complex analysis"
       notation: "msup H p ($1"
@@ -4679,7 +4679,7 @@ concepts:
     
     - concept: hardy-littlewood-maximal-operator
       arity: 1
-      en: hardy-littlewood-maximal-operator of $1
+      en: hardy littlewood maximal operator of $1
       property: operator
       area: "real analysis"
       notation: "mi M"
@@ -4690,7 +4690,7 @@ concepts:
     
     - concept: harmonic-mean
       arity: 1
-      en: harmonic-mean of $1
+      en: harmonic mean of $1
       property: function
       area: "means"
       notation: "mi H"
@@ -4703,7 +4703,7 @@ concepts:
     
     - concept: hausdorff-measure
       arity: 1
-      en: hausdorff-measure of $1
+      en: hausdorff measure of $1
       property: "indexed function"
       area: "metric geometry"
       notation: "msup H $1"
@@ -4713,7 +4713,7 @@ concepts:
     
     - concept: hausdorff-metric
       arity: 1
-      en: hausdorff-metric of $1
+      en: hausdorff metric of $1
       property: function
       area: "metric geometry"
       notation: "msub d H"
@@ -4723,7 +4723,7 @@ concepts:
     
     - concept: hausdorff-space
       arity: 0
-      en: hausdorff-space
+      en: hausdorff space
       property: constant
       area: "topology"
       notation: "msub T 2"
@@ -4734,7 +4734,7 @@ concepts:
     
     - concept: hazard-function
       arity: 1
-      en: hazard-function of $1
+      en: hazard function of $1
       property: function
       area: "engineering"
       notation: "mi h"
@@ -4745,7 +4745,7 @@ concepts:
     
     - concept: heaviside-function
       arity: 1
-      en: heaviside-function of $1
+      en: heaviside function of $1
       property: function
       area: "special functions"
       notation: "mi H"
@@ -4759,7 +4759,7 @@ concepts:
     
     - concept: heawood-number
       arity: 1
-      en: heawood-number of $1
+      en: heawood number of $1
       property: function
       area: "topological graph theory"
       notation: "mi H"
@@ -4768,7 +4768,7 @@ concepts:
     
     - concept: hecke-operator
       arity: 1
-      en: hecke-operator of $1
+      en: hecke operator of $1
       property: operator
       area: "modular forms"
       notation: "msub T $1"
@@ -4778,7 +4778,7 @@ concepts:
     
     - concept: height-function
       arity: 1
-      en: height-function of $1
+      en: height function of $1
       property: function
       area: "algebra"
       notation: "mi H<br/>mi h"
@@ -4787,7 +4787,7 @@ concepts:
     
     - concept: height-of-abelian-group
       arity: 1
-      en: height-of-abelian-group of $1
+      en: height of abelian group of $1
       property: function
       area: "group theory"
       notation: "msub h $1"
@@ -4796,7 +4796,7 @@ concepts:
     
     - concept: height-of-prime-ideal
       arity: 1
-      en: height-of-prime-ideal of $1
+      en: height of prime ideal of $1
       property: function
       area: "commutative algebra"
       notation: "mi ht"
@@ -4809,7 +4809,7 @@ concepts:
     
     - concept: heisenberg-group
       arity: 0
-      en: heisenberg-group
+      en: heisenberg group
       property: symbol
       area: "group theory"
       notation: "mi H"
@@ -4820,7 +4820,7 @@ concepts:
     
     - concept: hermite-polynomial
       arity: 1
-      en: hermite-polynomial of $1
+      en: hermite polynomial of $1
       property: function
       area: "special functions"
       notation: "mi H<br/>mi He"
@@ -4833,7 +4833,7 @@ concepts:
     
     - concept: hermitian-adjoint
       arity: 1
-      en: hermitian-adjoint of $1
+      en: hermitian adjoint of $1
       property: msup
       area: "functional analysis"
       notation: "msup †,<br/>msup *"
@@ -4844,7 +4844,7 @@ concepts:
     
     - concept: hermitian-conjugate
       arity: 1
-      en: hermitian-conjugate of $1
+      en: hermitian conjugate of $1
       property: msup
       area: "linear algebra"
       notation: "msup H"
@@ -4856,7 +4856,7 @@ concepts:
     
     - concept: heronian-mean
       arity: 1
-      en: heronian-mean of $1
+      en: heronian mean of $1
       property: function
       area: "means"
       notation: "mi H"
@@ -4879,7 +4879,7 @@ concepts:
     
     - concept: heun-function
       arity: 1
-      en: heun-function of $1
+      en: heun function of $1
       property: function
       area: "special functions"
       notation: "mi Hf<br/>mi H⁢ℓ"
@@ -4891,7 +4891,7 @@ concepts:
     
     - concept: heun-polynomial
       arity: 1
-      en: heun-polynomial of $1
+      en: heun polynomial of $1
       property: function
       area: "special functions"
       notation: "mi Hp"
@@ -4912,7 +4912,7 @@ concepts:
     
     - concept: hilbert-symbol
       arity: 2
-      en: hilbert-symbol
+      en: hilbert symbol
       property: fenced
       area: "quadratic forms"
       notation: "mrow ( $1, $2"
@@ -4922,7 +4922,7 @@ concepts:
     
     - concept: hilbert-schmidt-norm
       arity: 1
-      en: hilbert-schmidt-norm of $1
+      en: hilbert schmidt norm of $1
       property: fenced
       area: "matrix norms"
       notation: "msub mrow | $1 | HS"
@@ -4934,7 +4934,7 @@ concepts:
     
     - concept: hit-or-miss-transform
       arity: 2
-      en: $1 hit-or-miss-transform $2
+      en: $1 hit or miss transform $2
       property: infix
       area: "mathematical morphology"
       notation: "mo ⊙"
@@ -4943,7 +4943,7 @@ concepts:
     
     - concept: hodge-star-operator
       arity: 1
-      en: hodge-star-operator of $1
+      en: hodge star operator of $1
       property: prefix
       area: "differential geometry"
       notation: "mo ⋆"
@@ -4963,7 +4963,7 @@ concepts:
     
     - concept: holonomy-group
       arity: 1
-      en: holonomy-group of $1
+      en: holonomy group of $1
       property: "indexed symbol"
       area: "differential geometry"
       notation: "mi Hol"
@@ -4974,7 +4974,7 @@ concepts:
     
     - concept: home-prime
       arity: 1
-      en: home-prime of $1
+      en: home prime of $1
       property: function
       area: "number theory"
       notation: "mi HP"
@@ -4984,7 +4984,7 @@ concepts:
     
     - concept: homology-group
       arity: 1
-      en: homology-group of $1
+      en: homology group of $1
       property: function
       area: "homology theory"
       notation: "msub H $1"
@@ -4994,7 +4994,7 @@ concepts:
     
     - concept: homomorphic-product
       arity: 2
-      en: $1 homomorphic-product $2
+      en: $1 homomorphic product $2
       property: infix
       area: "graph theory"
       notation: "mo ⋉"
@@ -5004,7 +5004,7 @@ concepts:
     
     - concept: homotopy-category
       arity: 1
-      en: homotopy-category of $1
+      en: homotopy category of $1
       property: function
       area: "category theory"
       notation: "mi Ho"
@@ -5013,7 +5013,7 @@ concepts:
     
     - concept: horsepower-mechanical
       arity: 1
-      en: horsepower-mechanical of $1
+      en: horsepower mechanical of $1
       property: unit
       area: "imperial unit"
       notation: "mi hp"
@@ -5024,7 +5024,7 @@ concepts:
     
     - concept: horsepower-metric
       arity: 1
-      en: horsepower-metric of $1
+      en: horsepower metric of $1
       property: unit
       area: "metric unit"
       notation: "mi PS<br/>mi cv<br/>mi hk<br/>mi pk<br/>mi ks<br/>mi ch"
@@ -5035,7 +5035,7 @@ concepts:
     
     - concept: hurwitz-zeta-function
       arity: 1
-      en: hurwitz-zeta-function of $1
+      en: hurwitz zeta function of $1
       property: function
       area: "special functions"
       notation: "mi ζ"
@@ -5059,7 +5059,7 @@ concepts:
     
     - concept: hydrated-compound
       arity: 2
-      en: $1 hydrated-compound $2
+      en: $1 hydrated compound $2
       property: infix
       area: "chemistry"
       notation: "mo ⋅<br/>mo •"
@@ -5070,7 +5070,7 @@ concepts:
     
     - concept: hyperbolic-cosine-integral
       arity: 1
-      en: hyperbolic-cosine-integral of $1
+      en: hyperbolic cosine integral of $1
       property: function
       area: "special functions"
       notation: "mi Chi"
@@ -5080,7 +5080,7 @@ concepts:
     
     - concept: hyperbolic-plane
       arity: 0
-      en: hyperbolic-plane
+      en: hyperbolic plane
       property: symbol
       area: "non-euclidean geometry"
       notation: "msup ℍ 2"
@@ -5090,7 +5090,7 @@ concepts:
     
     - concept: hyperbolic-sine-integral
       arity: 1
-      en: hyperbolic-sine-integral of $1
+      en: hyperbolic sine integral of $1
       property: function
       area: "special functions"
       notation: "mi Shi"
@@ -5100,7 +5100,7 @@ concepts:
     
     - concept: hyperbolic-space
       arity: 0
-      en: hyperbolic-space
+      en: hyperbolic space
       property: symbol
       area: "non-euclidean geometry"
       notation: "msupH$1"
@@ -5110,7 +5110,7 @@ concepts:
     
     - concept: hyperbolic-umbilic-canonical-integral-function
       arity: 1
-      en: hyperbolic-umbilic-canonical-integral-function of $1
+      en: hyperbolic umbilic canonical integral function of $1
       property: function
       area: "special functions"
       notation: "mrow Ψ sup (E"
@@ -5144,7 +5144,7 @@ concepts:
     
     - concept: identity-element
       arity: 0
-      en: identity-element
+      en: identity element
       property: symbol
       area: "group theory"
       notation: "mi e<br/>mi I<br/>mi E<br/>mn 1"
@@ -5158,7 +5158,7 @@ concepts:
     
     - concept: identity-function
       arity: 1
-      en: identity-function of $1
+      en: identity function of $1
       property: function
       area: "algebra"
       notation: "mi id<br/>msub id $1<br/>msub I $1"
@@ -5173,7 +5173,7 @@ concepts:
     
     - concept: identity-functor
       arity: 1
-      en: identity-functor of $1
+      en: identity functor of $1
       property: function
       area: "category theory"
       notation: "msub 1 $1<br/>msubI$1<br/>msub Id $1"
@@ -5183,7 +5183,7 @@ concepts:
     
     - concept: identity-matrix
       arity: 0
-      en: identity-matrix
+      en: identity matrix
       property: symbol
       area: "linear algebra"
       notation: "mi I"
@@ -5221,7 +5221,7 @@ concepts:
     
     - concept: incidence-relation
       arity: 2
-      en: $1 incidence-relation $2
+      en: $1 incidence relation $2
       property: infix
       area: "projective geometry"
       notation: "mi I"
@@ -5232,7 +5232,7 @@ concepts:
     
     - concept: incidence-structure
       arity: 3
-      en: incidence-structure of $1, $2 and $3
+      en: incidence structure of $1, $2 and $3
       property: fenced
       area: "incidence geometry"
       notation: "mrow ( $1, $2, $3"
@@ -5241,7 +5241,7 @@ concepts:
     
     - concept: inclusion-map
       arity: 1
-      en: inclusion-map of $1
+      en: inclusion map of $1
       property: function
       area: "set theory"
       notation: "mi ι"
@@ -5265,7 +5265,7 @@ concepts:
     
     - concept: incomplete-beta-function
       arity: 1
-      en: incomplete-beta-function of $1
+      en: incomplete beta function of $1
       property: function
       area: "special functions"
       notation: "mi B"
@@ -5277,7 +5277,7 @@ concepts:
     
     - concept: incomplete-elliptic-integral-of-the-first-kind
       arity: 1
-      en: incomplete-elliptic-integral-of-the-first-kind of $1
+      en: incomplete elliptic integral of the first kind of $1
       property: function
       area: "elliptic functions"
       notation: "mi F"
@@ -5288,7 +5288,7 @@ concepts:
     
     - concept: incomplete-elliptic-integral-of-the-second-kind
       arity: 1
-      en: incomplete-elliptic-integral-of-the-second-kind of $1
+      en: incomplete elliptic integral of the second kind of $1
       property: function
       area: "elliptic functions"
       notation: "mi E"
@@ -5299,7 +5299,7 @@ concepts:
     
     - concept: incomplete-gamma-function
       arity: 1
-      en: incomplete-gamma-function of $1
+      en: incomplete gamma function of $1
       property: function
       area: "special functions"
       notation: "mi Γ"
@@ -5323,7 +5323,7 @@ concepts:
     
     - concept: increase-tends-to?
       arity: 2
-      en: $1 increase-tends-to? $2
+      en: $1 increase tends to? $2
       property: infix
       area: "calculus"
       notation: "mo ↗"
@@ -5344,7 +5344,7 @@ concepts:
     
     - concept: index-of-subgroup
       arity: 2
-      en: index-of-subgroup
+      en: index of subgroup
       property: fenced
       area: "group theory"
       notation: "mrow [ $1 : $2 ]<br/>mrow ( $1 : $2 )<br/>mrow |$1 : $2 |"
@@ -5353,7 +5353,7 @@ concepts:
     
     - concept: index-of-lie-algebra
       arity: 1
-      en: index-of-lie-algebra of $1
+      en: index of lie algebra of $1
       property: function
       area: "lie algebra"
       notation: "mi ind"
@@ -5375,7 +5375,7 @@ concepts:
     
     - concept: infimum-limit
       arity: 1
-      en: infimum-limit of $1
+      en: infimum limit of $1
       property: indexed
       area: "limits"
       notation: "mi lim inf<br/>munder lim ¯"
@@ -5392,7 +5392,7 @@ concepts:
     
     - concept: infinite-product
       arity: 1
-      en: infinite-product of $1
+      en: infinite product of $1
       property: indexed
       area: "mathematical analysis"
       notation: "munderover Π $1∞"
@@ -5403,7 +5403,7 @@ concepts:
     
     - concept: infinitely-many-concurrently-active-copies
       arity: 1
-      en: infinitely-many-concurrently-active-copies of $1
+      en: infinitely many concurrently active copies of $1
       property: prefix
       area: "formal languages"
       notation: "mo !"
@@ -5421,7 +5421,7 @@ concepts:
     
     - concept: inner-automorphism-group
       arity: 1
-      en: inner-automorphism-group of $1
+      en: inner automorphism group of $1
       property: function
       area: "abstract algebra"
       notation: "mi Inn"
@@ -5435,7 +5435,7 @@ concepts:
     
     - concept: inner-jordan-measure
       arity: 1
-      en: inner-jordan-measure of $1
+      en: inner jordan measure of $1
       property: function
       area: "measure theory"
       notation: "msub m *"
@@ -5446,7 +5446,7 @@ concepts:
     
     - concept: inner-product
       arity: 2
-      en: $1 inner-product $2
+      en: $1 inner product $2
       property: infix<br/>fenced
       area: "linear algebra"
       notation: "mo ⋅<br/>mrow [ $1, $2 ]"
@@ -5459,7 +5459,7 @@ concepts:
     
     - concept: instantaneous-activity
       arity: 2
-      en: instantaneous-activity
+      en: instantaneous activity
       property: mixfix
       area: "chemistry"
       notation: "msub mrow { $1 } /mrow $2"
@@ -5468,7 +5468,7 @@ concepts:
     
     - concept: integer-part
       arity: 1
-      en: integer-part of $1
+      en: integer part of $1
       property: "function<br/>fenced"
       area: "number theory"
       notation: "mi int<br/>[ $1 ]"
@@ -5490,7 +5490,7 @@ concepts:
     
     - concept: interior-product
       arity: 1
-      en: interior-product of $1
+      en: interior product of $1
       property: "infix<br/>indexed function"
       area: "differential forms"
       notation: "mo ⨼<br/>msub ι $1"
@@ -5500,7 +5500,7 @@ concepts:
     
     - concept: intersection-number
       arity: 2
-      en: $1 intersection-number $2
+      en: $1 intersection number $2
       property: infix
       area: "algebraic geometry"
       notation: "mo ⋅<br/>"
@@ -5509,7 +5509,7 @@ concepts:
     
     - concept: inverse-image
       arity: 2
-      en: inverse-image
+      en: inverse image
       property: mixfix
       area: "set theory"
       notation: "mrow msup $1 -1 /msup [ $2 ]"
@@ -5521,7 +5521,7 @@ concepts:
     
     - concept: inverse-limit
       arity: 1
-      en: inverse-limit of $1
+      en: inverse limit of $1
       property: prefix
       area: "category theory"
       notation: "munder lim ←"
@@ -5534,7 +5534,7 @@ concepts:
     
     - concept: inverse-moment-of-function
       arity: 2
-      en: inverse-moment-of-function
+      en: inverse moment of function
       property: "<br/>msub<br/>mixfix"
       area: "mathematics"
       notation: "msub μ mrow - $1 /mrow<br/>mrow E [ msup $1 mrow - $2 /mrow ]"
@@ -5545,7 +5545,7 @@ concepts:
     
     - concept: inverse-tangent-integral
       arity: 1
-      en: inverse-tangent-integral of $1
+      en: inverse tangent integral of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub Ti $1"
@@ -5554,7 +5554,7 @@ concepts:
     
     - concept: inverse-wishart-distribution
       arity: 0
-      en: inverse-wishart-distribution
+      en: inverse wishart distribution
       property: symbol
       area: "probability theory"
       notation: "msubsup W p -1"
@@ -5565,7 +5565,7 @@ concepts:
     
     - concept: ionic-charge
       arity: 2
-      en: ionic-charge
+      en: ionic charge
       property: msup
       area: "chemistry"
       notation: "msup $1 $2<br/>"
@@ -5574,7 +5574,7 @@ concepts:
     
     - concept: isogonal-conjugate
       arity: 1
-      en: isogonal-conjugate of $1
+      en: isogonal conjugate of $1
       property: msup
       area: "geometry"
       notation: "msup $1 -1"
@@ -5598,7 +5598,7 @@ concepts:
     
     - concept: isotropy-group
       arity: 2
-      en: isotropy-group
+      en: isotropy group
       property: msub
       area: "group theory"
       notation: "msub $1 $2"
@@ -5611,7 +5611,7 @@ concepts:
     
     - concept: iverson-bracket
       arity: 1
-      en: iverson-bracket of $1
+      en: iverson bracket of $1
       property: fenced
       area: "set theory"
       urls: 
@@ -5619,7 +5619,7 @@ concepts:
     
     - concept: j-invariant
       arity: 1
-      en: j-invariant of $1
+      en: j invariant of $1
       property: function
       area: "number theory"
       notation: "mi j"
@@ -5629,7 +5629,7 @@ concepts:
     
     - concept: jacobi-matrix
       arity: 1
-      en: jacobi-matrix of $1
+      en: jacobi matrix of $1
       property: function
       area: "operator theory"
       notation: "mi J"
@@ -5642,7 +5642,7 @@ concepts:
     
     - concept: jacobi-polynomial
       arity: 1
-      en: jacobi-polynomial of $1
+      en: jacobi polynomial of $1
       property: function
       area: "orthogonal polynomials"
       notation: "msubsup P"
@@ -5656,7 +5656,7 @@ concepts:
     
     - concept: jacobi-symbol
       arity: 2
-      en: jacobi-symbol
+      en: jacobi symbol
       property: mixfix
       area: "number theory"
       notation: "mrow ( $1 | $2"
@@ -5668,7 +5668,7 @@ concepts:
     
     - concept: jacobi-theta-function
       arity: 1
-      en: jacobi-theta-function of $1
+      en: jacobi theta function of $1
       property: function
       area: "special-functions"
       notation: "mi ϑ"
@@ -5678,7 +5678,7 @@ concepts:
     
     - concept: jacobi-zeta-function
       arity: 2
-      en: jacobi-zeta-function
+      en: jacobi zeta function
       property: function
       area: "special-functions"
       notation: "mrow Z⁡ ( $1 |  $2 )"
@@ -5690,7 +5690,7 @@ concepts:
     
     - concept: jacobian-elliptic-function
       arity: 1
-      en: jacobian-elliptic-function of $1
+      en: jacobian elliptic function of $1
       property: function
       area: "special-functions"
       notation: "mi sn<br/>mi cn<br/>mi dn<br/>mi sd<br/>mi cd<br/>mi sc"
@@ -5705,7 +5705,7 @@ concepts:
     
     - concept: jacobson-radical
       arity: 1
-      en: jacobson-radical of $1
+      en: jacobson radical of $1
       property: function
       area: "ring theory"
       notation: "mi J<br/>mi rad"
@@ -5717,7 +5717,7 @@ concepts:
     
     - concept: jacobsthal-number
       arity: 0
-      en: jacobsthal-number
+      en: jacobsthal number
       property: symbol
       area: "number theory"
       notation: "mi J"
@@ -5727,7 +5727,7 @@ concepts:
     
     - concept: janko-group
       arity: 0
-      en: janko-group
+      en: janko group
       property: symbol
       area: "group theory"
       notation: "msub J 1<br/>msub J 2<br/>msub J 3<br/>msub J 4"
@@ -5760,7 +5760,7 @@ concepts:
     
     - concept: jone-polynomial
       arity: 1
-      en: jone-polynomial of $1
+      en: jone polynomial of $1
       property: function
       area: "knot theory"
       notation: "mi V"
@@ -5771,7 +5771,7 @@ concepts:
     
     - concept: jordan-block
       arity: 2
-      en: jordan-block
+      en: jordan block
       property: "indexed symbol"
       area: "linear algebra"
       notation: "msub J mrow $1, $2"
@@ -5783,7 +5783,7 @@ concepts:
     
     - concept: jordan-measure
       arity: 1
-      en: jordan-measure of $1
+      en: jordan measure of $1
       property: function
       area: "measure theory"
       notation: "mi m"
@@ -5794,7 +5794,7 @@ concepts:
     
     - concept: jordan-totient-function
       arity: 1
-      en: jordan-totient-function of $1
+      en: jordan totient function of $1
       property: function
       area: "number theory"
       notation: "msub J $1"
@@ -5803,7 +5803,7 @@ concepts:
     
     - concept: julia-set
       arity: 1
-      en: julia-set of $1
+      en: julia set of $1
       property: function
       area: "complex dynamics"
       notation: "mi J"
@@ -5814,7 +5814,7 @@ concepts:
     
     - concept: kaprekar-constant
       arity: 0
-      en: kaprekar-constant
+      en: kaprekar constant
       property: symbol
       area: "number theory"
       notation: "mn 6174"
@@ -5826,7 +5826,7 @@ concepts:
     
     - concept: kauffman-bracket
       arity: 1
-      en: kauffman-bracket of $1
+      en: kauffman bracket of $1
       property: fenced
       area: "knot theory"
       notation: "mrow ⟨ $1 ⟩"
@@ -5837,7 +5837,7 @@ concepts:
     
     - concept: kelvin-function
       arity: 1
-      en: kelvin-function of $1
+      en: kelvin function of $1
       property: function
       area: "special functions"
       notation: "msub ber ν⁡<br/>msub bei ν⁡"
@@ -5873,7 +5873,7 @@ concepts:
     
     - concept: khinchin-constant
       arity: 0
-      en: khinchin-constant
+      en: khinchin constant
       property: constant
       area: "continued fractions"
       notation: "mi K<br/>msub K 0"
@@ -5883,7 +5883,7 @@ concepts:
     
     - concept: killing-form
       arity: 1
-      en: killing-form of $1
+      en: killing form of $1
       property: function
       area: "lie algebra"
       notation: "mi B"
@@ -5895,7 +5895,7 @@ concepts:
     
     - concept: kleene-star
       arity: 1
-      en: kleene-star of $1
+      en: kleene star of $1
       property: msup
       area: "formal languages"
       notation: "msup *"
@@ -5904,7 +5904,7 @@ concepts:
     
     - concept: kleene-plus
       arity: 1
-      en: kleene-plus of $1
+      en: kleene plus of $1
       property: msup
       area: "formal languages"
       notation: "msup +"
@@ -5913,7 +5913,7 @@ concepts:
     
     - concept: klein-four-group
       arity: 0
-      en: klein-four-group
+      en: klein four group
       property: symbol
       area: "group theory"
       notation: "mi V<br/>msub K 4"
@@ -5923,7 +5923,7 @@ concepts:
     
     - concept: kloosterman-sum
       arity: 1
-      en: kloosterman-sum of $1
+      en: kloosterman sum of $1
       property: function
       area: "analytic number theory"
       notation: "mi S<br/>mi K"
@@ -5933,7 +5933,7 @@ concepts:
     
     - concept: kneser-graph
       arity: 2
-      en: kneser-graph
+      en: kneser graph
       property: "indexed symbol"
       area: "graph theory"
       notation: "mrow K ( $1, $2 )<br/>msub mi KG /mi $1, $2"
@@ -5943,7 +5943,7 @@ concepts:
     
     - concept: knodel-number
       arity: 1
-      en: knodel-number of $1
+      en: knodel number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "mi K"
@@ -5953,7 +5953,7 @@ concepts:
     
     - concept: kodaira-dimension
       arity: 1
-      en: kodaira-dimension of $1
+      en: kodaira dimension of $1
       property: function
       area: "algebraic geometry"
       notation: "mi κ"
@@ -5963,7 +5963,7 @@ concepts:
     
     - concept: kolmogorov-complexity
       arity: 1
-      en: kolmogorov-complexity of $1
+      en: kolmogorov complexity of $1
       property: function
       area: "information theory"
       notation: "mi K"
@@ -5973,7 +5973,7 @@ concepts:
     
     - concept: kolmogorov-space
       arity: 0
-      en: kolmogorov-space
+      en: kolmogorov space
       property: constant
       area: "topology"
       notation: "msub T 0"
@@ -5982,7 +5982,7 @@ concepts:
     
     - concept: kontsevich-integral
       arity: 1
-      en: kontsevich-integral of $1
+      en: kontsevich integral of $1
       property: function
       area: "knot theory"
       notation: "mi Z"
@@ -5994,7 +5994,7 @@ concepts:
     
     - concept: krawtchouk-polynomial
       arity: 1
-      en: krawtchouk-polynomial of $1
+      en: krawtchouk polynomial of $1
       property: function
       area: "orthogonal polynomials"
       notation: "msub K $1"
@@ -6006,7 +6006,7 @@ concepts:
     
     - concept: kripke-frame
       arity: 2
-      en: kripke-frame
+      en: kripke frame
       property: fenced
       area: "modal logic"
       notation: "mrow ⟨ $1, $2 ⟩"
@@ -6015,7 +6015,7 @@ concepts:
     
     - concept: kronecker-delta
       arity: 2
-      en: kronecker-delta
+      en: kronecker delta
       property: "indexed function"
       area: "special functions"
       notation: "msub δ mrow $1 $2 mrow"
@@ -6027,7 +6027,7 @@ concepts:
     
     - concept: kronecker-product
       arity: 2
-      en: $1 kronecker-product $2
+      en: $1 kronecker product $2
       property: infix
       area: "matrix theory"
       notation: "mo ⊗"
@@ -6040,7 +6040,7 @@ concepts:
     
     - concept: kronecker-symbol
       arity: 2
-      en: kronecker-symbol
+      en: kronecker symbol
       property: fenced<br/>fenced stacked
       area: "number theory"
       notation: "mrow ( $1 | $2 )<br/>( mfrac $1 $2 )"
@@ -6053,7 +6053,7 @@ concepts:
     
     - concept: krull-dimension
       arity: 1
-      en: krull-dimension of $1
+      en: krull dimension of $1
       property: function
       area: "commutative algebra"
       notation: "mi dim"
@@ -6064,7 +6064,7 @@ concepts:
     
     - concept: kulkarni-nomizu-product
       arity: 1
-      en: kulkarni-nomizu-product of $1
+      en: kulkarni nomizu product of $1
       property: embellished infix
       area: "differential geometry"
       notation: "mo ∧ /mo mspace=negative.../mspace mo ◯ /mo"
@@ -6073,7 +6073,7 @@ concepts:
     
     - concept: kullback-leibler-distance
       arity: 1
-      en: kullback-leibler-distance of $1
+      en: kullback leibler distance of $1
       property: function
       area: "mathematical statistics"
       notation: "mi KL<br/>msub D KL"
@@ -6099,7 +6099,7 @@ concepts:
     
     - concept: lagrange-multiplier
       arity: 0
-      en: lagrange-multiplier
+      en: lagrange multiplier
       property: symbol
       area: "mathematical optimization"
       notation: "mi λ"
@@ -6113,7 +6113,7 @@ concepts:
     
     - concept: lagrange-point
       arity: 0
-      en: lagrange-point
+      en: lagrange point
       property: symbol
       area: "celestial mechanics"
       notation: "msub L 1<br/>msub L 2<br/>msub L 3<br/>msub L 4<br/>msub L 5"
@@ -6126,7 +6126,7 @@ concepts:
     
     - concept: laguerre-polynomial
       arity: 1
-      en: laguerre-polynomial of $1
+      en: laguerre polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "mi L"
@@ -6140,7 +6140,7 @@ concepts:
     
     - concept: landau-constant
       arity: 0
-      en: landau-constant
+      en: landau constant
       property: constant
       area: "complex analysis"
       notation: "mi A<br/>mi B<br/>mi L"
@@ -6150,7 +6150,7 @@ concepts:
     
     - concept: laplace-operator
       arity: 1
-      en: laplace-operator of $1
+      en: laplace operator of $1
       property: "<br/>embellished operator<br/>"
       area: "differential operators"
       notation: "msup ∇ 2<br/>mrow ∇ · ∇<br/>mi Δ"
@@ -6161,7 +6161,7 @@ concepts:
     
     - concept: laplace-transform
       arity: 1
-      en: laplace-transform of $1
+      en: laplace transform of $1
       property: operator
       area: "integral transforms"
       notation: "mi ℒ⁡"
@@ -6173,7 +6173,7 @@ concepts:
     
     - concept: laplacian-matrix
       arity: 0
-      en: laplacian-matrix
+      en: laplacian matrix
       property: symbol
       area: "graph theory"
       notation: "mi L"
@@ -6183,7 +6183,7 @@ concepts:
     
     - concept: latin-rectangle
       arity: 1
-      en: latin-rectangle of $1
+      en: latin rectangle of $1
       property: mtable
       area: "combinatorial mathematics"
       notation: "mtable"
@@ -6194,7 +6194,7 @@ concepts:
     
     - concept: latin-square
       arity: 1
-      en: latin-square of $1
+      en: latin square of $1
       property: mtable
       area: "combinatorial mathematics"
       notation: "mtable"
@@ -6207,7 +6207,7 @@ concepts:
     
     - concept: least-prime-factor
       arity: 1
-      en: least-prime-factor of $1
+      en: least prime factor of $1
       property: function
       area: "number theory"
       notation: "mi lpf"
@@ -6216,7 +6216,7 @@ concepts:
     
     - concept: lebesgue-constant
       arity: 1
-      en: lebesgue-constant of $1
+      en: lebesgue constant of $1
       property: indexed constant
       area: "fourier series"
       notation: "msub L $1"
@@ -6228,7 +6228,7 @@ concepts:
     
     - concept: lebesgue-integral
       arity: 1
-      en: lebesgue-integral of $1
+      en: lebesgue integral of $1
       property: indexed
       area: "measure theory"
       notation: "mo ∫"
@@ -6238,7 +6238,7 @@ concepts:
     
     - concept: leech-lattice
       arity: 0
-      en: leech-lattice
+      en: leech lattice
       property: symbol
       area: "group theory"
       notation: "msub Λ 24"
@@ -6249,7 +6249,7 @@ concepts:
     
     - concept: left-adjoint
       arity: 2
-      en: $1 left-adjoint $2
+      en: $1 left adjoint $2
       property: infix
       area: "category theory"
       notation: "mo ⊣"
@@ -6258,7 +6258,7 @@ concepts:
     
     - concept: left-composition
       arity: 2
-      en: $1 left-composition $2
+      en: $1 left composition $2
       property: infix
       area: "algebra"
       notation: "mo ;"
@@ -6269,7 +6269,7 @@ concepts:
     
     - concept: left-derivative
       arity: 1
-      en: left-derivative of $1
+      en: left derivative of $1
       property: operator
       area: "calculus"
       notation: "msub ∂ –"
@@ -6278,7 +6278,7 @@ concepts:
     
     - concept: legendre-chi-function
       arity: 1
-      en: legendre-chi-function of $1
+      en: legendre chi function of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub χ $1"
@@ -6288,7 +6288,7 @@ concepts:
     
     - concept: legendre-polynomial
       arity: 1
-      en: legendre-polynomial of $1
+      en: legendre polynomial of $1
       property: function
       area: "orthogonal polynomials"
       notation: "msub P $1"
@@ -6301,7 +6301,7 @@ concepts:
     
     - concept: legendre-symbol
       arity: 2
-      en: legendre-symbol
+      en: legendre symbol
       property: fenced<br/>fenced stacked
       area: "number theory"
       notation: "mrow ( $1 | $2 )<br/>mrow ( mfrac $1 $2 )"
@@ -6314,7 +6314,7 @@ concepts:
     
     - concept: lehmer-mean
       arity: 1
-      en: lehmer-mean of $1
+      en: lehmer mean of $1
       property: "indexed function"
       area: "means"
       notation: "msub L $1"
@@ -6324,7 +6324,7 @@ concepts:
     
     - concept: lehmer-number
       arity: 1
-      en: lehmer-number of $1
+      en: lehmer number of $1
       property: "indexed function"
       area: "number theory"
       notation: "msub U $1"
@@ -6346,7 +6346,7 @@ concepts:
     
     - concept: levi-civita-symbol
       arity: 3
-      en: levi-civita-symbol  of $1, $2 and $3
+      en: levi civita symbol  of $1, $2 and $3
       property: "indexed symbol"
       area: "combinatorics"
       notation: "msub ϵ mrow $1$2$3 /mrow"
@@ -6359,7 +6359,7 @@ concepts:
     
     - concept: levy-prokhorov-metric
       arity: 1
-      en: levy-prokhorov-metric of $1
+      en: levy prokhorov metric of $1
       property: function
       area: "measure theory"
       notation: "mi π"
@@ -6369,7 +6369,7 @@ concepts:
     
     - concept: lexicographic-product
       arity: 2
-      en: $1 lexicographic-product $2
+      en: $1 lexicographic product $2
       property: infix<br/>mixfix
       area: "graph theory"
       notation: "mo ∙<br/>$1 [ $2 ]"
@@ -6380,7 +6380,7 @@ concepts:
     
     - concept: lexicographic-order
       arity: 2
-      en: $1 lexicographic-order $2
+      en: $1 lexicographic order $2
       property: infix
       area: "discrete mathematics"
       notation: "mo <"
@@ -6393,7 +6393,7 @@ concepts:
     
     - concept: lie-derivative
       arity: 1
-      en: lie-derivative of $1
+      en: lie derivative of $1
       property: "indexed operator"
       area: "lie algebra"
       notation: "msub ℒ $1"
@@ -6404,7 +6404,7 @@ concepts:
     
     - concept: lie-superbracket
       arity: 2
-      en: lie-superbracket
+      en: lie superbracket
       property: fenced
       area: "lie algebra"
       notation: "mrow [ $1 , $2 ]"
@@ -6415,7 +6415,7 @@ concepts:
     
     - concept: like-charge
       arity: 2
-      en: $1 like-charge $2
+      en: $1 like charge $2
       property: infix
       area: "physics"
       notation: "mo ⇈"
@@ -6424,7 +6424,7 @@ concepts:
     
     - concept: line-graph
       arity: 1
-      en: line-graph of $1
+      en: line graph of $1
       property: function
       area: "graph theory"
       notation: "mi L"
@@ -6434,7 +6434,7 @@ concepts:
     
     - concept: line-integral
       arity: 1
-      en: line-integral of $1
+      en: line integral of $1
       property: indexed
       area: "analysis"
       notation: "mo ∫"
@@ -6450,7 +6450,7 @@ concepts:
     
     - concept: linear-span
       arity: 1
-      en: linear-span of $1
+      en: linear span of $1
       property: function
       area: "linear algebra"
       notation: "mi span"
@@ -6472,7 +6472,7 @@ concepts:
     
     - concept: gunter-link
       arity: 1
-      en: gunter-link of $1
+      en: gunter link of $1
       property: unit
       area: "units"
       notation: "mi l.<br/>mi li.<br/>mi lnk."
@@ -6481,7 +6481,7 @@ concepts:
     
     - concept: liouville-constant
       arity: 0
-      en: liouville-constant
+      en: liouville constant
       property: constant
       area: "number theory"
       notation: "mi L"
@@ -6492,7 +6492,7 @@ concepts:
     
     - concept: liouville-function
       arity: 1
-      en: liouville-function of $1
+      en: liouville function of $1
       property: function
       area: "number theory"
       notation: "mi λ"
@@ -6516,7 +6516,7 @@ concepts:
     
     - concept: logarithmic-integral
       arity: 1
-      en: logarithmic-integral of $1
+      en: logarithmic integral of $1
       property: function
       area: "special functions"
       notation: "mi li"
@@ -6527,7 +6527,7 @@ concepts:
     
     - concept: logarithmic-moment-of-function
       arity: 2
-      en: logarithmic-moment-of-function
+      en: logarithmic moment of function
       property: "<br/><br/>mixfix"
       area: "mathematics"
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
@@ -6547,7 +6547,7 @@ concepts:
     
     - concept: lommel-function
       arity: 2
-      en: lommel-function
+      en: lommel function
       property: "indexed function"
       area: "special functions"
       notation: "msub S mrow $1,$2 /mrow<br/>msub s mrow $1, $2 /mrow"
@@ -6560,7 +6560,7 @@ concepts:
     
     - concept: long-division
       arity: 1
-      en: long-division of $1
+      en: long division of $1
       property: mfrac
       area: "arithmetic"
       notation: "mfrac?"
@@ -6570,7 +6570,7 @@ concepts:
     
     - concept: loop-space
       arity: 1
-      en: loop-space of $1
+      en: loop space of $1
       property: function
       area: "topology"
       notation: "mi Ω"
@@ -6581,7 +6581,7 @@ concepts:
     
     - concept: lower-closure-poset
       arity: 1
-      en: lower-closure-poset of $1
+      en: lower closure poset of $1
       property: prefix
       area: "order theory"
       notation: "mo ↓"
@@ -6590,7 +6590,7 @@ concepts:
     
     - concept: lower-darboux-integral
       arity: 1
-      en: lower-darboux-integral of $1
+      en: lower darboux integral of $1
       property: indexed
       area: "real analysis"
       notation: "munder ¯"
@@ -6601,7 +6601,7 @@ concepts:
     
     - concept: lower-dini-derivative
       arity: 1
-      en: lower-dini-derivative of $1
+      en: lower dini derivative of $1
       property: decorated function
       area: "analysis"
       notation: "msubsup $1 - '"
@@ -6612,7 +6612,7 @@ concepts:
     
     - concept: lower-shadow
       arity: 1
-      en: lower-shadow of $1
+      en: lower shadow of $1
       property: function
       area: "combinatorics"
       notation: "mi 𝜕<br/>msub 𝜕 -"
@@ -6623,7 +6623,7 @@ concepts:
     
     - concept: lucas-number
       arity: 1
-      en: lucas-number of $1
+      en: lucas number of $1
       property: "indexed symbol"
       area: "integer sequences"
       notation: "msub L $1"
@@ -6634,7 +6634,7 @@ concepts:
     
     - concept: lucas-sequence
       arity: 1
-      en: lucas-sequence of $1
+      en: lucas sequence of $1
       property: "indexed function"
       area: "integer sequences"
       notation: "msub U $1<br/>msub V $1"
@@ -6644,7 +6644,7 @@ concepts:
     
     - concept: lyapunov-candidate-function
       arity: 1
-      en: lyapunov-candidate-function of $1
+      en: lyapunov candidate function of $1
       property: function
       area: "stability theory"
       notation: "mi V"
@@ -6657,7 +6657,7 @@ concepts:
     
     - concept: macdonald-polynomial
       arity: 1
-      en: macdonald-polynomial of $1
+      en: macdonald polynomial of $1
       property: function
       area: "orthogonal polynomials"
       notation: "msub P λ"
@@ -6667,7 +6667,7 @@ concepts:
     
     - concept: mahler-measure
       arity: 1
-      en: mahler-measure of $1
+      en: mahler measure of $1
       property: function
       area: "number theory"
       notation: "mi M"
@@ -6678,7 +6678,7 @@ concepts:
     
     - concept: mangoldt-function
       arity: 1
-      en: mangoldt-function of $1
+      en: mangoldt function of $1
       property: function
       area: "special functions"
       notation: "mi Λ"
@@ -6691,7 +6691,7 @@ concepts:
     
     - concept: mapping-class-group
       arity: 1
-      en: mapping-class-group of $1
+      en: mapping class group of $1
       property: function
       area: "geometric topology"
       notation: "mi MCG"
@@ -6701,7 +6701,7 @@ concepts:
     
     - concept: mapping-cone
       arity: 1
-      en: mapping-cone of $1
+      en: mapping cone of $1
       property: "indexed symbol"
       area: "homotopy theory"
       notation: "msub C $1<br/>mrow C $1"
@@ -6714,7 +6714,7 @@ concepts:
     
     - concept: matching-polynomial
       arity: 1
-      en: matching-polynomial of $1
+      en: matching polynomial of $1
       property: "indexed function"
       area: "graph theory"
       notation: "msub m $1<br/>msub M $1<br/>msub μ $1"
@@ -6723,7 +6723,7 @@ concepts:
     
     - concept: mathieu-function-of-first-kind
       arity: 1
-      en: mathieu-function-of-first-kind of $1
+      en: mathieu function of first kind of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub ce $1<br/>msub se $1"
@@ -6746,7 +6746,7 @@ concepts:
     
     - concept: mathieu-function-of-second-kind
       arity: 1
-      en: mathieu-function-of-second-kind of $1
+      en: mathieu function of second kind of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub fe $1<br/>msub ge $1"
@@ -6769,7 +6769,7 @@ concepts:
     
     - concept: mathieu-group
       arity: 1
-      en: mathieu-group of $1
+      en: mathieu group of $1
       property: "indexed symbol"
       area: "group theory"
       notation: "msub M 11<br/>msub M 12<br/>msub M 22<br/>msub M 23<br/>msub M 24"
@@ -6804,7 +6804,7 @@ concepts:
     
     - concept: matrix-ring
       arity: 1
-      en: matrix-ring of $1
+      en: matrix ring of $1
       property: function
       area: "abstract algebra"
       notation: "msub M $1"
@@ -6814,7 +6814,7 @@ concepts:
     
     - concept: maximum-degree
       arity: 1
-      en: maximum-degree of $1
+      en: maximum degree of $1
       property: function
       area: "graph theory"
       notation: "mi Δ"
@@ -6825,7 +6825,7 @@ concepts:
     
     - concept: mean-curvature
       arity: 1
-      en: mean-curvature of $1
+      en: mean curvature of $1
       property: function
       area: "differential geometry"
       notation: "mi H"
@@ -6836,7 +6836,7 @@ concepts:
     
     - concept: mean-squared-error
       arity: 1
-      en: mean-squared-error of $1
+      en: mean squared error of $1
       property: function
       area: "statistics"
       notation: "mi MSE"
@@ -6845,7 +6845,7 @@ concepts:
     
     - concept: meixner-pollaczek-polynomial
       arity: 1
-      en: meixner-pollaczek-polynomial of $1
+      en: meixner pollaczek polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "mi P"
@@ -6856,7 +6856,7 @@ concepts:
     
     - concept: mellin-transform
       arity: 1
-      en: mellin-transform of $1
+      en: mellin transform of $1
       property: operator
       area: "integral transforms"
       notation: "mi ℳ"
@@ -6868,7 +6868,7 @@ concepts:
     
     - concept: meridian-radius-of-curvature
       arity: 1
-      en: meridian-radius-of-curvature of $1
+      en: meridian radius of curvature of $1
       property: function
       area: "geodesy"
       notation: "mi M"
@@ -6878,7 +6878,7 @@ concepts:
     
     - concept: meridian-distance
       arity: 1
-      en: meridian-distance of $1
+      en: meridian distance of $1
       property: function
       area: "geodesy"
       notation: "mi m"
@@ -6887,7 +6887,7 @@ concepts:
     
     - concept: mersenne-number
       arity: 1
-      en: mersenne-number of $1
+      en: mersenne number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub M $1"
@@ -6897,7 +6897,7 @@ concepts:
     
     - concept: mersenne-prime
       arity: 1
-      en: mersenne-prime of $1
+      en: mersenne prime of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub M $1"
@@ -6908,7 +6908,7 @@ concepts:
     
     - concept: merten-function
       arity: 1
-      en: merten-function of $1
+      en: merten function of $1
       property: function
       area: "number theory"
       notation: "mi M"
@@ -6928,7 +6928,7 @@ concepts:
     
     - concept: metaplectic-group
       arity: 0
-      en: metaplectic-group
+      en: metaplectic group
       property: symbol
       area: "group theory"
       notation: "msub Mp 2n"
@@ -6939,7 +6939,7 @@ concepts:
     
     - concept: mills-constant
       arity: 0
-      en: mills-constant
+      en: mills constant
       property: symbol
       area: "number theory"
       notation: "mi A"
@@ -6950,7 +6950,7 @@ concepts:
     
     - concept: mills-ratio
       arity: 1
-      en: mills-ratio of $1
+      en: mills ratio of $1
       property: function
       area: "probability theory"
       notation: "mi m<br/>mi M"
@@ -6961,7 +6961,7 @@ concepts:
     
     - concept: minimum-degree
       arity: 1
-      en: minimum-degree of $1
+      en: minimum degree of $1
       property: function
       area: "graph theory"
       notation: "mi δ<br/>"
@@ -6972,7 +6972,7 @@ concepts:
     
     - concept: minkowski-difference
       arity: 2
-      en: $1 minkowski-difference $2
+      en: $1 minkowski difference $2
       property: infix
       area: "geometry"
       notation: "mo -"
@@ -6983,7 +6983,7 @@ concepts:
     
     - concept: minkowski-sum
       arity: 2
-      en: $1 minkowski-sum $2
+      en: $1 minkowski sum $2
       property: infix
       area: "geometry"
       notation: "mo +"
@@ -6995,7 +6995,7 @@ concepts:
     
     - concept: mittag-leffler-function
       arity: 1
-      en: mittag-leffler-function of $1
+      en: mittag leffler function of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub E $1"
@@ -7007,7 +7007,7 @@ concepts:
     
     - concept: mobius-function
       arity: 1
-      en: mobius-function of $1
+      en: mobius function of $1
       property: function
       area: "number theory"
       notation: "mi μ"
@@ -7020,7 +7020,7 @@ concepts:
     
     - concept: modified-bessel-function-of-first-kind
       arity: 1
-      en: modified-bessel-function-of-first-kind of $1
+      en: modified bessel function of first kind of $1
       property: function
       area: "special functions"
       notation: "msub I $1"
@@ -7031,7 +7031,7 @@ concepts:
     
     - concept: modified-bessel-function-of-second-kind
       arity: 1
-      en: modified-bessel-function-of-second-kind of $1
+      en: modified bessel function of second kind of $1
       property: function
       area: "special functions"
       notation: "msub K $1"
@@ -7042,7 +7042,7 @@ concepts:
     
     - concept: modified-mathieu-function
       arity: 1
-      en: modified-mathieu-function of $1
+      en: modified mathieu function of $1
       property: function
       area: "special functions"
       notation: "msub Ce $1<br/>msub Se $1<br/>msub Me $1<br/>msub Fe $1<br/>msub Ge $1"
@@ -7061,7 +7061,7 @@ concepts:
     
     - concept: modified-spherical-bessel-function
       arity: 1
-      en: modified-spherical-bessel-function of $1
+      en: modified spherical bessel function of $1
       property: function
       area: "special functions"
       notation: "msubsup i $1 (1)<br/>msubsup i $1 (2)<br/>msub k $1"
@@ -7073,7 +7073,7 @@ concepts:
     
     - concept: modified-struve-function
       arity: 1
-      en: modified-struve-function of $1
+      en: modified struve function of $1
       property: function
       area: "special functions"
       notation: "msub L $1"
@@ -7084,7 +7084,7 @@ concepts:
     
     - concept: modular-discriminant
       arity: 1
-      en: modular-discriminant of $1
+      en: modular discriminant of $1
       property: operator
       area: "special functions"
       notation: "mi Δ<br/>"
@@ -7108,7 +7108,7 @@ concepts:
     
     - concept: moebius-function
       arity: 1
-      en: moebius-function of $1
+      en: moebius function of $1
       property: function
       area: "number theory"
       notation: "mi μ"
@@ -7118,7 +7118,7 @@ concepts:
     
     - concept: moment-of-function
       arity: 2
-      en: moment-of-function
+      en: moment of function
       property: "<br/>msub<br/>mixfix"
       area: "mathematics"
       notation: "msub μ $1<br/>mrow E [ msup $1 $2 ]"
@@ -7142,7 +7142,7 @@ concepts:
     
     - concept: moment-of-inertia
       arity: 0
-      en: moment-of-inertia
+      en: moment of inertia
       property: symbol
       area: "physics"
       notation: "mi I"
@@ -7170,7 +7170,7 @@ concepts:
     
     - concept: monster-group
       arity: 0
-      en: monster-group
+      en: monster group
       property: symbol
       area: "group theory"
       notation: "mi M"
@@ -7183,7 +7183,7 @@ concepts:
     
     - concept: moore-penrose-inverse
       arity: 1
-      en: moore-penrose-inverse of $1
+      en: moore penrose inverse of $1
       property: msup
       area: "linear algebra"
       notation: "msup $1 +"
@@ -7194,7 +7194,7 @@ concepts:
     
     - concept: moore-smith-sequence
       arity: 1
-      en: moore-smith-sequence of $1
+      en: moore smith sequence of $1
       property: fenced
       area: "topology"
       notation: "mrow ( $1"
@@ -7206,7 +7206,7 @@ concepts:
     
     - concept: motzkin-number
       arity: 1
-      en: motzkin-number of $1
+      en: motzkin number of $1
       property: "indexed symbol"
       area: "combinatorial analysis"
       notation: "msub M $1<br/>mi M"
@@ -7218,7 +7218,7 @@ concepts:
     
     - concept: multiple-integral
       arity: 1
-      en: multiple-integral of $1
+      en: multiple integral of $1
       property: indexed
       area: "multivariable calculus"
       notation: "mo ∫ ⋯ ∫<br/>mo ∫"
@@ -7230,7 +7230,7 @@ concepts:
     
     - concept: multiplicative-inverse
       arity: 1
-      en: multiplicative-inverse of $1
+      en: multiplicative inverse of $1
       property: msup<br/>mixfix
       area: "abstract algebra"
       notation: "msup $1 -1<br/>mrow 1 / $1"
@@ -7246,7 +7246,7 @@ concepts:
     
     - concept: multiplicative-order
       arity: 1
-      en: multiplicative-order of $1
+      en: multiplicative order of $1
       property: "indexed function"
       area: "modular arithmetic"
       notation: "msub O $1<br/>msub ord $1"
@@ -7256,7 +7256,7 @@ concepts:
     
     - concept: multiplier-algebra
       arity: 1
-      en: multiplier-algebra of $1
+      en: multiplier algebra of $1
       property: function
       area: "functional analysis"
       notation: "mrow M($1"
@@ -7276,7 +7276,7 @@ concepts:
     
     - concept: multiset-coefficient
       arity: 2
-      en: multiset-coefficient
+      en: multiset coefficient
       property: fenced-stacked
       area: "combinatorics"
       notation: "mrow ( ( mfrac $1 $2 )"
@@ -7287,7 +7287,7 @@ concepts:
     
     - concept: multivariate-gaussian-distribution
       arity: 0
-      en: multivariate-gaussian-distribution
+      en: multivariate gaussian distribution
       property: symbol
       area: "probability theory"
       notation: "msub 𝒩 $1"
@@ -7315,7 +7315,7 @@ concepts:
     
     - concept: mutual-information
       arity: 1
-      en: mutual-information of $1
+      en: mutual information of $1
       property: function
       area: "information theory"
       notation: "mi I"
@@ -7325,7 +7325,7 @@ concepts:
     
     - concept: narayana-number
       arity: 2
-      en: narayana-number
+      en: narayana number
       property: function
       area: "combinatorial analysis"
       notation: "mrow N ($1, $2"
@@ -7336,7 +7336,7 @@ concepts:
     
     - concept: narrow-denjoy-integral
       arity: 1
-      en: narrow-denjoy-integral of $1
+      en: narrow denjoy integral of $1
       property: indexed
       area: "calculus"
       notation: "mo ∫"
@@ -7351,7 +7351,7 @@ concepts:
     
     - concept: negative-binomial-distribution
       arity: 0
-      en: negative-binomial-distribution
+      en: negative binomial distribution
       property: symbol
       area: "probability theory"
       notation: "mi NB"
@@ -7362,7 +7362,7 @@ concepts:
     
     - concept: negative-hypergeometric-distribution
       arity: 1
-      en: negative-hypergeometric-distribution of $1
+      en: negative hypergeometric distribution of $1
       property: "indexed symbol"
       area: "probability theory"
       notation: "mi NHG"
@@ -7383,7 +7383,7 @@ concepts:
     
     - concept: neighbourhood-filter
       arity: 1
-      en: neighbourhood-filter of $1
+      en: neighbourhood filter of $1
       property: function
       area: "topology"
       notation: "mi 𝒩"
@@ -7395,7 +7395,7 @@ concepts:
     
     - concept: neron-severi-group
       arity: 1
-      en: neron-severi-group of $1
+      en: neron severi group of $1
       property: function
       area: "group theory"
       notation: "mi NS"
@@ -7405,7 +7405,7 @@ concepts:
     
     - concept: neron-tate-height
       arity: 0
-      en: neron-tate-height
+      en: neron tate height
       property: symbol
       area: "number theory"
       notation: "mover h ^"
@@ -7437,7 +7437,7 @@ concepts:
     
     - concept: non-oriented-angle
       arity: 1
-      en: non-oriented-angle of $1
+      en: non oriented angle of $1
       property: prefix
       area: "geometry"
       notation: "mo ∠"
@@ -7485,7 +7485,7 @@ concepts:
     
     - concept: not-divisible-by
       arity: 2
-      en: $1 not-divisible-by $2
+      en: $1 not divisible by $2
       property: infix
       area: "number theory"
       notation: "mo ∤"
@@ -7494,7 +7494,7 @@ concepts:
     
     - concept: null-graph
       arity: 0
-      en: null-graph
+      en: null graph
       property: symbol
       area: "graph theory"
       notation: "msub mover K ¯ /mover $1"
@@ -7507,7 +7507,7 @@ concepts:
     
     - concept: numerical-part
       arity: 1
-      en: numerical-part of $1
+      en: numerical part of $1
       property: fenced
       area: "SI units"
       notation: "mrow { $1 }"
@@ -7553,7 +7553,7 @@ concepts:
     
     - concept: odds-ratio
       arity: 0
-      en: odds-ratio
+      en: odds ratio
       property: symbol
       area: "statistics"
       notation: "mi OR"
@@ -7562,7 +7562,7 @@ concepts:
     
     - concept: onsager-machlup-function
       arity: 1
-      en: onsager-machlup-function of $1
+      en: onsager machlup function of $1
       property: function
       area: "functional analysis"
       notation: "mi L"
@@ -7573,7 +7573,7 @@ concepts:
     
     - concept: open-ball
       arity: 2
-      en: open-ball
+      en: open ball
       property: mixfix
       area: "topology"
       notation: "mrow msub B $1 /msub ( $2"
@@ -7585,7 +7585,7 @@ concepts:
     
     - concept: open-interval
       arity: 2
-      en: open-interval
+      en: open interval
       property: fenced
       area: "algebra"
       notation: "mrow ( $1, $2 )<br/>mrow ] $1 , $2 ["
@@ -7595,7 +7595,7 @@ concepts:
     
     - concept: open-real-interval
       arity: 2
-      en: open-real-interval
+      en: open real interval
       property: fenced
       area: "algebra"
       notation: "mrow ($1 . . $2)"
@@ -7618,7 +7618,7 @@ concepts:
     
     - concept: opposite-charge
       arity: 2
-      en: $1 opposite-charge $2
+      en: $1 opposite charge $2
       property: infix
       area: "physics"
       notation: "mo ⇅"
@@ -7627,7 +7627,7 @@ concepts:
     
     - concept: or-product
       arity: 2
-      en: $1 or-product $2
+      en: $1 or product $2
       property: infix
       area: "graph theory"
       notation: "mo *"
@@ -7639,7 +7639,7 @@ concepts:
     
     - concept: order-of-group
       arity: 1
-      en: order-of-group of $1
+      en: order of group of $1
       property: "function<br/>fenced"
       area: "group theory"
       notation: "mi ord<br/>mrow | $1 |"
@@ -7673,7 +7673,7 @@ concepts:
     
     - concept: orthogonal-group
       arity: 1
-      en: orthogonal-group of $1
+      en: orthogonal group of $1
       property: function
       area: "group theory"
       notation: "mi O"
@@ -7686,7 +7686,7 @@ concepts:
     
     - concept: outer-automorphism-group
       arity: 1
-      en: outer-automorphism-group of $1
+      en: outer automorphism group of $1
       property: function
       area: "abstract algebra"
       notation: "mi Out"
@@ -7698,7 +7698,7 @@ concepts:
     
     - concept: outer-jordan-measure
       arity: 1
-      en: outer-jordan-measure of $1
+      en: outer jordan measure of $1
       property: function
       area: "measure theory"
       notation: "msup m *"
@@ -7709,7 +7709,7 @@ concepts:
     
     - concept: outer-product
       arity: 2
-      en: $1 outer-product $2
+      en: $1 outer product $2
       property: infix
       area: "linear algebra"
       notation: "mo ⊗"
@@ -7720,7 +7720,7 @@ concepts:
     
     - concept: p-core
       arity: 1
-      en: p-core of $1
+      en: p core of $1
       property: function
       area: "group theory"
       notation: "msub O p"
@@ -7732,7 +7732,7 @@ concepts:
     
     - concept: pade-approximant
       arity: 3
-      en: pade-approximant  of $1, $2 and $3
+      en: pade approximant  of $1, $2 and $3
       property: mixfix
       area: "numerical analysis"
       notation: "msub mrow [ $1 / $2 ] /mrow $3"
@@ -7743,7 +7743,7 @@ concepts:
     
     - concept: padovan-sequence
       arity: 1
-      en: padovan-sequence of $1
+      en: padovan sequence of $1
       property: function
       area: "number theory"
       notation: "mi P"
@@ -7753,7 +7753,7 @@ concepts:
     
     - concept: paraboloidal-coordinate
       arity: 3
-      en: paraboloidal-coordinate of $1, $2 and $3
+      en: paraboloidal coordinate of $1, $2 and $3
       property: fenced
       area: "geometry"
       notation: "mrow ( $1, $2 , $3"
@@ -7775,7 +7775,7 @@ concepts:
     
     - concept: parallel-morphism
       arity: 2
-      en: parallel-morphism
+      en: parallel morphism
       property: embellished infix
       area: "category theory"
       notation: "<munderover><br/><mrow/><br/><munder><mo>⟶</mo> $1</munder><br/><mover><mo>⟶</mo> $2</mover><br/></munderover>"
@@ -7784,7 +7784,7 @@ concepts:
     
     - concept: partial-charge
       arity: 0
-      en: partial-charge
+      en: partial charge
       property: symbol
       area: "chemistry"
       notation: "msup δ $1<br/>mrow δ $1"
@@ -7817,7 +7817,7 @@ concepts:
     
     - concept: partition-function
       arity: 1
-      en: partition-function of $1
+      en: partition function of $1
       property: function
       area: "number theory"
       notation: "mi p"
@@ -7826,7 +7826,7 @@ concepts:
     
     - concept: pauli-matrix
       arity: 1
-      en: pauli-matrix of $1
+      en: pauli matrix of $1
       property: "indexed symbol"
       area: "mathematical physics"
       notation: "msub σ $1"
@@ -7838,7 +7838,7 @@ concepts:
     
     - concept: peclet-number
       arity: 1
-      en: peclet-number of $1
+      en: peclet number of $1
       property: "indexed symbol"
       area: "fluid dynamics"
       notation: "msub Pe $1"
@@ -7849,7 +7849,7 @@ concepts:
     
     - concept: peirce-arrow
       arity: 2
-      en: $1 peirce-arrow $2
+      en: $1 peirce arrow $2
       property: infix
       area: "logic"
       notation: "mo ↓"
@@ -7858,7 +7858,7 @@ concepts:
     
     - concept: pell-number
       arity: 0
-      en: pell-number
+      en: pell number
       property: symbol
       area: "number theory"
       notation: "msub P $1"
@@ -7868,7 +7868,7 @@ concepts:
     
     - concept: pell-luca-number
       arity: 0
-      en: pell-luca-number
+      en: pell luca number
       property: symbol
       area: "number theory"
       notation: "msub Q $1"
@@ -7878,7 +7878,7 @@ concepts:
     
     - concept: periodic-continued-fraction
       arity: 1
-      en: periodic-continued-fraction of $1
+      en: periodic continued fraction of $1
       property: mfrac
       area: "mathematical analysis"
       notation: "mfrac with ellipses"
@@ -7922,7 +7922,7 @@ concepts:
     
     - concept: perrin-sequence
       arity: 1
-      en: perrin-sequence of $1
+      en: perrin sequence of $1
       property: function
       area: "number theory"
       notation: "mi P"
@@ -7969,7 +7969,7 @@ concepts:
     
     - concept: phi-coefficient
       arity: 0
-      en: phi-coefficient
+      en: phi coefficient
       property: symbol
       area: "statistics"
       notation: "mi φ<br/>msub r φ"
@@ -7980,7 +7980,7 @@ concepts:
     
     - concept: picard-group
       arity: 1
-      en: picard-group of $1
+      en: picard group of $1
       property: function
       area: "group theory"
       notation: "mi Pic"
@@ -7992,7 +7992,7 @@ concepts:
     
     - concept: planck-constant
       arity: 0
-      en: planck-constant
+      en: planck constant
       property: constant
       area: "physics"
       notation: "mi h<br/>mi ℎ"
@@ -8003,7 +8003,7 @@ concepts:
     
     - concept: plastic-constant
       arity: 0
-      en: plastic-constant
+      en: plastic constant
       property: constant
       area: "geometry"
       notation: "mi P<br/>mi p"
@@ -8020,7 +8020,7 @@ concepts:
     
     - concept: playing-card-suit
       arity: 1
-      en: playing-card-suit of $1
+      en: playing card suit of $1
       property: unit
       area: "game theory"
       notation: "mo ♣<br/>mo ♠<br/>mo ♦<br/>mo ♥"
@@ -8042,7 +8042,7 @@ concepts:
     
     - concept: plucker-coordinate
       arity: 2
-      en: plucker-coordinate
+      en: plucker coordinate
       property: fenced
       area: "geometry"
       notation: "mrow ( $1 : $2 : ... : $n"
@@ -8053,7 +8053,7 @@ concepts:
     
     - concept: pointwise-convergent
       arity: 1
-      en: pointwise-convergent of $1
+      en: pointwise convergent of $1
       property: postfix
       area: "convergence"
       notation: "mtext pointwise"
@@ -8064,7 +8064,7 @@ concepts:
     
     - concept: poisson-bracket
       arity: 2
-      en: poisson-bracket
+      en: poisson bracket
       property: fenced
       area: "classical mechanics"
       notation: "mrow { $1, $2 }"
@@ -8075,7 +8075,7 @@ concepts:
     
     - concept: poisson-distribution
       arity: 0
-      en: poisson-distribution
+      en: poisson distribution
       property: symbol
       area: "probability theory"
       notation: "mi Pois"
@@ -8087,7 +8087,7 @@ concepts:
     
     - concept: polar-set
       arity: 1
-      en: polar-set of $1
+      en: polar set of $1
       property: msup
       area: "functional analysis"
       notation: "msup $1 °"
@@ -8098,7 +8098,7 @@ concepts:
     
     - concept: pollaczek-polynomial
       arity: 1
-      en: pollaczek-polynomial of $1
+      en: pollaczek polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "msubsup P n (λ"
@@ -8109,7 +8109,7 @@ concepts:
     
     - concept: polygamma-function
       arity: 1
-      en: polygamma-function of $1
+      en: polygamma function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi ψ"
@@ -8121,7 +8121,7 @@ concepts:
     
     - concept: polynomial-ring
       arity: 2
-      en: polynomial-ring
+      en: polynomial ring
       property: mixfix
       area: "ring theory"
       notation: "mrow $1 [ $2 ]"
@@ -8145,7 +8145,7 @@ concepts:
     
     - concept: pontrjagin-dual
       arity: 1
-      en: pontrjagin-dual of $1
+      en: pontrjagin dual of $1
       property: mover
       area: "harmonic analysis"
       notation: "mover $1 ^"
@@ -8155,7 +8155,7 @@ concepts:
     
     - concept: pontryagin-class
       arity: 1
-      en: pontryagin-class of $1
+      en: pontryagin class of $1
       property: "indexed symbol"
       area: "differential topology"
       notation: "msub p $1"
@@ -8167,7 +8167,7 @@ concepts:
     
     - concept: positive-part
       arity: 1
-      en: positive-part of $1
+      en: positive part of $1
       property: msup<br/>msub
       area: "elementary mathematics"
       notation: "msup $1 +<br/>msub $1 +"
@@ -8178,7 +8178,7 @@ concepts:
     
     - concept: positivitiy-predicate
       arity: 1
-      en: positivitiy-predicate of $1
+      en: positivitiy predicate of $1
       property: prefix
       area: "predicative mathematics"
       notation: "mo ◊"
@@ -8187,7 +8187,7 @@ concepts:
     
     - concept: post-canonical-system
       arity: 1
-      en: post-canonical-system of $1
+      en: post canonical system of $1
       property: fenced
       area: "formal languages"
       notation: "mrow (A,I,R"
@@ -8198,7 +8198,7 @@ concepts:
     
     - concept: power-set
       arity: 1
-      en: power-set of $1
+      en: power set of $1
       property: "function<br/>msup"
       area: "set theory"
       notation: "mi P<br/>mi 𝒫<br/>mi ℙ<br/>mi ℘<br/>msup 2 $1"
@@ -8209,7 +8209,7 @@ concepts:
     
     - concept: preregular-space
       arity: 0
-      en: preregular-space
+      en: preregular space
       property: constant
       area: "topology"
       notation: "msub R 1"
@@ -8218,7 +8218,7 @@ concepts:
     
     - concept: present-value
       arity: 0
-      en: present-value
+      en: present value
       property: symbol
       area: "economics"
       notation: "mi PV<br/>mi v"
@@ -8228,7 +8228,7 @@ concepts:
     
     - concept: prime-constant
       arity: 0
-      en: prime-constant
+      en: prime constant
       property: symbol
       area: "number theory"
       notation: "mi P<br/>mi ρ"
@@ -8240,7 +8240,7 @@ concepts:
     
     - concept: prime-counting-function
       arity: 1
-      en: prime-counting-function of $1
+      en: prime counting function of $1
       property: function
       area: "number theory"
       notation: "mi π"
@@ -8249,7 +8249,7 @@ concepts:
     
     - concept: prime-difference-function
       arity: 1
-      en: prime-difference-function of $1
+      en: prime difference function of $1
       property: "indexed function"
       area: "number theory"
       notation: "mi d"
@@ -8258,7 +8258,7 @@ concepts:
     
     - concept: prime-gap
       arity: 1
-      en: prime-gap of $1
+      en: prime gap of $1
       property: "indexed function"
       area: "number theory"
       notation: "mi G<br/>mi g"
@@ -8278,7 +8278,7 @@ concepts:
     
     - concept: principal-value
       arity: 1
-      en: principal-value of $1
+      en: principal value of $1
       property: function
       area: "complex analysis"
       notation: "mi Log"
@@ -8287,7 +8287,7 @@ concepts:
     
     - concept: probability-limit
       arity: 1
-      en: probability-limit of $1
+      en: probability limit of $1
       property: "indexed function"
       area: "probability theory"
       notation: "mi plim"
@@ -8298,7 +8298,7 @@ concepts:
     
     - concept: product-integral
       arity: 1
-      en: product-integral of $1
+      en: product integral of $1
       property: indexed
       area: "calculus"
       notation: "mo ∏"
@@ -8309,7 +8309,7 @@ concepts:
     
     - concept: product-measure
       arity: 2
-      en: product-measure
+      en: product measure
       property: function
       area: "measure theory"
       notation: "mrow $1 × $2"
@@ -8319,7 +8319,7 @@ concepts:
     
     - concept: projective-line
       arity: 1
-      en: projective-line of $1
+      en: projective line of $1
       property: function
       area: "projective geometry"
       notation: "mi P"
@@ -8329,7 +8329,7 @@ concepts:
     
     - concept: projective-space
       arity: 0
-      en: projective-space
+      en: projective space
       property: symbol
       area: "projective geometry"
       notation: "mi ℙ<br/>mi ℝ⁢ ℙ"
@@ -8344,7 +8344,7 @@ concepts:
     
     - concept: proper-subgroup
       arity: 2
-      en: $1 proper-subgroup $2
+      en: $1 proper subgroup $2
       property: infix
       area: "group theory"
       notation: "mo <"
@@ -8366,7 +8366,7 @@ concepts:
     
     - concept: prouhet-thue-morse-constant
       arity: 0
-      en: prouhet-thue-morse-constant
+      en: prouhet thue morse constant
       property: constant
       area: "number theory"
       notation: "mi τ"
@@ -8375,7 +8375,7 @@ concepts:
     
     - concept: prufer-group
       arity: 1
-      en: prufer-group of $1
+      en: prufer group of $1
       property: mixfix
       area: "group theory"
       notation: "mrow Z ( msup $1 ∞ /msup"
@@ -8398,7 +8398,7 @@ concepts:
     
     - concept: pseudo-inner-product
       arity: 2
-      en: pseudo-inner-product
+      en: pseudo inner product
       property: fenced
       area: "lie algebra"
       notation: "mrow ( $1, $2"
@@ -8426,7 +8426,7 @@ concepts:
     
     - concept: pythagoras-constant
       arity: 0
-      en: pythagoras-constant
+      en: pythagoras constant
       property: constant
       area: "geometry"
       notation: "msqrt 2"
@@ -8440,7 +8440,7 @@ concepts:
     
     - concept: pythagorean-triple
       arity: 3
-      en: pythagorean-triple  $1, $2 and $3
+      en: pythagorean triple  $1, $2 and $3
       property: fenced
       area: "geometry"
       notation: "mrow ($1, $2, $3"
@@ -8450,7 +8450,7 @@ concepts:
     
     - concept: q-binomial-coefficient
       arity: 1
-      en: q-binomial-coefficient of $1
+      en: q binomial coefficient of $1
       property: fenced-stacked
       area: "combinatorics"
       notation: "msub mrow [ stacked mfrac ] q"
@@ -8471,7 +8471,7 @@ concepts:
     
     - concept: quadratic-differential
       arity: 1
-      en: quadratic-differential of $1
+      en: quadratic differential of $1
       property: mixfix
       area: "complex manifolds"
       notation: "mrow d $1 ⊗ d $1"
@@ -8482,7 +8482,7 @@ concepts:
     
     - concept: quadratic-variation
       arity: 2
-      en: quadratic-variation
+      en: quadratic variation
       property: indexed fenced
       area: "stochastic processes"
       notation: "msub mrow [ $1 ] /mrow $2"
@@ -8504,7 +8504,7 @@ concepts:
     
     - concept: quotient-group
       arity: 2
-      en: $1 quotient-group $2
+      en: $1 quotient group $2
       property: infix
       area: "group theory"
       notation: "mo /"
@@ -8515,7 +8515,7 @@ concepts:
     
     - concept: quotient-space
       arity: 2
-      en: $1 quotient-space $2
+      en: $1 quotient space $2
       property: infix
       area: "topology"
       notation: "mo /"
@@ -8530,7 +8530,7 @@ concepts:
     
     - concept: r-complexity-class
       arity: 0
-      en: r-complexity-class
+      en: r complexity class
       property: symbol
       area: "complexity theory"
       notation: "mi R"
@@ -8541,7 +8541,7 @@ concepts:
     
     - concept: racah-polynomial
       arity: 1
-      en: racah-polynomial of $1
+      en: racah polynomial of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub R $1"
@@ -8552,7 +8552,7 @@ concepts:
     
     - concept: radial-mathieu-function
       arity: 1
-      en: radial-mathieu-function of $1
+      en: radial mathieu function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi Mc<br/>mi Ms"
@@ -8577,7 +8577,7 @@ concepts:
     
     - concept: radius-vector
       arity: 0
-      en: radius-vector
+      en: radius vector
       property: symbol
       area: "geometry"
       notation: "mix<br/>mir<br/>mis"
@@ -8592,7 +8592,7 @@ concepts:
     
     - concept: ramanujan-sum
       arity: 1
-      en: ramanujan-sum of $1
+      en: ramanujan sum of $1
       property: "indexed function"
       area: "number theory"
       notation: "msub c $1"
@@ -8603,7 +8603,7 @@ concepts:
     
     - concept: ramanujan-tau-function
       arity: 1
-      en: ramanujan-tau-function of $1
+      en: ramanujan tau function of $1
       property: function
       area: "number theory"
       notation: "mi τ"
@@ -8614,7 +8614,7 @@ concepts:
     
     - concept: ramanujan-soldner-constant
       arity: 0
-      en: ramanujan-soldner-constant
+      en: ramanujan soldner constant
       property: constant
       area: "special functions"
       notation: "mi μ"
@@ -8627,7 +8627,7 @@ concepts:
     
     - concept: ramification-index
       arity: 1
-      en: ramification-index of $1
+      en: ramification index of $1
       property: msub
       area: "algebraic number theory"
       notation: "msub e $1"
@@ -8637,7 +8637,7 @@ concepts:
     
     - concept: ramsey-number
       arity: 1
-      en: ramsey-number of $1
+      en: ramsey number of $1
       property: function
       area: "graph theory"
       notation: "mi R"
@@ -8661,7 +8661,7 @@ concepts:
     
     - concept: real-bipolar
       arity: 1
-      en: real-bipolar of $1
+      en: real bipolar of $1
       property: msup
       area: "functional analysis"
       notation: "msup $1 r r"
@@ -8672,7 +8672,7 @@ concepts:
     
     - concept: real-part
       arity: 1
-      en: real-part of $1
+      en: real part of $1
       property: function
       area: "complex analysis"
       notation: "mi ℜ<br/>mi Re<br/>mi ℛℯ"
@@ -8683,7 +8683,7 @@ concepts:
     
     - concept: real-prepolar
       arity: 1
-      en: real-prepolar of $1
+      en: real prepolar of $1
       property: prescript
       area: "functional analysis"
       notation: "msup <mrow/> r /msup $1"
@@ -8694,7 +8694,7 @@ concepts:
     
     - concept: real-polar
       arity: 1
-      en: real-polar of $1
+      en: real polar of $1
       property: msup
       area: "functional analysis"
       notation: "msup $1 r"
@@ -8705,7 +8705,7 @@ concepts:
     
     - concept: recession-cone
       arity: 1
-      en: recession-cone of $1
+      en: recession cone of $1
       property: function
       area: "convex analysis"
       notation: "mi recc"
@@ -8714,7 +8714,7 @@ concepts:
     
     - concept: reciprocal-polynomial
       arity: 1
-      en: reciprocal-polynomial of $1
+      en: reciprocal polynomial of $1
       property: msup
       area: "algebra"
       notation: "msup $1 *<br/>msup $1 R"
@@ -8737,7 +8737,7 @@ concepts:
     
     - concept: reduced-suspension
       arity: 1
-      en: reduced-suspension of $1
+      en: reduced suspension of $1
       property: function
       area: "topology"
       notation: "mi Σ"
@@ -8746,7 +8746,7 @@ concepts:
     
     - concept: relative-homology
       arity: 1
-      en: relative-homology of $1
+      en: relative homology of $1
       property: "indexed function"
       area: "algebraic topology"
       notation: "mi H"
@@ -8790,7 +8790,7 @@ concepts:
     
     - concept: resolvent-set
       arity: 1
-      en: resolvent-set of $1
+      en: resolvent set of $1
       property: function
       area: "set theory"
       notation: "mi ρ"
@@ -8800,7 +8800,7 @@ concepts:
     
     - concept: restricted-quantifier
       arity: 2
-      en: restricted-quantifier
+      en: restricted quantifier
       property: mixfix
       area: "formal logic"
       notation: "msub mrow ( Ǝ $1 ) /mrow $2<br/>msub mrow ( ∀ $1 ) /mrow $2"
@@ -8810,7 +8810,7 @@ concepts:
     
     - concept: restricted-wreath-product
       arity: 2
-      en: $1 restricted-wreath-product $2
+      en: $1 restricted wreath product $2
       property: infix
       area: "group theory"
       notation: "mo wr<br/>msub wr $1"
@@ -8848,7 +8848,7 @@ concepts:
     
     - concept: rewrite-rule
       arity: 2
-      en: $1 rewrite-rule $2
+      en: $1 rewrite rule $2
       property: infix
       area: "logic"
       notation: "mo →"
@@ -8859,7 +8859,7 @@ concepts:
     
     - concept: reynolds-number
       arity: 0
-      en: reynolds-number
+      en: reynolds number
       property: symbol
       area: "fluid dynamics"
       notation: "mi Re"
@@ -8868,7 +8868,7 @@ concepts:
     
     - concept: ricci-scalar
       arity: 0
-      en: ricci-scalar
+      en: ricci scalar
       property: symbol
       area: "riemannian geometry"
       notation: "mi S<br/>mi R<br/>mi Sc"
@@ -8880,7 +8880,7 @@ concepts:
     
     - concept: ricci-tensor
       arity: 1
-      en: ricci-tensor of $1
+      en: ricci tensor of $1
       property: "indexed symbol"
       area: "riemannian geometry"
       notation: "mi R"
@@ -8890,7 +8890,7 @@ concepts:
     
     - concept: riemann-integral
       arity: 1
-      en: riemann-integral of $1
+      en: riemann integral of $1
       property: indexed
       area: "calculus"
       notation: "mo ∫"
@@ -8905,7 +8905,7 @@ concepts:
     
     - concept: riemann-sphere
       arity: 1
-      en: riemann-sphere of $1
+      en: riemann sphere of $1
       property: scripted symbol
       area: "projective geometry"
       notation: "mover ℂ ^<br/>mover ℂ ¯<br/>msub ℂ ∞"
@@ -8920,7 +8920,7 @@ concepts:
     
     - concept: riemann-theta-function
       arity: 1
-      en: riemann-theta-function of $1
+      en: riemann theta function of $1
       property: function
       area: "special functions"
       notation: "mi θ⁡"
@@ -8931,7 +8931,7 @@ concepts:
     
     - concept: riemann-zeta-function
       arity: 1
-      en: riemann-zeta-function of $1
+      en: riemann zeta function of $1
       property: function
       area: "special functions"
       notation: "mi ζ"
@@ -8946,7 +8946,7 @@ concepts:
     
     - concept: riemann-christoffel-tensor
       arity: 1
-      en: riemann-christoffel-tensor of $1
+      en: riemann christoffel tensor of $1
       property: "indexed function"
       area: "riemannian geometry"
       notation: "mi R"
@@ -8960,7 +8960,7 @@ concepts:
     
     - concept: riemann-stieltje-integral
       arity: 1
-      en: riemann-stieltje-integral of $1
+      en: riemann stieltje integral of $1
       property: indexed
       area: "measure theory"
       notation: "mo ∫"
@@ -8976,7 +8976,7 @@ concepts:
     
     - concept: right-angle
       arity: 1
-      en: right-angle of $1
+      en: right angle of $1
       property: prefix
       area: "geometry"
       notation: "mo ∟<br/>mo ⊾<br/>mo ⦜<br/>mo ⦝"
@@ -8986,7 +8986,7 @@ concepts:
     
     - concept: right-derivative
       arity: 1
-      en: right-derivative of $1
+      en: right derivative of $1
       property: operator
       area: "calculus"
       notation: "msub ∂ +"
@@ -8995,7 +8995,7 @@ concepts:
     
     - concept: right-quotient
       arity: 2
-      en: $1 right-quotient $2
+      en: $1 right quotient $2
       property: infix
       area: "formal languages"
       notation: "mo \\"
@@ -9004,7 +9004,7 @@ concepts:
     
     - concept: ring-of-formal-power-series
       arity: 2
-      en: ring-of-formal-power-series
+      en: ring of formal power series
       property: mixfix
       area: "ring theory"
       notation: "mrow $1 [[ $2 ]]"
@@ -9013,7 +9013,7 @@ concepts:
     
     - concept: rising-factorial
       arity: 2
-      en: rising-factorial
+      en: rising factorial
       property: mixfix
       area: "combinatorics"
       notation: "msup $1 mover $2 ¯<br/>msup $1 mrow ( $2 ) /mrow"
@@ -9030,7 +9030,7 @@ concepts:
     
     - concept: roman-numeral
       arity: 0
-      en: roman-numeral
+      en: roman numeral
       property: symbol
       area: "number theory"
       notation: "mi i<br/>mi ii<br/>mi iii<br/>mi iv<br/>mi v<br/>mi vi<br/>mi vii<br/>mi viii<br/>mi ix<br/>mi x"
@@ -9054,7 +9054,7 @@ concepts:
     
     - concept: root-of-unity
       arity: 0
-      en: root-of-unity
+      en: root of unity
       property: symbol
       area: "complex numbers"
       notation: "mi ω"
@@ -9065,7 +9065,7 @@ concepts:
     
     - concept: root-mean-square
       arity: 1
-      en: root-mean-square of $1
+      en: root mean square of $1
       property: msub
       area: "means"
       notation: "msub $1 RMS"
@@ -9077,7 +9077,7 @@ concepts:
     
     - concept: rooted-product-of-graphs
       arity: 2
-      en: $1 rooted-product-of-graphs $2
+      en: $1 rooted product of graphs $2
       property: infix
       area: "graph theory"
       notation: "mo ∘"
@@ -9086,7 +9086,7 @@ concepts:
     
     - concept: ruark-number
       arity: 0
-      en: ruark-number
+      en: ruark number
       property: symbol
       area: "physics"
       notation: "mi Ru"
@@ -9095,7 +9095,7 @@ concepts:
     
     - concept: s-set-theory
       arity: 0
-      en: s-set-theory
+      en: s set theory
       property: constant
       area: "set theory"
       notation: "miS"
@@ -9104,7 +9104,7 @@ concepts:
     
     - concept: s5-modal-logic
       arity: 0
-      en: s5-modal-logic
+      en: s5 modal logic
       property: constant
       area: "logic"
       notation: "miS5"
@@ -9113,7 +9113,7 @@ concepts:
     
     - concept: sample-space
       arity: 0
-      en: sample-space
+      en: sample space
       property: symbol
       area: "probability theory"
       notation: "mi S<br/>mi Ω<br/>mi U"
@@ -9124,7 +9124,7 @@ concepts:
     
     - concept: sample-variance
       arity: 1
-      en: sample-variance of $1
+      en: sample variance of $1
       property: embellished symbol
       area: "probability theory"
       notation: "msub m 2<br/>msup s 2<br/>msubsup s $1 2<br/>msubsup σ $1 2"
@@ -9135,7 +9135,7 @@ concepts:
     
     - concept: scalar-triple-product
       arity: 3
-      en: scalar-triple-product  of $1, $2 and $3
+      en: scalar triple product  of $1, $2 and $3
       property: mixfix<br/>fenced
       area: "vector algebra"
       notation: "mrow $1 ⋅ ( $2 × $3 )<br/>mrow [ $1 , $2 , $3 ]"
@@ -9145,7 +9145,7 @@ concepts:
     
     - concept: scaled-riemann-theta-function
       arity: 1
-      en: scaled-riemann-theta-function of $1
+      en: scaled riemann theta function of $1
       property: mover
       area: "special functions"
       notation: "mover θ⁡ ^"
@@ -9155,7 +9155,7 @@ concepts:
     
     - concept: schlaefli-symbol
       arity: 1
-      en: schlaefli-symbol of $1
+      en: schlaefli symbol of $1
       property: fenced
       area: "geometry"
       notation: "mrow { $1 , ..., $n }"
@@ -9164,7 +9164,7 @@ concepts:
     
     - concept: schroder-number
       arity: 1
-      en: schroder-number of $1
+      en: schroder number of $1
       property: "indexed symbol"
       area: "combinatorics"
       notation: "msub S $1"
@@ -9175,7 +9175,7 @@ concepts:
     
     - concept: schur-multiplier
       arity: 1
-      en: schur-multiplier of $1
+      en: schur multiplier of $1
       property: function
       area: "group theory"
       notation: "mi M"
@@ -9188,7 +9188,7 @@ concepts:
     
     - concept: schwartz-space
       arity: 0
-      en: schwartz-space
+      en: schwartz space
       property: symbol
       area: "topology"
       notation: "mi𝒮<br/>mi S"
@@ -9199,7 +9199,7 @@ concepts:
     
     - concept: schwarzian-derivative
       arity: 2
-      en: schwarzian-derivative
+      en: schwarzian derivative
       property: fenced<br/>mixfix
       area: "complex analysis"
       notation: "mrow { $1, $2 }<br/>mrow ( S $1 ) ($2"
@@ -9211,7 +9211,7 @@ concepts:
     
     - concept: second-carmichael-function
       arity: 1
-      en: second-carmichael-function of $1
+      en: second carmichael function of $1
       property: function
       area: "number theory"
       notation: "msup λ '"
@@ -9221,7 +9221,7 @@ concepts:
     
     - concept: sectional-curvature
       arity: 1
-      en: sectional-curvature of $1
+      en: sectional curvature of $1
       property: function
       area: "riemannian geometry"
       notation: "mi K<br/>mi κ"
@@ -9263,7 +9263,7 @@ concepts:
     
     - concept: set-of-invertible-maps
       arity: 1
-      en: set-of-invertible-maps of $1
+      en: set of invertible maps of $1
       property: prefix
       area: "commutative algebra"
       notation: "mo !"
@@ -9272,7 +9272,7 @@ concepts:
     
     - concept: shannon-entropy
       arity: 0
-      en: shannon-entropy
+      en: shannon entropy
       property: symbol
       area: "information theory"
       notation: "mi H"
@@ -9286,7 +9286,7 @@ concepts:
     
     - concept: shift-operator
       arity: 1
-      en: shift-operator of $1
+      en: shift operator of $1
       property: oeprator
       area: "functional analysis"
       notation: "msup T t"
@@ -9300,7 +9300,7 @@ concepts:
     
     - concept: shimura-variety
       arity: 1
-      en: shimura-variety of $1
+      en: shimura variety of $1
       property: function
       area: "algebraic geometry"
       notation: "mi Sh"
@@ -9311,7 +9311,7 @@ concepts:
     
     - concept: short-exact-sequence
       arity: 3
-      en: short-exact-sequence
+      en: short exact sequence
       property: mixfix
       area: "group theory"
       notation: "mrow 0 →$1 → $2 → $3 → 0"
@@ -9321,7 +9321,7 @@ concepts:
     
     - concept: short-rate
       arity: 0
-      en: short-rate
+      en: short rate
       property: symbol
       area: "mathematical finance"
       notation: "msub r t"
@@ -9333,7 +9333,7 @@ concepts:
     
     - concept: sidon-sequence
       arity: 0
-      en: sidon-sequence
+      en: sidon sequence
       property: symbol
       area: "combinatorics"
       notation: "mi A"
@@ -9345,7 +9345,7 @@ concepts:
     
     - concept: sign-function
       arity: 1
-      en: sign-function of $1
+      en: sign function of $1
       property: function
       area: "special-functions"
       notation: "mi sgn"
@@ -9356,7 +9356,7 @@ concepts:
     
     - concept: signature-of-permutation
       arity: 1
-      en: signature-of-permutation of $1
+      en: signature of permutation of $1
       property: function
       area: "combinatorics"
       notation: "mi sign"
@@ -9367,7 +9367,7 @@ concepts:
     
     - concept: silver-ratio
       arity: 0
-      en: silver-ratio
+      en: silver ratio
       property: constant
       area: "number theory"
       notation: "msub δ S"
@@ -9401,7 +9401,7 @@ concepts:
     
     - concept: sinc-function
       arity: 1
-      en: sinc-function of $1
+      en: sinc function of $1
       property: function
       area: "special functions"
       notation: "mi S<br/>mi sinc"
@@ -9412,7 +9412,7 @@ concepts:
     
     - concept: sine-integral
       arity: 1
-      en: sine-integral of $1
+      en: sine integral of $1
       property: operator
       area: "special functions"
       notation: "mi Si"
@@ -9424,7 +9424,7 @@ concepts:
     
     - concept: size-of-test
       arity: 0
-      en: size-of-test
+      en: size of test
       property: symbol
       area: "statistics"
       notation: "mi α"
@@ -9433,7 +9433,7 @@ concepts:
     
     - concept: skewes-number
       arity: 1
-      en: skewes-number of $1
+      en: skewes number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub Sk $1"
@@ -9443,7 +9443,7 @@ concepts:
     
     - concept: small-o
       arity: 1
-      en: small-o of $1
+      en: small o of $1
       property: prefix
       area: "complexity"
       notation: "mi o"
@@ -9453,7 +9453,7 @@ concepts:
     
     - concept: smith-number
       arity: 1
-      en: smith-number of $1
+      en: smith number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "mi S"
@@ -9463,7 +9463,7 @@ concepts:
     
     - concept: sobolev-space
       arity: 2
-      en: sobolev-space
+      en: sobolev space
       property: "indexed symbol"
       area: "fourier analysis"
       notation: "msubsup W $1 $2"
@@ -9487,7 +9487,7 @@ concepts:
     
     - concept: soft-o
       arity: 0
-      en: soft-o
+      en: soft o
       property: symbol
       area: "complexity theory"
       notation: "mi Õ"
@@ -9497,7 +9497,7 @@ concepts:
     
     - concept: solid-angle
       arity: 0
-      en: solid-angle
+      en: solid angle
       property: symbol
       area: "geometry"
       notation: "mi Ω"
@@ -9517,7 +9517,7 @@ concepts:
     
     - concept: special-linear-group
       arity: 1
-      en: special-linear-group of $1
+      en: special linear group of $1
       property: "indexed function"
       area: "group theory"
       notation: "msub SL $1"
@@ -9529,7 +9529,7 @@ concepts:
     
     - concept: special-orthogonal-group
       arity: 1
-      en: special-orthogonal-group of $1
+      en: special orthogonal group of $1
       property: "indexed function"
       area: "group theory"
       notation: "mi SO"
@@ -9539,7 +9539,7 @@ concepts:
     
     - concept: special-unitary-group
       arity: 1
-      en: special-unitary-group of $1
+      en: special unitary group of $1
       property: function
       area: "lie groups"
       notation: "mi SU"
@@ -9550,7 +9550,7 @@ concepts:
     
     - concept: spectral-radius
       arity: 1
-      en: spectral-radius of $1
+      en: spectral radius of $1
       property: function
       area: "spectral theory"
       notation: "mi ρ"
@@ -9570,7 +9570,7 @@ concepts:
     
     - concept: spectrum-category
       arity: 0
-      en: spectrum-category
+      en: spectrum category
       property: symbol
       area: "category theory"
       notation: "mi Sp"
@@ -9579,7 +9579,7 @@ concepts:
     
     - concept: spectrum-of-matrix
       arity: 1
-      en: spectrum-of-matrix of $1
+      en: spectrum of matrix of $1
       property: msub
       area: "linear algebra"
       notation: "msub σ $1"
@@ -9588,7 +9588,7 @@ concepts:
     
     - concept: spectrum-of-algebra
       arity: 1
-      en: spectrum-of-algebra of $1
+      en: spectrum of algebra of $1
       property: mover
       area: "algebra"
       notation: "mover ˆ"
@@ -9597,7 +9597,7 @@ concepts:
     
     - concept: spectrum-of-ring
       arity: 1
-      en: spectrum-of-ring of $1
+      en: spectrum of ring of $1
       property: function
       area: "group theory"
       notation: "mi Spec"
@@ -9606,7 +9606,7 @@ concepts:
     
     - concept: spherical-bessel-function-of-third-kind
       arity: 2
-      en: spherical-bessel-function-of-third-kind
+      en: spherical bessel function of third kind
       property: "indexed function"
       area: "special functions"
       notation: "msubsup h $1 (1)<br/>msubsup h $2 (2"
@@ -9617,7 +9617,7 @@ concepts:
     
     - concept: spherical-coordinate
       arity: 3
-      en: spherical-coordinate
+      en: spherical coordinate
       property: fenced
       area: "geometry"
       notation: "mrow ($1, $2, $3"
@@ -9627,7 +9627,7 @@ concepts:
     
     - concept: spin-angular-momentum
       arity: 0
-      en: spin-angular-momentum
+      en: spin angular momentum
       property: symbol
       area: "quantum mechanics"
       notation: "mi S"
@@ -9636,7 +9636,7 @@ concepts:
     
     - concept: spin-group
       arity: 0
-      en: spin-group
+      en: spin group
       property: symbol
       area: "group theory"
       notation: "mi Spin"
@@ -9648,7 +9648,7 @@ concepts:
     
     - concept: spin-quantum-number
       arity: 0
-      en: spin-quantum-number
+      en: spin quantum number
       property: symbol
       area: "quantum mechanics"
       notation: "mi s"
@@ -9667,7 +9667,7 @@ concepts:
     
     - concept: stable-distribution
       arity: 0
-      en: stable-distribution
+      en: stable distribution
       property: symbol
       area: "probability theory"
       notation: "msub S 1<br/>msub S 2"
@@ -9687,7 +9687,7 @@ concepts:
     
     - concept: standard-deviation
       arity: 0
-      en: standard-deviation
+      en: standard deviation
       property: symbol
       area: "probability theory"
       notation: "mi σ"
@@ -9699,7 +9699,7 @@ concepts:
     
     - concept: standard-flattening
       arity: 1
-      en: standard-flattening of $1
+      en: standard flattening of $1
       property: "indexed symbol"
       area: "multilinear algebra"
       notation: "msub 𝒜 ($1"
@@ -9711,7 +9711,7 @@ concepts:
     
     - concept: stanley-reisner-ring
       arity: 2
-      en: stanley-reisner-ring
+      en: stanley reisner ring
       property: mixfix
       area: "commutative algebra"
       notation: "mrow $1 [ $2 ]"
@@ -9724,7 +9724,7 @@ concepts:
     
     - concept: stanley-reisner-ideal
       arity: 1
-      en: stanley-reisner-ideal of $1
+      en: stanley reisner ideal of $1
       property: msub
       area: "commutative algebra"
       notation: "msub I $1"
@@ -9746,7 +9746,7 @@ concepts:
     
     - concept: star-height
       arity: 1
-      en: star-height of $1
+      en: star height of $1
       property: function
       area: "formal languages"
       notation: "mi h"
@@ -9755,7 +9755,7 @@ concepts:
     
     - concept: steinberg-group
       arity: 1
-      en: steinberg-group of $1
+      en: steinberg group of $1
       property: function
       area: "k-theory"
       notation: "mi St"
@@ -9766,7 +9766,7 @@ concepts:
     
     - concept: stiefel-manifold
       arity: 2
-      en: stiefel-manifold
+      en: stiefel manifold
       property: mixfix
       area: "differential geometry"
       notation: "mrow msub V $1 /msub ( $2"
@@ -9777,7 +9777,7 @@ concepts:
     
     - concept: stiefel-whitney-class
       arity: 1
-      en: stiefel-whitney-class of $1
+      en: stiefel whitney class of $1
       property: function
       area: "algebraic topology"
       notation: "mi w"
@@ -9790,7 +9790,7 @@ concepts:
     
     - concept: stieltjes-wigert-polynomial
       arity: 1
-      en: stieltjes-wigert-polynomial of $1
+      en: stieltjes wigert polynomial of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub S $1"
@@ -9801,7 +9801,7 @@ concepts:
     
     - concept: stirling-number-of-first-kind
       arity: 1
-      en: stirling-number-of-first-kind of $1
+      en: stirling number of first kind of $1
       property: function
       area: "special functions"
       notation: "mi s"
@@ -9812,7 +9812,7 @@ concepts:
     
     - concept: stirling-number-of-second-kind
       arity: 1
-      en: stirling-number-of-second-kind of $1
+      en: stirling number of second kind of $1
       property: function
       area: "special functions"
       notation: "mi S"
@@ -9823,7 +9823,7 @@ concepts:
     
     - concept: strength-of-a-graph
       arity: 1
-      en: strength-of-a-graph of $1
+      en: strength of a graph of $1
       property: function
       area: "graph theory"
       notation: "mi σ"
@@ -9834,7 +9834,7 @@ concepts:
     
     - concept: string-concatenation
       arity: 2
-      en: $1 string-concatenation $2
+      en: $1 string concatenation $2
       property: infix
       area: "computer science"
       notation: "mo"
@@ -9844,7 +9844,7 @@ concepts:
     
     - concept: strong-product
       arity: 2
-      en: $1 strong-product $2
+      en: $1 strong product $2
       property: infix
       area: "graph theory"
       notation: "mo ⊠"
@@ -9856,7 +9856,7 @@ concepts:
     
     - concept: struve-function
       arity: 1
-      en: struve-function of $1
+      en: struve function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi H"
@@ -9912,7 +9912,7 @@ concepts:
     
     - concept: succeeds-or-equals
       arity: 2
-      en: $1 succeeds-or-equals $2
+      en: $1 succeeds or equals $2
       property: infix
       area: "set theory"
       notation: "mo ≽"
@@ -9933,7 +9933,7 @@ concepts:
     
     - concept: such-that
       arity: 2
-      en: $1 such-that $2
+      en: $1 such that $2
       property: infix
       area: "set theory"
       notation: "$1 | $2<br/>$1 : $2"
@@ -9952,7 +9952,7 @@ concepts:
     
     - concept: superfluous-submodule
       arity: 2
-      en: $1 superfluous-submodule $2
+      en: $1 superfluous submodule $2
       property: infix
       area: "abstract algebra"
       notation: "msub ⊆ s<br/>mo ≪"
@@ -9991,7 +9991,7 @@ concepts:
     
     - concept: supremum-limit
       arity: 1
-      en: supremum-limit of $1
+      en: supremum limit of $1
       property: indexed
       area: "limits"
       notation: "mi lim sup<br/>mover lim ¯"
@@ -10008,7 +10008,7 @@ concepts:
     
     - concept: surface-integral
       arity: 1
-      en: surface-integral of $1
+      en: surface integral of $1
       property: indexed
       area: "calculus"
       notation: "mo ∫"
@@ -10041,7 +10041,7 @@ concepts:
     
     - concept: symmetric-algebra
       arity: 1
-      en: symmetric-algebra of $1
+      en: symmetric algebra of $1
       property: function
       area: "algebra"
       notation: "mi S<br/>mi Sym"
@@ -10052,7 +10052,7 @@ concepts:
     
     - concept: symmetric-difference
       arity: 2
-      en: $1 symmetric-difference $2
+      en: $1 symmetric difference $2
       property: infix
       area: "set theory"
       notation: "mo △<br/>mo ⊕<br/>mo ⊖"
@@ -10063,7 +10063,7 @@ concepts:
     
     - concept: symmetric-group
       arity: 1
-      en: symmetric-group of $1
+      en: symmetric group of $1
       property: "msub<br/>function<br/>postfix"
       area: "group theory"
       notation: "msub S $1<br/>msub 𝔖 $1<br/>msub Σ $1<br/>mrow Σ ( $1 )<br/>mrow Sym ( $1 )<br/>mrow $1 !<br/>"
@@ -10074,7 +10074,7 @@ concepts:
     
     - concept: symmetric-space
       arity: 0
-      en: symmetric-space
+      en: symmetric space
       property: constant
       area: "topology"
       notation: "msub R 0"
@@ -10083,7 +10083,7 @@ concepts:
     
     - concept: symplectic-group
       arity: 1
-      en: symplectic-group of $1
+      en: symplectic group of $1
       property: function
       area: "group theory"
       notation: "mi Sp"
@@ -10096,7 +10096,7 @@ concepts:
     
     - concept: szego-polynomial
       arity: 1
-      en: szego-polynomial of $1
+      en: szego polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "msub ϕ $1"
@@ -10107,7 +10107,7 @@ concepts:
     
     - concept: tangent-bundle
       arity: 1
-      en: tangent-bundle of $1
+      en: tangent bundle of $1
       property: function
       area: "differential geometry"
       notation: "mi T"
@@ -10119,7 +10119,7 @@ concepts:
     
     - concept: tangent-space
       arity: 1
-      en: tangent-space of $1
+      en: tangent space of $1
       property: "indexed function"
       area: "topology"
       notation: "msub T $1"
@@ -10130,7 +10130,7 @@ concepts:
     
     - concept: tate-algebra
       arity: 0
-      en: tate-algebra
+      en: tate algebra
       property: symbol
       area: "analytic geometry"
       notation: "msub T n"
@@ -10141,7 +10141,7 @@ concepts:
     
     - concept: tate-module
       arity: 1
-      en: tate-module of $1
+      en: tate module of $1
       property: "indexed function"
       area: "group theory"
       notation: "msub T $1"
@@ -10152,7 +10152,7 @@ concepts:
     
     - concept: tau-particle
       arity: 0
-      en: tau-particle
+      en: tau particle
       property: symbol
       area: "particle physics"
       notation: "mi τ"
@@ -10161,7 +10161,7 @@ concepts:
     
     - concept: taxicab-number
       arity: 1
-      en: taxicab-number of $1
+      en: taxicab number of $1
       property: function
       area: "number theory"
       notation: "mi Ta"
@@ -10171,7 +10171,7 @@ concepts:
     
     - concept: taylor-polynomial
       arity: 1
-      en: taylor-polynomial of $1
+      en: taylor polynomial of $1
       property: function
       area: "number theory"
       notation: "mi Ta"
@@ -10182,7 +10182,7 @@ concepts:
     
     - concept: teichmuller-space
       arity: 1
-      en: teichmuller-space of $1
+      en: teichmuller space of $1
       property: function
       area: "differential geometry"
       notation: "mi T"
@@ -10204,7 +10204,7 @@ concepts:
     
     - concept: tensor-algebra
       arity: 1
-      en: tensor-algebra of $1
+      en: tensor algebra of $1
       property: function
       area: "multilinear algebra"
       notation: "mi T<br/>msup T •"
@@ -10213,7 +10213,7 @@ concepts:
     
     - concept: tensor-product
       arity: 2
-      en: $1 tensor-product $2
+      en: $1 tensor product $2
       property: infix
       area: "algebra"
       notation: "mo ⊗"
@@ -10226,7 +10226,7 @@ concepts:
     
     - concept: tensor-product-of-graphs
       arity: 2
-      en: $1 tensor-product-of-graphs $2
+      en: $1 tensor product of graphs $2
       property: infix
       area: "graph theory"
       notation: "mo ×"
@@ -10238,7 +10238,7 @@ concepts:
     
     - concept: therefore-sign
       arity: 1
-      en: therefore-sign of $1
+      en: therefore sign of $1
       property: prefix
       area: "logic"
       notation: "mo ∴"
@@ -10249,7 +10249,7 @@ concepts:
     
     - concept: theta-function
       arity: 1
-      en: theta-function of $1
+      en: theta function of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub θ $1"
@@ -10263,7 +10263,7 @@ concepts:
     
     - concept: thom-space
       arity: 1
-      en: thom-space of $1
+      en: thom space of $1
       property: function
       area: "algebraic topology"
       notation: "mi T"
@@ -10274,7 +10274,7 @@ concepts:
     
     - concept: thompson-group
       arity: 0
-      en: thompson-group
+      en: thompson group
       property: symbol
       area: "group theory"
       notation: "mi Th"
@@ -10294,7 +10294,7 @@ concepts:
     
     - concept: todd-class
       arity: 1
-      en: todd-class of $1
+      en: todd class of $1
       property: function
       area: "characteristic classes"
       notation: "mi td<br/>mi Td"
@@ -10305,7 +10305,7 @@ concepts:
     
     - concept: topological-entropy
       arity: 1
-      en: topological-entropy of $1
+      en: topological entropy of $1
       property: function
       area: "topology"
       notation: "mi h"
@@ -10316,7 +10316,7 @@ concepts:
     
     - concept: toroidal-coordinate
       arity: 1
-      en: toroidal-coordinate of $1
+      en: toroidal coordinate of $1
       property: fenced
       area: "geometry"
       notation: "mrow ( σ , τ , ϕ"
@@ -10348,7 +10348,7 @@ concepts:
     
     - concept: torsion-submodule
       arity: 1
-      en: torsion-submodule of $1
+      en: torsion submodule of $1
       property: function
       area: "abstract algebra"
       notation: "mi T"
@@ -10357,7 +10357,7 @@ concepts:
     
     - concept: torsion-subgroup
       arity: 1
-      en: torsion-subgroup of $1
+      en: torsion subgroup of $1
       property: msub
       area: "group theory"
       notation: "msub $1 T"
@@ -10367,7 +10367,7 @@ concepts:
     
     - concept: torsion-tensor
       arity: 1
-      en: torsion-tensor of $1
+      en: torsion tensor of $1
       property: function
       area: "differential geometry"
       notation: "mi T"
@@ -10376,7 +10376,7 @@ concepts:
     
     - concept: total-derivative
       arity: 2
-      en: total-derivative
+      en: total derivative
       property: mixfix
       area: "differential calculus"
       notation: "mrow d msub $1 $2 /msub"
@@ -10389,7 +10389,7 @@ concepts:
     
     - concept: total-variation
       arity: 1
-      en: total-variation of $1
+      en: total variation of $1
       property: fenced
       area: "measure theory"
       notation: "mrow |$1 |"
@@ -10409,7 +10409,7 @@ concepts:
     
     - concept: transitive-closure
       arity: 1
-      en: transitive-closure of $1
+      en: transitive closure of $1
       property: msup
       area: "set theory"
       notation: "msup $1 +"
@@ -10432,7 +10432,7 @@ concepts:
     
     - concept: triangle-function
       arity: 1
-      en: triangle-function of $1
+      en: triangle function of $1
       property: function
       area: "special functions"
       notation: "mi Λ<br/>mi tri"
@@ -10445,7 +10445,7 @@ concepts:
     
     - concept: triangular-number
       arity: 1
-      en: triangular-number of $1
+      en: triangular number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub T $1"
@@ -10457,7 +10457,7 @@ concepts:
     
     - concept: trilinear-coordinates
       arity: 2
-      en: $1 trilinear-coordinates $2
+      en: $1 trilinear coordinates $2
       property: infix
       area: "geometry"
       notation: "mrow $1 : $2 : $3"
@@ -10477,7 +10477,7 @@ concepts:
     
     - concept: triple-bond
       arity: 2
-      en: $1 triple-bond $2
+      en: $1 triple bond $2
       property: infix
       area: "chemistry"
       notation: "mo ≡"
@@ -10486,7 +10486,7 @@ concepts:
     
     - concept: triple-scalar-product
       arity: 3
-      en: triple-scalar-product of $1, $2 and $3
+      en: triple scalar product of $1, $2 and $3
       property: fenced
       area: "algebra"
       notation: "mrow [$1, $2, $3]"
@@ -10497,7 +10497,7 @@ concepts:
     
     - concept: triple-torus
       arity: 1
-      en: triple-torus of $1
+      en: triple torus of $1
       property: "indexed symbol"
       area: "topology"
       notation: "msup 𝕋 3"
@@ -10518,7 +10518,7 @@ concepts:
     
     - concept: tube-domain
       arity: 1
-      en: tube-domain of $1
+      en: tube domain of $1
       property: msub
       area: "complex analysis"
       notation: "msub T $1"
@@ -10528,7 +10528,7 @@ concepts:
     
     - concept: turan-graph
       arity: 2
-      en: turan-graph
+      en: turan graph
       property: "function<br/>indexed function"
       area: "graph theory"
       notation: "mi T<br/>mi D<br/>msub T $1<br/>msub T $1,$2"
@@ -10539,7 +10539,7 @@ concepts:
     
     - concept: turan-number
       arity: 3
-      en: turan-number of $1, $2 and $3
+      en: turan number of $1, $2 and $3
       property: function
       area: "graph theory"
       notation: "mrow T($1,$2,$3"
@@ -10563,7 +10563,7 @@ concepts:
     
     - concept: twisted-tensor-product
       arity: 2
-      en: $1 twisted-tensor-product $2
+      en: $1 twisted tensor product $2
       property: infix
       area: "topology"
       notation: "msub ⊗ τ"
@@ -10572,7 +10572,7 @@ concepts:
     
     - concept: tychonoff-space
       arity: 0
-      en: tychonoff-space
+      en: tychonoff space
       property: symbol
       area: "topology"
       notation: "msub T 3<br/>msub T π<br/>msub T 3½"
@@ -10583,7 +10583,7 @@ concepts:
     
     - concept: typing-judgement
       arity: 2
-      en: $1 typing-judgement $2
+      en: $1 typing judgement $2
       property: infix
       area: "type theory"
       notation: "mo : "
@@ -10592,7 +10592,7 @@ concepts:
     
     - concept: ulam-number
       arity: 1
-      en: ulam-number of $1
+      en: ulam number of $1
       property: "indexed symbol"
       area: "integer sequences"
       notation: "msub U $1"
@@ -10624,7 +10624,7 @@ concepts:
     
     - concept: uniformly-convergent
       arity: 1
-      en: uniformly-convergent of $1
+      en: uniformly convergent of $1
       property: infix<br/>indexed<br/>postfix
       area: "convergence"
       notation: "mo ⇉<br/>mover ⟶ unif.<br/>mo unif lim<br/>mtext uniformly"
@@ -10633,7 +10633,7 @@ concepts:
     
     - concept: unit-part
       arity: 1
-      en: unit-part of $1
+      en: unit part of $1
       property: fenced
       area: "SI units"
       notation: "mrow [ $1 ]"
@@ -10643,7 +10643,7 @@ concepts:
     
     - concept: unit-vector
       arity: 1
-      en: unit-vector of $1
+      en: unit vector of $1
       property: mover
       area: "linear algebra"
       notation: "mover $1 ^"
@@ -10654,7 +10654,7 @@ concepts:
     
     - concept: unitary-group
       arity: 1
-      en: unitary-group of $1
+      en: unitary group of $1
       property: "indexed symbol"
       area: "group theory"
       notation: "msub U $1"
@@ -10666,7 +10666,7 @@ concepts:
     
     - concept: universal-gas-constant
       arity: 0
-      en: universal-gas-constant
+      en: universal gas constant
       property: constant
       area: "physics"
       notation: "mi R<br/>mover R -"
@@ -10679,7 +10679,7 @@ concepts:
     
     - concept: universal-parabolic-constant
       arity: 0
-      en: universal-parabolic-constant
+      en: universal parabolic constant
       property: constant
       area: "geometry"
       notation: "mi P"
@@ -10689,7 +10689,7 @@ concepts:
     
     - concept: universal-set
       arity: 0
-      en: universal-set
+      en: universal set
       property: symbol
       area: "set theory"
       notation: "miV<br/>miU<br/>miξ"
@@ -10702,7 +10702,7 @@ concepts:
     
     - concept: unique-existential
       arity: 1
-      en: unique-existential of $1
+      en: unique existential of $1
       property: prefix
       area: "logic"
       notation: "mo ∃ !<br/>msub ∃ mrow =1 /mrow"
@@ -10712,7 +10712,7 @@ concepts:
     
     - concept: unnatural-isomorphism
       arity: 2
-      en: $1 unnatural-isomorphism $2
+      en: $1 unnatural isomorphism $2
       property: infix
       area: "set theory"
       notation: "mo ≈"
@@ -10721,7 +10721,7 @@ concepts:
     
     - concept: unrestricted-wreath-product
       arity: 2
-      en: $1 unrestricted-wreath-product $2
+      en: $1 unrestricted wreath product $2
       property: infix
       area: "group theory"
       notation: "mo ≀<br/>mo Wr<br/>msub Wr $1"
@@ -10733,7 +10733,7 @@ concepts:
     
     - concept: upper-closure-poset
       arity: 1
-      en: upper-closure-poset of $1
+      en: upper closure poset of $1
       property: prefix
       area: "order theory"
       notation: "mo ↑"
@@ -10742,7 +10742,7 @@ concepts:
     
     - concept: upper-darboux-integral
       arity: 1
-      en: upper-darboux-integral of $1
+      en: upper darboux integral of $1
       property: indexed
       area: "real analysis"
       notation: "mover ¯"
@@ -10752,7 +10752,7 @@ concepts:
     
     - concept: upper-dini-derivative
       arity: 1
-      en: upper-dini-derivative of $1
+      en: upper dini derivative of $1
       property: decorated function
       area: "analysis"
       notation: "msubsup $1 + '"
@@ -10763,7 +10763,7 @@ concepts:
     
     - concept: upper-half-plane
       arity: 0
-      en: upper-half-plane
+      en: upper half plane
       property: symbol
       area: "complex analysis"
       notation: "mi ℍ<br/>msup ℍ +"
@@ -10774,7 +10774,7 @@ concepts:
     
     - concept: upper-shadow
       arity: 1
-      en: upper-shadow of $1
+      en: upper shadow of $1
       property: function
       area: "combinatorics"
       notation: "msup 𝜕 +"
@@ -10803,7 +10803,7 @@ concepts:
     
     - concept: vector-concatenation
       arity: 2
-      en: $1 vector-concatenation $2
+      en: $1 vector concatenation $2
       property: infix
       area: "machine learning"
       notation: "mo ◦<br/>mo ⊕"
@@ -10813,7 +10813,7 @@ concepts:
     
     - concept: vector-projection
       arity: 1
-      en: vector-projection of $1
+      en: vector projection of $1
       property: function
       area: "linear algebra"
       notation: "mi proj"
@@ -10858,7 +10858,7 @@ concepts:
     
     - concept: vertical-composition
       arity: 2
-      en: $1 vertical-composition $2
+      en: $1 vertical composition $2
       property: infix
       area: "category theory"
       notation: "mo ∘"
@@ -10868,7 +10868,7 @@ concepts:
     
     - concept: volterra-integral
       arity: 1
-      en: volterra-integral of $1
+      en: volterra integral of $1
       property: indexed
       area: "calculus"
       notation: "mo Π"
@@ -10892,7 +10892,7 @@ concepts:
     
     - concept: volume-element
       arity: 0
-      en: volume-element
+      en: volume element
       property: symbol
       area: "measure theory"
       notation: "mrow d V"
@@ -10902,7 +10902,7 @@ concepts:
     
     - concept: walsh-function
       arity: 1
-      en: walsh-function of $1
+      en: walsh function of $1
       property: "indexed function"
       area: "special functions"
       notation: "mi W"
@@ -10913,7 +10913,7 @@ concepts:
     
     - concept: wavelet-transform
       arity: 2
-      en: wavelet-transform
+      en: wavelet transform
       property: "embellished function"
       area: "functional analysis"
       notation: "mrow [ msub W $1 /msub $2 ]"
@@ -10926,7 +10926,7 @@ concepts:
     
     - concept: way-below
       arity: 2
-      en: $1 way-below $2
+      en: $1 way below $2
       property: infix
       area: "domain theory"
       notation: "mo≪<br/>mo≫"
@@ -10939,7 +10939,7 @@ concepts:
     
     - concept: weak-convergence
       arity: 2
-      en: $1 weak-convergence $2
+      en: $1 weak convergence $2
       property: infix
       area: "analysis"
       notation: "mover →w<br/>mo ⇀"
@@ -10949,7 +10949,7 @@ concepts:
     
     - concept: weber-function
       arity: 1
-      en: weber-function of $1
+      en: weber function of $1
       property: "indexed function"
       area: "special functions"
       notation: "msub E ν"
@@ -10960,7 +10960,7 @@ concepts:
     
     - concept: weierstrass-elliptic-function
       arity: 1
-      en: weierstrass-elliptic-function of $1
+      en: weierstrass elliptic function of $1
       property: function
       area: "special functions"
       notation: "mi ℘"
@@ -10973,7 +10973,7 @@ concepts:
     
     - concept: weierstrass-sigma-function
       arity: 1
-      en: weierstrass-sigma-function of $1
+      en: weierstrass sigma function of $1
       property: function
       area: "special functions"
       notation: "mi σ"
@@ -10985,7 +10985,7 @@ concepts:
     
     - concept: weierstrass-zeta-function
       arity: 1
-      en: weierstrass-zeta-function of $1
+      en: weierstrass zeta function of $1
       property: function
       area: "special functions"
       notation: "mi ζ"
@@ -11008,7 +11008,7 @@ concepts:
     
     - concept: weighted-lehmer-mean
       arity: 2
-      en: weighted-lehmer-mean
+      en: weighted lehmer mean
       property: "indexed function"
       area: "means"
       notation: "msub L mrow $1 , $2 /mrow"
@@ -11018,7 +11018,7 @@ concepts:
     
     - concept: weighted-mean
       arity: 1
-      en: weighted-mean of $1
+      en: weighted mean of $1
       property: fenced
       area: "special functions"
       notation: "mrow ⟨ $1 ⟩"
@@ -11031,7 +11031,7 @@ concepts:
     
     - concept: wheel-graph
       arity: 1
-      en: wheel-graph of $1
+      en: wheel graph of $1
       property: "indexed symbol"
       area: "graph theory"
       notation: "msub W $1"
@@ -11041,7 +11041,7 @@ concepts:
     
     - concept: whitehead-group
       arity: 1
-      en: whitehead-group of $1
+      en: whitehead group of $1
       property: function
       area: "group theory"
       notation: "mi Wh"
@@ -11052,7 +11052,7 @@ concepts:
     
     - concept: whitehead-bracket
       arity: 2
-      en: whitehead-bracket
+      en: whitehead bracket
       property: fenced
       area: "lie algebra"
       notation: "mrow [ $1, $2 ]"
@@ -11063,7 +11063,7 @@ concepts:
     
     - concept: whitehead-torsion
       arity: 1
-      en: whitehead-torsion of $1
+      en: whitehead torsion of $1
       property: function
       area: "geometric topology"
       notation: "mi τ"
@@ -11074,7 +11074,7 @@ concepts:
     
     - concept: whittaker-function
       arity: 2
-      en: whittaker-function
+      en: whittaker function
       property: "indexed function"
       area: "special functions"
       notation: "msub M mrow $1, $2 /mrow<br/>msub W mrow $1, $2 /mrow"
@@ -11086,7 +11086,7 @@ concepts:
     
     - concept: wiener-algebra
       arity: 0
-      en: wiener-algebra
+      en: wiener algebra
       property: symbol
       area: "Fourier analysis"
       notation: "mrowA(T"
@@ -11096,7 +11096,7 @@ concepts:
     
     - concept: wiener-process
       arity: 1
-      en: wiener-process of $1
+      en: wiener process of $1
       property: "indexed symbol"
       area: "martingale theory"
       notation: "msub W $1"
@@ -11107,7 +11107,7 @@ concepts:
     
     - concept: wiener-sausage
       arity: 1
-      en: wiener-sausage of $1
+      en: wiener sausage of $1
       property: "indexed symbol"
       area: "mathematical physics"
       notation: "msub W $1"
@@ -11118,7 +11118,7 @@ concepts:
     
     - concept: wilson-polynomial
       arity: 1
-      en: wilson-polynomial of $1
+      en: wilson polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "msub W $1"
@@ -11130,7 +11130,7 @@ concepts:
     
     - concept: wilson-quotient
       arity: 1
-      en: wilson-quotient of $1
+      en: wilson quotient of $1
       property: function
       area: "number theory"
       notation: "mi W"
@@ -11140,7 +11140,7 @@ concepts:
     
     - concept: winding-number
       arity: 1
-      en: winding-number of $1
+      en: winding number of $1
       property: "function<br/>symbol"
       area: "algebraic topology"
       notation: "mi 𝒩<br/>mi w"
@@ -11153,7 +11153,7 @@ concepts:
     
     - concept: window-function
       arity: 1
-      en: window-function of $1
+      en: window function of $1
       property: function
       area: "fourier analysis"
       notation: "mi w"
@@ -11164,7 +11164,7 @@ concepts:
     
     - concept: wishart-distribution
       arity: 0
-      en: wishart-distribution
+      en: wishart distribution
       property: symbol
       area: "probability theory"
       notation: "msub W p"
@@ -11175,7 +11175,7 @@ concepts:
     
     - concept: witt-polynomials
       arity: 1
-      en: witt-polynomials of $1
+      en: witt polynomials of $1
       property: "indexed function"
       area: "ring theory"
       notation: "msub W $1"
@@ -11185,7 +11185,7 @@ concepts:
     
     - concept: witt-vector
       arity: 1
-      en: witt-vector of $1
+      en: witt vector of $1
       property: fenced
       area: "ring theory"
       notation: "mrow ( $1, ... , $n"
@@ -11195,7 +11195,7 @@ concepts:
     
     - concept: woodall-number
       arity: 1
-      en: woodall-number of $1
+      en: woodall number of $1
       property: "indexed symbol"
       area: "number theory"
       notation: "msub W $1"
@@ -11206,7 +11206,7 @@ concepts:
     
     - concept: wright-function
       arity: 1
-      en: wright-function of $1
+      en: wright function of $1
       property: function
       area: "special functions"
       notation: "mi ϕ"
@@ -11215,7 +11215,7 @@ concepts:
     
     - concept: wright-omega-function
       arity: 1
-      en: wright-omega-function of $1
+      en: wright omega function of $1
       property: function
       area: "special functions"
       notation: "mi ω"
@@ -11250,7 +11250,7 @@ concepts:
     
     - concept: yang-mill-functional
       arity: 1
-      en: yang-mill-functional of $1
+      en: yang mill functional of $1
       property: function
       area: "gauge theory"
       notation: "mi ℒ"
@@ -11261,7 +11261,7 @@ concepts:
     
     - concept: z-matrix
       arity: 0
-      en: z-matrix
+      en: z matrix
       property: symbol
       area: "linear algebra"
       notation: "mi Z"
@@ -11270,7 +11270,7 @@ concepts:
     
     - concept: z-matrix-molecule
       arity: 1
-      en: z-matrix-molecule of $1
+      en: z matrix molecule of $1
       property: mtable
       area: "chemistry"
       notation: "mtable"
@@ -11279,7 +11279,7 @@ concepts:
     
     - concept: z-transform
       arity: 1
-      en: z-transform of $1
+      en: z transform of $1
       property: function
       area: "combinatorics"
       notation: "mi Z"
@@ -11291,7 +11291,7 @@ concepts:
     
     - concept: zernike-polynomial
       arity: 1
-      en: zernike-polynomial of $1
+      en: zernike polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
       notation: "msubsup Z"
@@ -11302,7 +11302,7 @@ concepts:
     
     - concept: zero-ideal
       arity: 0
-      en: zero-ideal
+      en: zero ideal
       property: symbol
       area: "ring theory"
       notation: "mrow {0}"
@@ -11312,7 +11312,7 @@ concepts:
     
     - concept: zero-matrix
       arity: 1
-      en: zero-matrix of $1
+      en: zero matrix of $1
       property: "indexed symbol"
       area: "linear algebra"
       notation: "msub mn 0 mrow m,n"
@@ -11321,7 +11321,7 @@ concepts:
     
     - concept: zero-morphism
       arity: 1
-      en: zero-morphism of $1
+      en: zero morphism of $1
       property: "indexed symbol"
       area: "category theory"
       notation: "msub mn 0 mrow X,Y"
@@ -11331,7 +11331,7 @@ concepts:
     
     - concept: zero-object
       arity: 0
-      en: zero-object
+      en: zero object
       property: symbol
       area: "algebra"
       notation: "mrow {0}"
@@ -11341,7 +11341,7 @@ concepts:
     
     - concept: zero-ring
       arity: 0
-      en: zero-ring
+      en: zero ring
       property: symbol
       area: "ring theory"
       notation: "mrow {0}<br/>mn 0"
@@ -11351,7 +11351,7 @@ concepts:
     
     - concept: zero-vector
       arity: 0
-      en: zero-vector
+      en: zero vector
       property: constant
       area: "linear algebra"
       notation: "mn 0"
@@ -11360,7 +11360,7 @@ concepts:
     
     - concept: zeta-function
       arity: 1
-      en: zeta-function of $1
+      en: zeta function of $1
       property: function
       area: "number theory"
       notation: "mi ζ"
@@ -11372,7 +11372,7 @@ concepts:
     
     - concept: zig-zag-product
       arity: 2
-      en: $1 zig-zag-product $2
+      en: $1 zig zag product $2
       property: infix
       area: "graph theory"
       notation: "mo ∘"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -3134,7 +3134,7 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Discriminant"
     
     - concept: disjoint-union
-      arity: 2
+      arity: 1
       en: disjoint union of $1
       property: indexed
       area: "set theory"
@@ -3149,7 +3149,7 @@ concepts:
 
     - concept: disjoint-union
       arity: 2
-      en: disjoint union of $1
+      en: disjoint union of $1 and $2
       property: infix
       area: "set theory"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -420,7 +420,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi>,</mo><mi>D</mi><mo>]</mo></math>"
+       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi><mo>,</mo><mi>D</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -2299,8 +2299,9 @@ concepts:
       en: $1 covering relation $2
       property: infix
       area: "order theory"
-      notation: "mo ⋖"
-      notationa: "mo <: "
+      comments:
+       - "<math><mi>X</mi><mo>⋖</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>&lt;:</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partially_ordered_set"
        - "https://en.wikipedia.org/wiki/Covering_relation"
@@ -2326,7 +2327,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi>,</mo><mi>D</mi><mo>]</mo></math>"
+       - "<math><mo>(</mo><mi>A</mi><mo>,</mo><mi>B</mi><mo>;</mo><mi>C</mi><mo>,</mo><mi>D</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -2580,11 +2581,12 @@ concepts:
       en: $1 defined as $2
       property: infix
       area: "general"
-      notation: "mo ≜"
-      notationd: "mo ≡"
-      notationc: "mo : ="
-      notationb: "mover = def"
-      notationa: "mo : "
+      comments:
+       - "<math><mi>X</mi><mo>≜</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>≝</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>:=</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mover><mo>=</mo><mi>def</mi></mover><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>:</mo><mi>Y</mi></math>"
       urls: 
        - "https://math.stackexchange.com/questions/522864/what-is-the-symbol-triangleq"
        - "https://drive.google.com/file/d/1z_dcQ6lsOA_0CsH55fwcg4hQF_w22olM/view"
@@ -3140,9 +3142,10 @@ concepts:
       en: $1 divisible by $2
       property: infix
       area: "number theory"
-      notation: "$1 | $2"
-      notationb: "$2 ⋮ $1"
-      notationa: "$2 / $1"
+      comments:
+       - "<math><mi>X</mi><mo>|</mo><mi>Y</mi></math>"
+       - "<math><mi>Y</mi><mo>⋮</mo><mi>X</mi></math>"
+       - "<math><mi>Y</mi><mo>/</mo><mi>X</mi></math>"
       urls: 
        - "https://youtu.be/9dyK_op-Ocw?t=251"
        - "https://en.wikipedia.org/wiki/Divisor"
@@ -3584,9 +3587,10 @@ concepts:
       en: $1 essential extension $2
       property: infix
       area: "abstract algebra"
-      notation: "msub ⊆ e"
-      notationb: "mo ⊴"
-      notationa: "mo ⊂"
+      comments:
+       - "<math><mi>X</mi><msub><mo>⊆</mo><mi>e</mi></msub><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊴</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊂</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -3790,11 +3794,12 @@ concepts:
       en: $1 exclusive or $2
       property: infix
       area: "logic"
-      notation: "mo ⊻"
-      notationd: "mo ⊕"
-      notationc: "mo ↮"
-      notationb: "mo ≢"
-      notationa: "mi XOR"
+      comments:
+       - "<math><mi>X</mi><mo>⊻</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊕</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>↮</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>≢</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mi>XOR</mi><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExclusiveDisjunction.html"
        - "https://ncatlab.org/nlab/show/exclusive+disjunction"
@@ -3824,7 +3829,6 @@ concepts:
        - "<math><mi>E</mi><mrow><mi>X</mi></mrow></math>"
        - "<math><mi>M</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "msub μ $1"
-      notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
       alias:
@@ -4780,7 +4784,8 @@ concepts:
       en: $1 geometric product $2
       property: infix
       area: "geometric algebra"
-      notation: "mo invisible times"
+      comments:
+       - "<math><mi>X</mi><mo>&#x2062;</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Geometric_algebra"
     
@@ -5468,8 +5473,9 @@ concepts:
       en: $1 hydrated compound $2
       property: infix
       area: "chemistry"
-      notation: "mo ⋅"
-      notationa: "mo •"
+      comments:
+       - "<math><mi>X</mi><mo>⋅</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>•</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hydrate"
        - "https://en.wikipedia.org/wiki/Cobalt(II)_chloride"
@@ -5595,7 +5601,7 @@ concepts:
       property: function
       area: "category theory"
       notation: "msub 1 $1"
-      notationb: "msubI$1"
+      notationb: "msub I $1"
       notationa: "msub Id $1"
       urls: 
        - "https://ncatlab.org/nlab/show/identity+functor"
@@ -5649,7 +5655,8 @@ concepts:
       en: $1 incidence relation $2
       property: infix
       area: "projective geometry"
-      notation: "mi I"
+      comments:
+       - "<math><mi>X</mi><mi>I</mi><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Incidence_(geometry)"
        - "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"
@@ -5757,7 +5764,8 @@ concepts:
       en: $1 increase tends to? $2
       property: infix
       area: "calculus"
-      notation: "mo ↗"
+      comments:
+       - "<math><mi>X</mi><mo>↗</mo><mi>Y</mi></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"
@@ -5767,8 +5775,9 @@ concepts:
       en: $1 independent $2
       property: infix
       area: "probability theory"
-      notation: "mo ⟂"
-      notationa: "mo ⫫"
+      comments:
+       - "<math><mi>X</mi><mo>⟂</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⫫</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Independence_(probability_theory)"
        - "https://en.wikipedia.org/wiki/Independence_(mathematical_logic)"
@@ -9498,8 +9507,9 @@ concepts:
       en: $1 restricted wreath product $2
       property: infix
       area: "group theory"
-      notation: "mo wr"
-      notationa: "msub wr $1"
+      comments:
+       - "<math><mi>X</mi><mi>wr</mi><mi>Y</mi></math>"
+       - "<math><mi>X</mi><msub><mi>wr</mi><mi>&#x03a9;</mi></msub><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -10023,7 +10033,7 @@ concepts:
     - concept: shift-operator
       arity: 1
       en: shift operator of $1
-      property: oeprator
+      property: operator
       area: "functional analysis"
       notation: "msup T t"
       urls: 
@@ -10717,8 +10727,9 @@ concepts:
       en: $1 such that $2
       property: infix
       area: "set theory"
-      notation: "$1 | $2"
-      notationa: "$1 : $2"
+      comments:
+       - "<math><mi>X</mi><mo>|</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>:</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Set_(mathematics)#Set-builder_notation"
     
@@ -10738,8 +10749,9 @@ concepts:
       en: $1 superfluous submodule $2
       property: infix
       area: "abstract algebra"
-      notation: "msub ⊆ s"
-      notationa: "mo ≪"
+      comments:
+       - "<math><mi>X</mi><msub><mo>⊆</mo><mi>s</mi></msub><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>≪</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -10847,9 +10859,10 @@ concepts:
       en: $1 symmetric difference $2
       property: infix
       area: "set theory"
-      notation: "mo △"
-      notationb: "mo ⊕"
-      notationa: "mo ⊖"
+      comments:
+       - "<math><mi>X</mi><mo>△</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊕</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊖</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymmetricDifference.html"
        - "https://en.wikipedia.org/wiki/Symmetric_difference"
@@ -11101,7 +11114,8 @@ concepts:
       en: $1 to $2
       property: infix
       area: "arithmetic"
-      notation: "mo : "
+      comments:
+       - "<math><mi>X</mi><mo>:</mo><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/One-to-One.html"
     
@@ -11280,7 +11294,7 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Triangular_number"
     
     - concept: trilinear-coordinates
-      arity: 2
+      arity: 3
       en: $1 trilinear coordinates $2
       property: infix
       area: "geometry"
@@ -11402,7 +11416,8 @@ concepts:
       en: $1 twisted tensor product $2
       property: infix
       area: "topology"
-      notation: "msub ⊗ τ"
+      comments:
+       - "<math><mi>X</mi><msub><mo>⊗</mo><mi>τ</mi></msub><mi>Y</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/twisted+tensor+product"
     
@@ -11424,7 +11439,8 @@ concepts:
       en: $1 typing judgement $2
       property: infix
       area: "type theory"
-      notation: "mo : "
+      comments:
+       - "<math><mi>X</mi><mo>:</mo><mi>Y</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/judgment"
     
@@ -11572,9 +11588,10 @@ concepts:
       en: $1 unrestricted wreath product $2
       property: infix
       area: "group theory"
-      notation: "mo ≀"
-      notationb: "mo Wr"
-      notationa: "msub Wr $1"
+      comments:
+       - "<math><mi>X</mi><mo>≀</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>Wr</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><msub><mo>Wr</mo><mi>&#x03a9;</mi></msub><mi>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -11659,8 +11676,9 @@ concepts:
       en: $1 vector concatenation $2
       property: infix
       area: "machine learning"
-      notation: "mo ◦"
-      notationa: "mo ⊕"
+      comments:
+       - "<math><mi>X</mi><mo>◦</mo><mi>Y</mi></math>"
+       - "<math><mi>X</mi><mo>⊕</mo><mi>Y</mi></math>"
       urls: 
        - "https://arxiv.org/pdf/1903.00172v1.pdf"
        - "https://arxiv.org/abs/1901.10879"
@@ -11788,8 +11806,8 @@ concepts:
       en: $1 way below $2
       property: infix
       area: "domain theory"
-      notation: "mo≪"
-      notationa: "mo≫"
+      comments:
+       - "<math><mi>X</mi><mo>≪</mo><mi>Y</mi></math>"
       urls: 
        - "http://mizar.org/fm/1997-6/pdf6-1/waybel_3.pdf"
        - "https://en.wikipedia.org/wiki/Domain_theory"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10928,6 +10928,7 @@ concepts:
       en: symmetric space
       property: constant
       area: "topology"
+      comments:
        - "<math><msub><mi>R</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions)s"
@@ -10986,6 +10987,7 @@ concepts:
       en: tate algebra
       property: symbol
       area: "analytic geometry"
+      comments:
        - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tate_algebra"
@@ -11464,6 +11466,7 @@ concepts:
       en: tychonoff space
       property: symbol
       area: "topology"
+      comments:
        - "<math><msub><mi>T</mi><mn>3</mn></msub></math>"
        - "<math><msub><mi>T</mi><mn>π</mn></msub></math>"
        - "<math><msub><mi>T</mi><mn>3½</mn></msub></math>"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -8920,7 +8920,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi>X</mi><mo>&amp;lt;</mo><mi>Y</mi></mrow></math>"
+       - "<math><mrow><mi>X</mi><mo>&lt;</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Subgroup"
     
@@ -8929,6 +8929,7 @@ concepts:
       en: $1 proportional $2
       property: infix
       area: "arithmetic"
+      comments:
        - "<math><mrow><mi>X</mi><mo>∝</mo><mi>Y</mi></mrow></math>"
        - "<math><mrow><mi>X</mi><mo>~</mo><mi>Y</mi></mrow></math>"
       urls: 
@@ -9652,8 +9653,8 @@ concepts:
       en: roman numeral
       property: symbol
       area: "number theory"
-      notationi: "mi i"
-      notationh: "mi ii"
+      notationj: "mi i"
+      notationi: "mi ii"
       notationh: "mi iii"
       notationg: "mi iv"
       notationf: "mi v"
@@ -11919,7 +11920,7 @@ concepts:
       comments:
        - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
        - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
-       urls: 
+      urls: 
        - "https://en.wikipedia.org/wiki/Winding_number"
        - "https://dlmf.nist.gov/1.9#E32"
        - "https://ncatlab.org/nlab/show/winding+number"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -537,7 +537,8 @@ concepts:
       en: associator of $1, $2, $3
       property: fenced
       area: "algebra"
-      notation: "mrow [$1, $2, $3]"
+      comments:
+       - "<math><mo>[</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Associator.html"
        - "https://en.wikipedia.org/wiki/Associator"
@@ -812,7 +813,8 @@ concepts:
       en: bijection, $1, of $2 to $3
       property: mixfix
       area: "set theory"
-      notation: "mrow $1 : $2 ⤖ $3"
+      comments:
+       - "<math><mi>f</mi><mo>:</mo><mi>X</mi><mo>⤖</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -1383,7 +1385,8 @@ concepts:
       en: christoffel symbol of first kind>mrow msub Δ $1 [$2] ($3" of $1, $2, $3
       property: "indexed symbol"
       area: "Riemannian geometry"
-      notation: "msub Γ mrow $1 $2 $3"
+      comments:
+       - "<math><msub><mi>&Gamma;</mi><mrow><mi>k</mi><mi>i</mi><mi>j</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -1391,11 +1394,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Christoffel_symbol"
     
     - concept: christoffel-symbol-of-second-kind
-      arity: 1
-      en: christoffel symbol of second kind of $1
+      arity: 3
+      en: christoffel symbol of second kind of $1 $2 $3
       property: "indexed symbol"
       area: "Riemannian geometry"
-      notation: "msubsup Γ"
+      comments:
+       - "<math><multiscripts><mi>&Gamma;</mi><mrow/><mi>k</mi><mi>i</mi><mrow/><mi>j</mi><mrow/></multiscripts></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -5239,7 +5243,8 @@ concepts:
       en: incidence structure of $1, $2 and $3
       property: fenced
       area: "incidence geometry"
-      notation: "mrow ( $1, $2, $3"
+      comments:
+       - "<math><mo>(</mo><mi>P</mi><mo>,</mo><mi>L</mi><mo>,</mo><mi>I</mi><mo>)</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Incidence_structure"
     
@@ -9048,7 +9053,8 @@ concepts:
       en: roof of $1, $2 and $3
       property: mixfix
       area: "category theory"
-      notation: "mrow $1 ←$2 → $3"
+      comments:
+       - "<math><mi>X</mi><mo>&leftarrow;</mo><mi>Y</mi><mo>&rightarrow;</mo><mi>Z</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
@@ -9251,7 +9257,8 @@ concepts:
       en: selection
       property: "indexed function"
       area: "relational algebra"
-      notation: "msub σ mrow $1 $2 $3 /mrow"
+      comments:
+       - "<math><msub><mi>&sigma;</mi><mrow><mi>a</mi><mi>&theta;</mi><mi>b</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Selection_(relational_algebra)"
     
@@ -9320,7 +9327,8 @@ concepts:
       en: short exact sequence $1 $2 $3
       property: mixfix
       area: "group theory"
-      notation: "mrow 0 →$1 → $2 → $3 → 0"
+      comments:
+       - "<math><mn>0</mn><mo>&rightarrow;</mo><mi>X</mi><mo>&rightarrow;</mo><mi>Y</mi><mo>&rightarrow;</mo><mi>Z</mi><mo>&rightarrow;</mo><mn>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShortExactSequence.html"
        - "https://en.wikipedia.org/wiki/Exact_sequence"
@@ -9626,7 +9634,8 @@ concepts:
       en: spherical coordinate
       property: fenced
       area: "geometry"
-      notation: "mrow ($1, $2, $3"
+      comments:
+       - "<math><mo>(</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/SphericalCoordinates.html"
        - "https://www.encyclopediaofmath.org/index.php/Spherical_coordinates"
@@ -10029,7 +10038,8 @@ concepts:
       en: surjection  $1 $2 $3
       property: mixfix<br/>infix
       area: "set theory"
-      notation: "mrow $1 : $2 ↠ $3<br/>msup mo ≤ mo * /msup"
+      comments:
+       - "<math><mi>f</mi><mo>:</mo><mi>X</mi><mo>&#x21a0;</mo><mi>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
        - "https://en.wikipedia.org/wiki/Surjective_function"
@@ -10430,7 +10440,8 @@ concepts:
       en: triangle
       property: prefix
       area: "geometry"
-      notation: "mrow △ $1 $2 $3"
+      comments:
+       - "<math><mo>△</mo><mrow><mi>A</mi><mo>&thinsp;</mo><mi>B</mi><mo>&thinsp;</mo><mi>C</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Triangle.html"
        - "https://en.wikipedia.org/wiki/Triangle"
@@ -10496,7 +10507,8 @@ concepts:
       en: triple scalar product of $1, $2 and $3
       property: fenced
       area: "algebra"
-      notation: "mrow [$1, $2, $3]"
+      comments:
+       - "<math><mo>[</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/TripleScalarProduct.html"
       alias:
@@ -10549,7 +10561,8 @@ concepts:
       en: turan number of $1, $2 and $3
       property: function
       area: "graph theory"
-      notation: "mrow T($1,$2,$3"
+      comments:
+       - "<math><mi>T</mi><mrow><mo>(</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>,</mo><mi>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tur%C3%A1n_number"
        - "https://www.encyclopediaofmath.org/index.php/Turan_number"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -33,7 +33,8 @@ concepts:
       en: abundance of $1
       property: prefix
       area: "number theory"
-      notation: "mi A"
+      comments:
+        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Abundance.html"
     
@@ -52,7 +53,8 @@ concepts:
       en: ackermann function of $1
       property: function
       area: "computability theory"
-      notation: "mi A"
+      comments:
+        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ackermann_function"
        - "https://www.encyclopediaofmath.org/index.php/Ackermann_function"
@@ -146,7 +148,8 @@ concepts:
       en: adjoint representation of $1
       property: function
       area: "lie algebra"
-      notation: "mi Ad"
+      comments:
+        - "<math><mrow><mi>Ad</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdjointRepresentation.html"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -157,7 +160,8 @@ concepts:
       en: adjugate of $1
       property: function
       area: "linear algebra"
-      notation: "mi adj"
+      comments:
+        - "<math><mrow><mi>adj</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjugate_matrix"
     
@@ -166,7 +170,8 @@ concepts:
       en: affine group of $1
       property: function
       area: "group theory"
-      notation: "mi Aff"
+      comments:
+        - "<math><mrow><mi>Aff</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineGroup.html"
        - "https://en.wikipedia.org/wiki/Affine_group"
@@ -177,7 +182,8 @@ concepts:
       en: affine hull of $1
       property: function
       area: "affine geometry"
-      notation: "mi aff"
+      comments:
+        - "<math><mrow><mi>aff</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineHull.html"
        - "https://en.wikipedia.org/wiki/Affine_hull"
@@ -267,7 +273,8 @@ concepts:
       en: alternating factorial of $1
       property: function
       area: "functions"
-      notation: "mi af"
+      comments:
+        - "<math><mrow><mi>af</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Alternating_factorial"
     
@@ -351,7 +358,8 @@ concepts:
       en: anger function of $1
       property: function
       area: "special functions"
-      notation: "mi J"
+      comments:
+        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngerFunction.html"
        - "https://en.wikipedia.org/wiki/Anger_function"
@@ -363,7 +371,8 @@ concepts:
       en: angle of parallelism of $1
       property: function
       area: "hyperbolic geometry"
-      notation: "mi Π"
+      comments:
+        - "<math><mrow><mi>Π</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngleofParallelism.html"
        - "https://en.wikipedia.org/wiki/Angle_of_parallelism"
@@ -409,7 +418,8 @@ concepts:
       en: annihilator of $1
       property: function
       area: "ring theory"
-      notation: "mi Ann"
+      comments:
+        - "<math><mrow><mi>Ann</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Annihilator.html"
        - "https://en.wikipedia.org/wiki/Annihilator_(ring_theory)"
@@ -420,7 +430,8 @@ concepts:
       en: annulus of $1
       property: function
       area: "complex analysis"
-      notation: "mi ann"
+      comments:
+        - "<math><mrow><mi>ann</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Annulus_(mathematics)"
        - "https://ncatlab.org/nlab/show/annulus"
@@ -505,7 +516,8 @@ concepts:
       en: arf invariant of $1
       property: function
       area: "geometric topology"
-      notation: "mi Arf"
+      comments:
+        - "<math><mrow><mi>Arf</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ArfInvariant.html"
        - "https://en.wikipedia.org/wiki/Arf_invariant"
@@ -516,7 +528,8 @@ concepts:
       en: argument of $1
       property: function
       area: "complex analysis"
-      notation: "mi Arg"
+      comments:
+        - "<math><mrow><mi>Arg</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Argument_(complex_analysis)"
     
@@ -561,7 +574,8 @@ concepts:
       en: automorphism group of $1
       property: function
       area: "group theory"
-      notation: "mi Aut"
+      comments:
+        - "<math><mrow><mi>Aut</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Automorphism"
@@ -571,7 +585,8 @@ concepts:
       en: backward difference of $1
       property: operator
       area: "special functions"
-      notation: "mi ∇"
+      comments:
+        - "<math><mrow><mi>∇</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BackwardDifference.html"
        - "https://en.wikipedia.org/wiki/Finite_difference"
@@ -901,7 +916,8 @@ concepts:
       en: blaschke product of $1
       property: function
       area: "complex analysis"
-      notation: "mi B"
+      comments:
+        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlaschkeProduct.html"
        - "https://en.wikipedia.org/wiki/Blaschke_product"
@@ -975,7 +991,8 @@ concepts:
       en: bounded variation of $1
       property: function
       area: "analysis"
-      notation: "mi BV"
+      comments:
+        - "<math><mrow><mi>BV</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BoundedVariation.html"
        - "https://en.wikipedia.org/wiki/Bounded_variation"
@@ -996,7 +1013,8 @@ concepts:
       en: brauer group of $1
       property: function
       area: "group theory"
-      notation: "mi Br"
+      comments:
+        - "<math><mrow><mi>Br</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrauerGroup.html"
        - "https://en.wikipedia.org/wiki/Brauer_group"
@@ -1019,7 +1037,8 @@ concepts:
       en: burnside group of $1
       property: function
       area: "group theory"
-      notation: "mi B"
+      comments:
+        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Burnside_group"
     
@@ -1080,7 +1099,8 @@ concepts:
       en: carmichael function of $1
       property: function
       area: "number theory"
-      notation: "mi λ"
+      comments:
+        - "<math><mrow><mi>λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
        - "https://en.wikipedia.org/wiki/Carmichael_function"
@@ -1219,7 +1239,8 @@ concepts:
       en: center of $1
       property: function
       area: "algebra"
-      notation: "mi Z"
+      comments:
+        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(group_theory)"
        - "https://en.wikipedia.org/wiki/Center_(algebra)"
@@ -1263,7 +1284,8 @@ concepts:
       en: character of $1
       property: "indexed function"
       area: "group theory"
-      notation: "mi χ"
+      comments:
+        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Character.html"
        - "https://en.wikipedia.org/wiki/Character_(mathematics)"
@@ -1277,7 +1299,8 @@ concepts:
       en: characteristic of $1
       property: function
       area: "ring theory"
-      notation: "mi char"
+      comments:
+        - "<math><mrow><mi>char</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Characteristic.html"
        - "https://en.wikipedia.org/wiki/Characteristic_(algebra)"
@@ -1354,7 +1377,8 @@ concepts:
       en: cheeger constant of $1
       property: function
       area: "Riemannian geometry"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant"
     
@@ -1363,7 +1387,8 @@ concepts:
       en: cheeger number of $1
       property: function
       area: "graph theory"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant_(graph_theory)"
       alias:
@@ -1397,7 +1422,8 @@ concepts:
       en: chord of $1
       property: function
       area: "geometry"
-      notation: "mi crd"
+      comments:
+        - "<math><mrow><mi>crd</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chord_(geometry)"
     
@@ -1474,7 +1500,8 @@ concepts:
       en: clifford algebra of $1
       property: function
       area: "universal algebra"
-      notation: "mi Cl"
+      comments:
+        - "<math><mrow><mi>Cl</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clifford_algebra"
     
@@ -1495,7 +1522,8 @@ concepts:
       en: clique number of $1
       property: function
       area: "graph theory"
-      notation: "mi ω"
+      comments:
+        - "<math><mrow><mi>ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clique_number"
     
@@ -1548,7 +1576,8 @@ concepts:
       en: codimension of $1
       property: function
       area: "linear algebra"
-      notation: "mi codim"
+      comments:
+        - "<math><mrow><mi>codim</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Codimension.html"
        - "https://en.wikipedia.org/wiki/Codimension"
@@ -1560,7 +1589,8 @@ concepts:
       en: cofinality of $1
       property: function
       area: "order theory"
-      notation: "mi cf"
+      comments:
+        - "<math><mrow><mi>cf</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cofinality"
        - "https://ncatlab.org/nlab/show/cofinality"
@@ -1593,7 +1623,8 @@ concepts:
       en: coimage of $1
       property: function
       area: "abstract algebra"
-      notation: "mi coim"
+      comments:
+        - "<math><mrow><mi>coim</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coimage"
        - "https://ncatlab.org/nlab/show/coimage"
@@ -1603,7 +1634,8 @@ concepts:
       en: cokernel of $1
       property: function
       area: "category theory"
-      notation: "mi coker"
+      comments:
+        - "<math><mrow><mi>coker</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cokernel.html"
        - "https://en.wikipedia.org/wiki/Cokernel"
@@ -1785,7 +1817,8 @@ concepts:
       en: condition number of $1
       property: function
       area: "numerical analysis"
-      notation: "mi κ"
+      comments:
+        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Condition_number"
        - "https://dlmf.nist.gov/3.2#SS5.p1"
@@ -1817,7 +1850,8 @@ concepts:
       en: conductor of $1
       property: function
       area: "algebraic number theory"
-      notation: "mi 𝔣⁢"
+      comments:
+        - "<math><mrow><mi>𝔣⁢</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Conductor_(class_field_theory)"
     
@@ -1877,7 +1911,8 @@ concepts:
       en: conjugacy class of $1
       property: function
       area: "group theory"
-      notation: "mi Cl"
+      comments:
+        - "<math><mrow><mi>Cl</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugacyClass.html"
        - "https://en.wikipedia.org/wiki/Conjugacy_class"
@@ -1909,7 +1944,8 @@ concepts:
       en: connectivity of $1
       property: function
       area: "graph theory"
-      notation: "mi κ"
+      comments:
+        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Connectivity.html"
        - "https://en.wikipedia.org/wiki/Connectivity_(graph_theory)"
@@ -2088,7 +2124,8 @@ concepts:
       en: correlation of $1
       property: function
       area: "statistics"
-      notation: "mi corr"
+      comments:
+        - "<math><mrow><mi>corr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Correlation_and_dependence"
     
@@ -2109,7 +2146,8 @@ concepts:
       en: cosine integral of $1
       property: operator
       area: "special-functions"
-      notation: "mi Ci"
+      comments:
+        - "<math><mrow><mi>Ci</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -2134,7 +2172,8 @@ concepts:
       en: covariance of $1
       property: function
       area: "statistics"
-      notation: "mi cov"
+      comments:
+        - "<math><mrow><mi>cov</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Covariance.html"
        - "https://en.wikipedia.org/wiki/Covariance_operator"
@@ -2208,7 +2247,8 @@ concepts:
       en: crossing number of $1
       property: function
       area: "graph theory"
-      notation: "mi Cr"
+      comments:
+        - "<math><mrow><mi>Cr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Crossing_number_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Crossing_number_(knot_theory)"
@@ -2288,7 +2328,8 @@ concepts:
       en: curvature of $1
       property: function
       area: "differential geometry"
-      notation: "mi κ"
+      comments:
+        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Curvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"
@@ -2359,7 +2400,8 @@ concepts:
       en: davenport constant of $1
       property: function
       area: "group theory"
-      notation: "mi D"
+      comments:
+        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DavenportConstant.html"
        - "https://en.wikipedia.org/wiki/Davenport_constant"
@@ -2403,7 +2445,8 @@ concepts:
       en: dedekind eta function of $1
       property: function
       area: "special functions"
-      notation: "mi η"
+      comments:
+        - "<math><mrow><mi>η</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DedekindEtaFunction.html"
        - "https://en.wikipedia.org/wiki/Dedekind_eta_function"
@@ -2414,7 +2457,8 @@ concepts:
       en: dedekind zeta function of $1
       property: function
       area: "special functions"
-      notation: "mi ζ"
+      comments:
+        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dedekind_zeta_function"
     
@@ -2458,7 +2502,8 @@ concepts:
       en: degree of graph of $1
       property: function
       area: "graph theory"
-      notation: "mi deg"
+      comments:
+        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
       alias:
@@ -2481,7 +2526,8 @@ concepts:
       en: degree of mapping of $1
       property: function
       area: "topology"
-      notation: "mi deg"
+      comments:
+        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_continuous_mapping"
       alias:
@@ -2492,7 +2538,8 @@ concepts:
       en: degree of polynomial of $1
       property: function
       area: "polynomials"
-      notation: "mi deg"
+      comments:
+        - "<math><mrow><mi>deg</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_polynomial"
       alias:
@@ -2530,7 +2577,8 @@ concepts:
       en: derived category of $1
       property: function
       area: "category theory"
-      notation: "mi D"
+      comments:
+        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derived_category"
        - "https://ncatlab.org/nlab/show/derived+category"
@@ -2552,7 +2600,8 @@ concepts:
       en: diagonal intersection of $1
       property: function
       area: "set theory"
-      notation: "mi Δ"
+      comments:
+        - "<math><mrow><mi>Δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_intersection"
     
@@ -2561,7 +2610,8 @@ concepts:
       en: diagonal matrix of $1
       property: function
       area: "linear algebra"
-      notation: "mi diag"
+      comments:
+        - "<math><mrow><mi>diag</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_matrix"
     
@@ -2579,7 +2629,8 @@ concepts:
       en: dickman function of $1
       property: function
       area: "special functions"
-      notation: "mi ρ"
+      comments:
+        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DickmanFunction.html"
        - "https://en.wikipedia.org/wiki/Dickman_function"
@@ -2603,7 +2654,8 @@ concepts:
       en: differential entropy of $1
       property: function
       area: "information theory"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialEntropy.html"
        - "https://en.wikipedia.org/wiki/Differential_entropy"
@@ -2698,7 +2750,8 @@ concepts:
       en: dirac delta function of $1
       property: function
       area: "analysis"
-      notation: "mi δ"
+      comments:
+        - "<math><mrow><mi>δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracDeltaFunction.html"
        - "https://en.wikipedia.org/wiki/Dirac_delta_function"
@@ -2723,7 +2776,8 @@ concepts:
       en: dirac measure of $1
       property: function
       area: "measure theory"
-      notation: "mi δ"
+      comments:
+        - "<math><mrow><mi>δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirac_measure"
     
@@ -2732,7 +2786,8 @@ concepts:
       en: dirac operator of $1
       property: function
       area: "differential operators"
-      notation: "mi D"
+      comments:
+        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracOperator.html"
        - "https://en.wikipedia.org/wiki/Dirac_operator"
@@ -2794,7 +2849,8 @@ concepts:
       en: dirichlet character of $1
       property: function
       area: "special-functions"
-      notation: "mi χ"
+      comments:
+        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletCharacter.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_character"
@@ -2828,7 +2884,8 @@ concepts:
       en: dirichlet eta function of $1
       property: function
       area: "analytic number theory"
-      notation: "mi η"
+      comments:
+        - "<math><mrow><mi>η</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletEtaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%97(x)"
@@ -2850,7 +2907,8 @@ concepts:
       en: dirichlet l function of $1
       property: function
       area: "special-functions"
-      notation: "mi L"
+      comments:
+        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletL-Function.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_L-function"
@@ -2862,7 +2920,8 @@ concepts:
       en: discrete valuation of $1
       property: function
       area: "commutative algebra"
-      notation: "mi ν"
+      comments:
+        - "<math><mrow><mi>ν</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Discrete_valuation"
        - "https://ncatlab.org/nlab/show/discrete+valuation"
@@ -2957,7 +3016,8 @@ concepts:
       en: divisor function of $1
       property: indexed
       area: "number theory"
-      notation: "mi σ"
+      comments:
+        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DivisorFunction.html"
        - "https://en.wikipedia.org/wiki/D(n)"
@@ -2971,7 +3031,8 @@ concepts:
       en: domain of $1
       property: function
       area: "set theory"
-      notation: "mi dom"
+      comments:
+        - "<math><mrow><mi>dom</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_a_function"
     
@@ -2992,7 +3053,8 @@ concepts:
       en: domination number of $1
       property: function
       area: "graph theory"
-      notation: "mi γ"
+      comments:
+        - "<math><mrow><mi>γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DominationNumber.html"
        - "https://en.wikipedia.org/wiki/Dominating_set"
@@ -3061,7 +3123,8 @@ concepts:
       en: drinfeld center of $1
       property: prefix
       area: "category theory"
-      notation: "mi 𝒵"
+      comments:
+        - "<math><mrow><mi>𝒵</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(category_theory)"
       alias:
@@ -3126,7 +3189,8 @@ concepts:
       en: e function of $1
       property: function
       area: "special functions"
-      notation: "mi E"
+      comments:
+        - "<math><mrow><mi>E</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/E-Function.html"
        - "https://en.wikipedia.org/wiki/E-function"
@@ -3149,7 +3213,8 @@ concepts:
       en: edge cover number of $1
       property: function
       area: "graph theory"
-      notation: "mi ρ"
+      comments:
+        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EdgeCoverNumber.html"
        - "https://en.wikipedia.org/wiki/Edge_covering_number"
@@ -3159,7 +3224,8 @@ concepts:
       en: effective domain of $1
       property: function
       area: "convex analysis"
-      notation: "mi dom"
+      comments:
+        - "<math><mrow><mi>dom</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Effective_domain"
     
@@ -3168,7 +3234,8 @@ concepts:
       en: efficiency of $1
       property: function
       area: "statistics"
-      notation: "mi e"
+      comments:
+        - "<math><mrow><mi>e</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Antenna_efficiency"
        - "https://en.wikipedia.org/wiki/Efficiency_(statistics)"
@@ -3215,7 +3282,8 @@ concepts:
       en: endomorphism monoid of $1
       property: function
       area: "category theory"
-      notation: "mi End"
+      comments:
+        - "<math><mrow><mi>End</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Endomorphism.html"
        - "https://en.wikipedia.org/wiki/Endomorphism"
@@ -3247,7 +3315,8 @@ concepts:
       en: entropy of $1
       property: unit
       area: "physics"
-      notation: "mi S"
+      comments:
+        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Entropy"
        - "https://en.wikipedia.org/wiki/Entropy_(arrow_of_time)"
@@ -3260,7 +3329,8 @@ concepts:
       en: epigraph of $1
       property: function
       area: "analysis"
-      notation: "mi epi"
+      comments:
+        - "<math><mrow><mi>epi</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epigraph_(mathematics)"
     
@@ -3279,7 +3349,8 @@ concepts:
       en: equalizer of $1
       property: function
       area: "set theory"
-      notation: "mi Eq"
+      comments:
+        - "<math><mrow><mi>Eq</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Equalizer.html"
        - "https://en.wikipedia.org/wiki/Equaliser_(mathematics)"
@@ -3444,7 +3515,8 @@ concepts:
       en: euler characteristic of $1
       property: function
       area: "algebraic topology"
-      notation: "mi χ"
+      comments:
+        - "<math><mrow><mi>χ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerCharacteristic.html"
        - "https://en.wikipedia.org/wiki/Euler_characteristic"
@@ -3456,7 +3528,8 @@ concepts:
       en: euler class of $1
       property: function
       area: "algebraic topology"
-      notation: "mi e"
+      comments:
+        - "<math><mrow><mi>e</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_class"
        - "https://ncatlab.org/nlab/show/Euler+class"
@@ -3535,7 +3608,8 @@ concepts:
       en: eulerian number of $1
       property: function
       area: "combinatorics"
-      notation: "mi A"
+      comments:
+        - "<math><mrow><mi>A</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerianNumber.html"
        - "https://en.wikipedia.org/wiki/Eulerian_number"
@@ -3597,7 +3671,8 @@ concepts:
       en: exponential integral of $1
       property: 
       area: 
-      notation: "mi Ei"
+      comments:
+        - "<math><mrow><mi>Ei</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialIntegral.html"
        - "https://en.wikipedia.org/wiki/Exponential_integral"
@@ -3622,7 +3697,8 @@ concepts:
       en: exterior derivative of $1
       property: operator
       area: "differential forms"
-      notation: "mi d"
+      comments:
+        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorDerivative.html"
        - "https://en.wikipedia.org/wiki/Exterior_derivative"
@@ -3632,7 +3708,8 @@ concepts:
       en: exterior algebra of $1
       property: function
       area: "multilinear algebra"
-      notation: "mi Λ"
+      comments:
+        - "<math><mrow><mi>Λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Exterior_algebra"
     
@@ -3690,7 +3767,8 @@ concepts:
       en: fatou set of $1
       property: function
       area: "complex dynamics"
-      notation: "mi F"
+      comments:
+        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Julia_set"
     
@@ -3840,7 +3918,8 @@ concepts:
       en: fisher information of $1
       property: function
       area: "statistics"
-      notation: "mi I"
+      comments:
+        - "<math><mrow><mi>I</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FisherInformation.html"
        - "https://en.wikipedia.org/wiki/Fisher_information"
@@ -3877,7 +3956,8 @@ concepts:
       en: fock space of $1
       property: function
       area: "quantum mechanics"
-      notation: "mi F"
+      comments:
+        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fock_space"
        - "https://ncatlab.org/nlab/show/Fock+space"
@@ -3992,7 +4072,8 @@ concepts:
       en: franel number of $1
       property: "indexed symbol"
       area: "combinatorics"
-      notation: "mi Fr"
+      comments:
+        - "<math><mrow><mi>Fr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FranelNumber.html"
     
@@ -4012,7 +4093,8 @@ concepts:
       en: frechet derivative of $1
       property: operator
       area: "banach spaces"
-      notation: "mi D"
+      comments:
+        - "<math><mrow><mi>D</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrechetDerivative.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_derivative"
@@ -4036,7 +4118,8 @@ concepts:
       en: fredholm determinant of $1
       property: function
       area: "mathematical physics"
-      notation: "mi det"
+      comments:
+        - "<math><mrow><mi>det</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fredholm_determinant"
        - "https://ncatlab.org/nlab/show/Fredholm+determinant"
@@ -4162,7 +4245,8 @@ concepts:
       en: g function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi G"
+      comments:
+        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/G-Function.html"
        - "https://en.wikipedia.org/wiki/Meijer_G-function"
@@ -4174,7 +4258,8 @@ concepts:
       en: gabor transform of $1
       property: operator
       area: "integral transforms"
-      notation: "mi G"
+      comments:
+        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gabor_transform"
        - "https://en.wikipedia.org/wiki/Gabor%E2%80%93Wigner_transform"
@@ -4185,7 +4270,8 @@ concepts:
       en: gain function of $1
       property: function
       area: "graph theory"
-      notation: "mi φ"
+      comments:
+        - "<math><mrow><mi>φ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gain_graph"
        - "https://en.wikipedia.org/wiki/Gain_group"
@@ -4196,7 +4282,8 @@ concepts:
       en: galilean transformation of $1
       property: function
       area: "physics"
-      notation: "mi G"
+      comments:
+        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GalileanTransformation.html"
        - "https://en.wikipedia.org/wiki/Galilean_transformation"
@@ -4244,7 +4331,8 @@ concepts:
       en: gamma function of $1
       property: operator
       area: "special functions"
-      notation: "mi Γ"
+      comments:
+        - "<math><mrow><mi>Γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%93(x)"
@@ -4273,7 +4361,8 @@ concepts:
       en: gauss of $1
       property: unit
       area: "physics"
-      notation: "mi G"
+      comments:
+        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gauss_(unit)"
     
@@ -4296,7 +4385,8 @@ concepts:
       en: gaussian curvature of $1
       property: function
       area: "differential geometry"
-      notation: "mi Κ"
+      comments:
+        - "<math><mrow><mi>Κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianCurvature.html"
        - "https://en.wikipedia.org/wiki/Gaussian_curvature"
@@ -4441,7 +4531,8 @@ concepts:
       en: geodesic distance of $1
       property: function
       area: "graph theory"
-      notation: "mi d"
+      comments:
+        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Diameter_(graph_theory)"
@@ -4475,7 +4566,8 @@ concepts:
       en: geometric mean of $1
       property: function
       area: "means"
-      notation: "mi GM"
+      comments:
+        - "<math><mrow><mi>GM</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Geometric_mean"
@@ -4589,7 +4681,8 @@ concepts:
       en: grassmannian of $1
       property: function
       area: "differential geometry"
-      notation: "mi Gr"
+      comments:
+        - "<math><mrow><mi>Gr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Grassmannian.html"
        - "https://en.wikipedia.org/wiki/Grassmannian"
@@ -4600,7 +4693,8 @@ concepts:
       en: green function of $1
       property: function
       area: "mathematical physics"
-      notation: "mi G"
+      comments:
+        - "<math><mrow><mi>G</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GreensFunction.html"
        - "https://en.wikipedia.org/wiki/Green%27s_function_(many-body_theory)"
@@ -4657,7 +4751,8 @@ concepts:
       en: gudermannian function of $1
       property: function
       area: "trigonometry"
-      notation: "mi gd"
+      comments:
+        - "<math><mrow><mi>gd</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GudermannianFunction.html"
        - "https://en.wikipedia.org/wiki/Gudermannian_function"
@@ -4709,7 +4804,8 @@ concepts:
       en: hankel function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HankelFunction.html"
        - "https://dlmf.nist.gov/10.1"
@@ -4743,7 +4839,8 @@ concepts:
       en: hardy littlewood maximal operator of $1
       property: operator
       area: "real analysis"
-      notation: "mi M"
+      comments:
+        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function"
       alias:
@@ -4754,7 +4851,8 @@ concepts:
       en: harmonic mean of $1
       property: function
       area: "means"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HarmonicMean.html"
        - "https://en.wikipedia.org/wiki/Harmonic_mean"
@@ -4798,7 +4896,8 @@ concepts:
       en: hazard function of $1
       property: function
       area: "engineering"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HazardFunction.html"
       alias:
@@ -4809,7 +4908,8 @@ concepts:
       en: heaviside function of $1
       property: function
       area: "special functions"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/1.16#E13)[https://en.wikipedia.org/wiki/Heaviside_step_function"
        - "https://en.wikipedia.org/wiki/Heaviside_step_function"
@@ -4823,7 +4923,8 @@ concepts:
       en: heawood number of $1
       property: function
       area: "topological graph theory"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heawood_number"
     
@@ -4860,7 +4961,8 @@ concepts:
       en: height of prime ideal of $1
       property: function
       area: "commutative algebra"
-      notation: "mi ht"
+      comments:
+        - "<math><mrow><mi>ht</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Krull_dimension#height"
       alias:
@@ -4873,7 +4975,8 @@ concepts:
       en: heisenberg group
       property: symbol
       area: "group theory"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeisenbergGroup.html"
        - "https://en.wikipedia.org/wiki/Heisenberg_group"
@@ -4920,7 +5023,8 @@ concepts:
       en: heronian mean of $1
       property: function
       area: "means"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeronianMean.html"
        - "https://en.wikipedia.org/wiki/Heronian_mean"
@@ -4930,7 +5034,8 @@ concepts:
       en: hessian of $1
       property: operator
       area: "differential operators"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hessian.html"
        - "https://en.wikipedia.org/wiki/Hessian_matrix"
@@ -4955,7 +5060,8 @@ concepts:
       en: heun polynomial of $1
       property: function
       area: "special functions"
-      notation: "mi Hp"
+      comments:
+        - "<math><mrow><mi>Hp</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.5#p1"
@@ -5017,7 +5123,8 @@ concepts:
       en: holomorph of $1
       property: function
       area: "group theory"
-      notation: "mi Hol"
+      comments:
+        - "<math><mrow><mi>Hol</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Holomorph_(mathematics)"
        - "https://ncatlab.org/nlab/show/holomorph"
@@ -5027,7 +5134,8 @@ concepts:
       en: holonomy group of $1
       property: "indexed symbol"
       area: "differential geometry"
-      notation: "mi Hol"
+      comments:
+        - "<math><mrow><mi>Hol</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Holonomy.html"
        - "https://en.wikipedia.org/wiki/Holonomy"
@@ -5038,7 +5146,8 @@ concepts:
       en: home prime of $1
       property: function
       area: "number theory"
-      notation: "mi HP"
+      comments:
+        - "<math><mrow><mi>HP</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomePrime.html"
        - "https://en.wikipedia.org/wiki/Home_prime"
@@ -5068,7 +5177,8 @@ concepts:
       en: homotopy category of $1
       property: function
       area: "category theory"
-      notation: "mi Ho"
+      comments:
+        - "<math><mrow><mi>Ho</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/homotopy+category"
     
@@ -5077,7 +5187,8 @@ concepts:
       en: horsepower mechanical of $1
       property: unit
       area: "imperial unit"
-      notation: "mi hp"
+      comments:
+        - "<math><mrow><mi>hp</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
       alias:
@@ -5099,7 +5210,8 @@ concepts:
       en: hurwitz zeta function of $1
       property: function
       area: "special functions"
-      notation: "mi ζ"
+      comments:
+        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HurwitzZetaFunction.html"
        - "https://en.wikipedia.org/wiki/Hurwitz_zeta_function"
@@ -5111,7 +5223,8 @@ concepts:
       en: hvat of $1
       property: unit
       area: "customary units"
-      notation: "mi hvat"
+      comments:
+        - "<math><mrow><mi>hvat</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kubni_hvat"
        - "https://en.wikipedia.org/wiki/%C4%8Cetvorni_hvat"
@@ -5134,7 +5247,8 @@ concepts:
       en: hyperbolic cosine integral of $1
       property: function
       area: "special functions"
-      notation: "mi Chi"
+      comments:
+        - "<math><mrow><mi>Chi</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicCosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E16"
@@ -5154,7 +5268,8 @@ concepts:
       en: hyperbolic sine integral of $1
       property: function
       area: "special functions"
-      notation: "mi Shi"
+      comments:
+        - "<math><mrow><mi>Shi</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicSineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E15"
@@ -5308,7 +5423,8 @@ concepts:
       en: inclusion map of $1
       property: function
       area: "set theory"
-      notation: "mi ι"
+      comments:
+        - "<math><mrow><mi>ι</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Inclusion_map"
       alias:
@@ -5332,7 +5448,8 @@ concepts:
       en: incomplete beta function of $1
       property: function
       area: "special functions"
-      notation: "mi B"
+      comments:
+        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteBetaFunction.html"
        - "https://dlmf.nist.gov/8.17"
@@ -5344,7 +5461,8 @@ concepts:
       en: incomplete elliptic integral of the first kind of $1
       property: function
       area: "elliptic functions"
-      notation: "mi F"
+      comments:
+        - "<math><mrow><mi>F</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5355,7 +5473,8 @@ concepts:
       en: incomplete elliptic integral of the second kind of $1
       property: function
       area: "elliptic functions"
-      notation: "mi E"
+      comments:
+        - "<math><mrow><mi>E</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5366,7 +5485,8 @@ concepts:
       en: incomplete gamma function of $1
       property: function
       area: "special functions"
-      notation: "mi Γ"
+      comments:
+        - "<math><mrow><mi>Γ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteGammaFunction.html"
        - "https://en.wikipedia.org/wiki/Incomplete_gamma_function"
@@ -5420,7 +5540,8 @@ concepts:
       en: index of lie algebra of $1
       property: function
       area: "lie algebra"
-      notation: "mi ind"
+      comments:
+        - "<math><mrow><mi>ind</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_Lie_algebra"
     
@@ -5489,7 +5610,8 @@ concepts:
       en: inner automorphism group of $1
       property: function
       area: "abstract algebra"
-      notation: "mi Inn"
+      comments:
+        - "<math><mrow><mi>Inn</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerAutomorphism.html"
        - "https://en.wikipedia.org/wiki/Inner_automorphism"
@@ -5687,7 +5809,8 @@ concepts:
       en: j invariant of $1
       property: function
       area: "number theory"
-      notation: "mi j"
+      comments:
+        - "<math><mrow><mi>j</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/j-Invariant.html"
        - "https://ncatlab.org/nlab/show/j-invariant"
@@ -5697,7 +5820,8 @@ concepts:
       en: jacobi matrix of $1
       property: function
       area: "operator theory"
-      notation: "mi J"
+      comments:
+        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiMatrix.html"
        - "https://en.wikipedia.org/wiki/Jacobi_operator"
@@ -5736,7 +5860,8 @@ concepts:
       en: jacobi theta function of $1
       property: function
       area: "special-functions"
-      notation: "mi ϑ"
+      comments:
+        - "<math><mrow><mi>ϑ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiThetaFunctions.html"
        - "https://en.wikipedia.org/wiki/Jacobi_theta_functions_(notational_variations)"
@@ -5829,7 +5954,8 @@ concepts:
       en: jone polynomial of $1
       property: function
       area: "knot theory"
-      notation: "mi V"
+      comments:
+        - "<math><mrow><mi>V</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JonesPolynomial.html"
        - "https://en.wikipedia.org/wiki/Jones_polynomial"
@@ -5852,7 +5978,8 @@ concepts:
       en: jordan measure of $1
       property: function
       area: "measure theory"
-      notation: "mi m"
+      comments:
+        - "<math><mrow><mi>m</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
        - "https://en.wikipedia.org/wiki/Jordan_measure"
@@ -5872,7 +5999,8 @@ concepts:
       en: julia set of $1
       property: function
       area: "complex dynamics"
-      notation: "mi J"
+      comments:
+        - "<math><mrow><mi>J</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JuliaSet.html"
        - "https://en.wikipedia.org/wiki/Julia_set"
@@ -5922,7 +6050,8 @@ concepts:
       en: kernel of $1
       property: function
       area: "linear algebra"
-      notation: "mi ker"
+      comments:
+        - "<math><mrow><mi>ker</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Kernel.html"
        - "https://en.wikipedia.org/wiki/Kernel_(algebra)"
@@ -5952,7 +6081,8 @@ concepts:
       en: killing form of $1
       property: function
       area: "lie algebra"
-      notation: "mi B"
+      comments:
+        - "<math><mrow><mi>B</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KillingForm.html"
        - "https://en.wikipedia.org/wiki/Killing_form"
@@ -6012,7 +6142,8 @@ concepts:
       en: knodel number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "mi K"
+      comments:
+        - "<math><mrow><mi>K</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KnoedelNumbers.html"
        - "https://en.wikipedia.org/wiki/Kn%C3%B6del_number"
@@ -6022,7 +6153,8 @@ concepts:
       en: kodaira dimension of $1
       property: function
       area: "algebraic geometry"
-      notation: "mi κ"
+      comments:
+        - "<math><mrow><mi>κ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kodaira_dimension"
        - "https://www.encyclopediaofmath.org/index.php/Kodaira_dimension"
@@ -6032,7 +6164,8 @@ concepts:
       en: kolmogorov complexity of $1
       property: function
       area: "information theory"
-      notation: "mi K"
+      comments:
+        - "<math><mrow><mi>K</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KolmogorovComplexity.html"
        - "https://en.wikipedia.org/wiki/Kolmogorov_complexity"
@@ -6051,7 +6184,8 @@ concepts:
       en: kontsevich integral of $1
       property: function
       area: "knot theory"
-      notation: "mi Z"
+      comments:
+        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KontsevichIntegral.html"
        - "https://en.wikipedia.org/wiki/Kontsevich_invariant"
@@ -6122,7 +6256,8 @@ concepts:
       en: krull dimension of $1
       property: function
       area: "commutative algebra"
-      notation: "mi dim"
+      comments:
+        - "<math><mrow><mi>dim</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrullDimension.html"
        - "https://en.wikipedia.org/wiki/Krull_dimension"
@@ -6197,7 +6332,8 @@ concepts:
       en: laguerre polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
-      notation: "mi L"
+      comments:
+        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaguerrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Laguerre_polynomials"
@@ -6232,7 +6368,8 @@ concepts:
       en: laplace transform of $1
       property: operator
       area: "integral transforms"
-      notation: "mi ℒ⁡"
+      comments:
+        - "<math><mrow><mi>ℒ⁡</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplaceTransform.html"
        - "https://en.wikipedia.org/wiki/Laplace_transform"
@@ -6279,7 +6416,8 @@ concepts:
       en: least prime factor of $1
       property: function
       area: "number theory"
-      notation: "mi lpf"
+      comments:
+        - "<math><mrow><mi>lpf</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeastPrimeFactor.html"
     
@@ -6432,7 +6570,8 @@ concepts:
       en: levy prokhorov metric of $1
       property: function
       area: "measure theory"
-      notation: "mi π"
+      comments:
+        - "<math><mrow><mi>π</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Prokhorov_metric"
        - "https://encyclopediaofmath.org/wiki/L%C3%A9vy-Prokhorov_metric"
@@ -6497,7 +6636,8 @@ concepts:
       en: line graph of $1
       property: function
       area: "graph theory"
-      notation: "mi L"
+      comments:
+        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LineGraph.html"
        - "https://en.wikipedia.org/wiki/Line_graph"
@@ -6523,7 +6663,8 @@ concepts:
       en: linear span of $1
       property: function
       area: "linear algebra"
-      notation: "mi span"
+      comments:
+        - "<math><mrow><mi>span</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LinearSpan.html"
        - "https://en.wikipedia.org/wiki/Linear_span"
@@ -6536,7 +6677,8 @@ concepts:
       en: link of $1
       property: function
       area: "graph theory"
-      notation: "mi Lk"
+      comments:
+        - "<math><mrow><mi>Lk</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Link.html"
     
@@ -6566,7 +6708,8 @@ concepts:
       en: liouville function of $1
       property: function
       area: "number theory"
-      notation: "mi λ"
+      comments:
+        - "<math><mrow><mi>λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvilleFunction.html"
        - "https://en.wikipedia.org/wiki/Liouville_function"
@@ -6590,7 +6733,8 @@ concepts:
       en: logarithmic integral of $1
       property: function
       area: "special functions"
-      notation: "mi li"
+      comments:
+        - "<math><mrow><mi>li</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LogarithmicIntegral.html"
        - "https://dlmf.nist.gov/6.2#i"
@@ -6612,7 +6756,8 @@ concepts:
       en: logit of $1
       property: function
       area: "statistics"
-      notation: "mi logit"
+      comments:
+        - "<math><mrow><mi>logit</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Logit"
     
@@ -6644,7 +6789,8 @@ concepts:
       en: loop space of $1
       property: function
       area: "topology"
-      notation: "mi Ω"
+      comments:
+        - "<math><mrow><mi>Ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LoopSpace.html"
        - "https://en.wikipedia.org/wiki/Loop_space"
@@ -6718,7 +6864,8 @@ concepts:
       en: lyapunov candidate function of $1
       property: function
       area: "stability theory"
-      notation: "mi V"
+      comments:
+        - "<math><mrow><mi>V</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LyapunovFunction.html"
        - "https://en.wikipedia.org/wiki/Lyapunov_function"
@@ -6741,7 +6888,8 @@ concepts:
       en: mahler measure of $1
       property: function
       area: "number theory"
-      notation: "mi M"
+      comments:
+        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MahlerMeasure.html"
        - "https://en.wikipedia.org/wiki/Mahler_measure"
@@ -6752,7 +6900,8 @@ concepts:
       en: mangoldt function of $1
       property: function
       area: "special functions"
-      notation: "mi Λ"
+      comments:
+        - "<math><mrow><mi>Λ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MangoldtFunction.html"
        - "https://dlmf.nist.gov/27.2#E14"
@@ -6765,7 +6914,8 @@ concepts:
       en: mapping class group of $1
       property: function
       area: "geometric topology"
-      notation: "mi MCG"
+      comments:
+        - "<math><mrow><mi>MCG</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_class_group"
        - "https://ncatlab.org/nlab/show/mapping+class+group"
@@ -6888,7 +7038,8 @@ concepts:
       en: maximum degree of $1
       property: function
       area: "graph theory"
-      notation: "mi Δ"
+      comments:
+        - "<math><mrow><mi>Δ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MaximumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -6899,7 +7050,8 @@ concepts:
       en: mean curvature of $1
       property: function
       area: "differential geometry"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MeanCurvature.html"
        - "https://en.wikipedia.org/wiki/Mean_curvature"
@@ -6910,7 +7062,8 @@ concepts:
       en: mean squared error of $1
       property: function
       area: "statistics"
-      notation: "mi MSE"
+      comments:
+        - "<math><mrow><mi>MSE</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mean_squared_error"
     
@@ -6919,7 +7072,8 @@ concepts:
       en: meixner pollaczek polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
-      notation: "mi P"
+      comments:
+        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meixner-PollaczekPolynomial.html"
        - "https://en.wikipedia.org/wiki/Meixner%E2%80%93Pollaczek_polynomials"
@@ -6930,7 +7084,8 @@ concepts:
       en: mellin transform of $1
       property: operator
       area: "integral transforms"
-      notation: "mi ℳ"
+      comments:
+        - "<math><mrow><mi>ℳ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MellinTransform.html"
        - "https://en.wikipedia.org/wiki/Mellin_transform"
@@ -6942,7 +7097,8 @@ concepts:
       en: meridian radius of curvature of $1
       property: function
       area: "geodesy"
-      notation: "mi M"
+      comments:
+        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Meridian_arc"
        - "https://en.wikipedia.org/wiki/Meridian_arc"
@@ -6952,7 +7108,8 @@ concepts:
       en: meridian distance of $1
       property: function
       area: "geodesy"
-      notation: "mi m"
+      comments:
+        - "<math><mrow><mi>m</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meridian.html"
     
@@ -6982,7 +7139,8 @@ concepts:
       en: merten function of $1
       property: function
       area: "number theory"
-      notation: "mi M"
+      comments:
+        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MertensFunction.html"
        - "https://en.wikipedia.org/wiki/Mertens_function"
@@ -7035,7 +7193,8 @@ concepts:
       en: minimum degree of $1
       property: function
       area: "graph theory"
-      notation: "mi δ<br/>"
+      comments:
+        - "<math><mrow><mi>δ<br/></mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinimumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7081,7 +7240,8 @@ concepts:
       en: mobius function of $1
       property: function
       area: "number theory"
-      notation: "mi μ"
+      comments:
+        - "<math><mrow><mi>μ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MoebiusFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%9C(n)"
@@ -7158,7 +7318,8 @@ concepts:
       en: modular discriminant of $1
       property: operator
       area: "special functions"
-      notation: "mi Δ<br/>"
+      comments:
+        - "<math><mrow><mi>Δ<br/></mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModularDiscriminant.html"
        - "https://en.wikipedia.org/wiki/Modular_form#The_modular_discriminant"
@@ -7182,7 +7343,8 @@ concepts:
       en: moebius function of $1
       property: function
       area: "number theory"
-      notation: "mi μ"
+      comments:
+        - "<math><mrow><mi>μ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Moebius_function"
        - "https://en.wikipedia.org/wiki/M%C3%B6bius_function"
@@ -7394,7 +7556,8 @@ concepts:
       en: mutual information of $1
       property: function
       area: "information theory"
-      notation: "mi I"
+      comments:
+        - "<math><mrow><mi>I</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MutualInformation.html"
        - "https://en.wikipedia.org/wiki/Mutual_information"
@@ -7442,7 +7605,8 @@ concepts:
       en: negative hypergeometric distribution of $1
       property: "indexed symbol"
       area: "probability theory"
-      notation: "mi NHG"
+      comments:
+        - "<math><mrow><mi>NHG</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution"
        - "https://www.encyclopediaofmath.org/index.php/Negative_hypergeometric_distribution"
@@ -7463,7 +7627,8 @@ concepts:
       en: neighbourhood filter of $1
       property: function
       area: "topology"
-      notation: "mi 𝒩"
+      comments:
+        - "<math><mrow><mi>𝒩</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_system"
       alias:
@@ -7475,7 +7640,8 @@ concepts:
       en: neron severi group of $1
       property: function
       area: "group theory"
-      notation: "mi NS"
+      comments:
+        - "<math><mrow><mi>NS</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Neron-SeveriGroup.html"
        - "https://encyclopediaofmath.org/wiki/N%C3%A9ron-Severi_group"
@@ -7496,7 +7662,8 @@ concepts:
       en: nerve of $1
       property: function
       area: "category theory"
-      notation: "mi N"
+      comments:
+        - "<math><mrow><mi>N</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nerve.html"
        - "https://en.wikipedia.org/wiki/Nerve_(category_theory)"
@@ -7507,7 +7674,8 @@ concepts:
       en: nome of $1
       property: function
       area: "special functions"
-      notation: "mi q"
+      comments:
+        - "<math><mrow><mi>q</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
        - "https://en.wikipedia.org/wiki/Nome_(mathematics)"
@@ -7596,7 +7764,8 @@ concepts:
       en: object of $1
       property: prefix
       area: "category theory"
-      notation: "mi Obj"
+      comments:
+        - "<math><mrow><mi>Obj</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Object.html"
        - "https://en.wikipedia.org/wiki/Lattice-based_access_control"
@@ -7644,7 +7813,8 @@ concepts:
       en: onsager machlup function of $1
       property: function
       area: "functional analysis"
-      notation: "mi L"
+      comments:
+        - "<math><mrow><mi>L</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Onsager%E2%80%93Machlup_function"
        - "https://www.encyclopediaofmath.org/index.php/Onsager-Machlup_function"
@@ -7755,7 +7925,8 @@ concepts:
       en: orthogonal group of $1
       property: function
       area: "group theory"
-      notation: "mi O"
+      comments:
+        - "<math><mrow><mi>O</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OrthogonalGroup.html"
        - "https://en.wikipedia.org/wiki/Orthogonal_group"
@@ -7768,7 +7939,8 @@ concepts:
       en: outer automorphism group of $1
       property: function
       area: "abstract algebra"
-      notation: "mi Out"
+      comments:
+        - "<math><mrow><mi>Out</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterAutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Outer_automorphism_group"
@@ -7826,7 +7998,8 @@ concepts:
       en: padovan sequence of $1
       property: function
       area: "number theory"
-      notation: "mi P"
+      comments:
+        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PadovanSequence.html"
        - "https://en.wikipedia.org/wiki/Padovan_sequence"
@@ -7901,7 +8074,8 @@ concepts:
       en: partition function of $1
       property: function
       area: "number theory"
-      notation: "mi p"
+      comments:
+        - "<math><mrow><mi>p</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partition_(number_theory)"
     
@@ -7972,7 +8146,8 @@ concepts:
       en: permanent of $1
       property: function
       area: "linear algebra"
-      notation: "mi perm"
+      comments:
+        - "<math><mrow><mi>perm</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Permanent.html"
        - "https://en.wikipedia.org/wiki/Permanent"
@@ -8006,7 +8181,8 @@ concepts:
       en: perrin sequence of $1
       property: function
       area: "number theory"
-      notation: "mi P"
+      comments:
+        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PerrinNumber.html"
        - "https://en.wikipedia.org/wiki/Perrin_number"
@@ -8065,7 +8241,8 @@ concepts:
       en: picard group of $1
       property: function
       area: "group theory"
-      notation: "mi Pic"
+      comments:
+        - "<math><mrow><mi>Pic</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PicardGroup.html"
        - "https://en.wikipedia.org/wiki/Picard_group"
@@ -8195,7 +8372,8 @@ concepts:
       en: polygamma function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi ψ"
+      comments:
+        - "<math><mrow><mi>ψ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PolygammaFunction.html"
        - "https://en.wikipedia.org/wiki/Polygamma_function"
@@ -8326,7 +8504,8 @@ concepts:
       en: prime counting function of $1
       property: function
       area: "number theory"
-      notation: "mi π"
+      comments:
+        - "<math><mrow><mi>π</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeCountingFunction.html"
     
@@ -8335,7 +8514,8 @@ concepts:
       en: prime difference function of $1
       property: "indexed function"
       area: "number theory"
-      notation: "mi d"
+      comments:
+        - "<math><mrow><mi>d</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeDifferenceFunction.html"
     
@@ -8364,7 +8544,8 @@ concepts:
       en: principal value of $1
       property: function
       area: "complex analysis"
-      notation: "mi Log"
+      comments:
+        - "<math><mrow><mi>Log</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complex_logarithm#Principal_value"
     
@@ -8373,7 +8554,8 @@ concepts:
       en: probability limit of $1
       property: "indexed function"
       area: "probability theory"
-      notation: "mi plim"
+      comments:
+        - "<math><mrow><mi>plim</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Convergence_of_random_variables#Convergence_in_probability"
       alias:
@@ -8405,7 +8587,8 @@ concepts:
       en: projective line of $1
       property: function
       area: "projective geometry"
-      notation: "mi P"
+      comments:
+        - "<math><mrow><mi>P</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Projective_line"
        - "https://ncatlab.org/nlab/show/projective+line"
@@ -8652,7 +8835,8 @@ concepts:
       en: radical of $1
       property: function
       area: "number theory"
-      notation: "mi rad"
+      comments:
+        - "<math><mrow><mi>rad</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Radical.html"
        - "https://en.wikipedia.org/wiki/Radical_of_a_Lie_algebra"
@@ -8692,7 +8876,8 @@ concepts:
       en: ramanujan tau function of $1
       property: function
       area: "number theory"
-      notation: "mi τ"
+      comments:
+        - "<math><mrow><mi>τ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansTauFunction.html"
        - "https://en.wikipedia.org/wiki/Ramanujan_tau_function"
@@ -8727,7 +8912,8 @@ concepts:
       en: ramsey number of $1
       property: function
       area: "graph theory"
-      notation: "mi R"
+      comments:
+        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamseyNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Ramsey_number"
@@ -8795,7 +8981,8 @@ concepts:
       en: recession cone of $1
       property: function
       area: "convex analysis"
-      notation: "mi recc"
+      comments:
+        - "<math><mrow><mi>recc</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Recession_cone"
     
@@ -8816,7 +9003,8 @@ concepts:
       en: rectification of $1
       property: function
       area: "euclidean geometry"
-      notation: "mi r"
+      comments:
+        - "<math><mrow><mi>r</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rectification.html"
        - "https://en.wikipedia.org/wiki/Rectification_(geometry)"
@@ -8827,7 +9015,8 @@ concepts:
       en: reduced suspension of $1
       property: function
       area: "topology"
-      notation: "mi Σ"
+      comments:
+        - "<math><mrow><mi>Σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
     
@@ -8836,7 +9025,8 @@ concepts:
       en: relative homology of $1
       property: "indexed function"
       area: "algebraic topology"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relative_homology"
        - "https://ncatlab.org/nlab/show/relative+homology"
@@ -8847,7 +9037,8 @@ concepts:
       en: repunit of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "mi R"
+      comments:
+        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Repunit.html"
        - "https://en.wikipedia.org/wiki/Repunit"
@@ -8880,7 +9071,8 @@ concepts:
       en: resolvent set of $1
       property: function
       area: "set theory"
-      notation: "mi ρ"
+      comments:
+        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Resolvent_set"
        - "https://www.encyclopediaofmath.org/index.php/Resolvent_set"
@@ -8971,7 +9163,8 @@ concepts:
       en: ricci tensor of $1
       property: "indexed symbol"
       area: "riemannian geometry"
-      notation: "mi R"
+      comments:
+        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciTensor.html"
        - "https://www.encyclopediaofmath.org/index.php/Ricci_tensor"
@@ -9011,7 +9204,8 @@ concepts:
       en: riemann theta function of $1
       property: function
       area: "special functions"
-      notation: "mi θ⁡"
+      comments:
+        - "<math><mrow><mi>θ⁡</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannThetaFunction.html"
        - "https://dlmf.nist.gov/21.2#i"
@@ -9022,7 +9216,8 @@ concepts:
       en: riemann zeta function of $1
       property: function
       area: "special functions"
-      notation: "mi ζ"
+      comments:
+        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannZetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%96(x)"
@@ -9037,7 +9232,8 @@ concepts:
       en: riemann christoffel tensor of $1
       property: "indexed function"
       area: "riemannian geometry"
-      notation: "mi R"
+      comments:
+        - "<math><mrow><mi>R</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-ChristoffelTensor.html"
        - "https://en.wikipedia.org/wiki/Riemann_curvature_tensor"
@@ -9271,7 +9467,8 @@ concepts:
       en: schur multiplier of $1
       property: function
       area: "group theory"
-      notation: "mi M"
+      comments:
+        - "<math><mrow><mi>M</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchurMultiplier.html"
        - "https://en.wikipedia.org/wiki/Schur_multiplier"
@@ -9399,7 +9596,8 @@ concepts:
       en: shimura variety of $1
       property: function
       area: "algebraic geometry"
-      notation: "mi Sh"
+      comments:
+        - "<math><mrow><mi>Sh</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Shimura_variety"
        - "https://ncatlab.org/nlab/show/Shimura+variety"
@@ -9446,7 +9644,8 @@ concepts:
       en: sign function of $1
       property: function
       area: "special-functions"
-      notation: "mi sgn"
+      comments:
+        - "<math><mrow><mi>sgn</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sign_function"
       alias:
@@ -9457,7 +9656,8 @@ concepts:
       en: signature of permutation of $1
       property: function
       area: "combinatorics"
-      notation: "mi sign"
+      comments:
+        - "<math><mrow><mi>sign</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/signature+of+a+permutation"
       alias:
@@ -9513,7 +9713,8 @@ concepts:
       en: sine integral of $1
       property: operator
       area: "special functions"
-      notation: "mi Si"
+      comments:
+        - "<math><mrow><mi>Si</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -9545,7 +9746,8 @@ concepts:
       en: small o of $1
       property: prefix
       area: "complexity"
-      notation: "mi o"
+      comments:
+        - "<math><mrow><mi>o</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
        - "https://mathworld.wolfram.com/o.html"
@@ -9555,7 +9757,8 @@ concepts:
       en: smith number of $1
       property: "indexed symbol"
       area: "number theory"
-      notation: "mi S"
+      comments:
+        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SmithNumber.html"
        - "https://en.wikipedia.org/wiki/Smith_number"
@@ -9577,7 +9780,8 @@ concepts:
       en: socle of $1
       property: function
       area: "group theory"
-      notation: "mi soc"
+      comments:
+        - "<math><mrow><mi>soc</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Socle.html"
        - "https://en.wikipedia.org/wiki/Socle_(mathematics)"
@@ -9612,7 +9816,8 @@ concepts:
       en: span of $1
       property: unit
       area: "imperial units"
-      notation: "mi span"
+      comments:
+        - "<math><mrow><mi>span</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(unit)"
     
@@ -9633,7 +9838,8 @@ concepts:
       en: special orthogonal group of $1
       property: "indexed function"
       area: "group theory"
-      notation: "mi SO"
+      comments:
+        - "<math><mrow><mi>SO</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialOrthogonalGroup.html"
        - "https://ncatlab.org/nlab/show/special+orthogonal+group"
@@ -9643,7 +9849,8 @@ concepts:
       en: special unitary group of $1
       property: function
       area: "lie groups"
-      notation: "mi SU"
+      comments:
+        - "<math><mrow><mi>SU</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialUnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Special_unitary_group"
@@ -9654,7 +9861,8 @@ concepts:
       en: spectral radius of $1
       property: function
       area: "spectral theory"
-      notation: "mi ρ"
+      comments:
+        - "<math><mrow><mi>ρ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpectralRadius.html"
        - "https://en.wikipedia.org/wiki/Spectral_radius"
@@ -9665,7 +9873,8 @@ concepts:
       en: spectrum of $1
       property: function
       area: "functional analysis"
-      notation: "mi σ"
+      comments:
+        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_(functional_analysis)"
     
@@ -9702,7 +9911,8 @@ concepts:
       en: spectrum of ring of $1
       property: function
       area: "group theory"
-      notation: "mi Spec"
+      comments:
+        - "<math><mrow><mi>Spec</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_ring"
     
@@ -9857,7 +10067,8 @@ concepts:
       en: star height of $1
       property: function
       area: "formal languages"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_height"
     
@@ -9866,7 +10077,8 @@ concepts:
       en: steinberg group of $1
       property: function
       area: "k-theory"
-      notation: "mi St"
+      comments:
+        - "<math><mrow><mi>St</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Group_of_Lie_type"
        - "https://en.wikipedia.org/wiki/Steinberg_group_(K-theory)"
@@ -9888,7 +10100,8 @@ concepts:
       en: stiefel whitney class of $1
       property: function
       area: "algebraic topology"
-      notation: "mi w"
+      comments:
+        - "<math><mrow><mi>w</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stiefel-WhitneyClass.html"
        - "https://en.wikipedia.org/wiki/Stiefel%E2%80%93Whitney_class"
@@ -9912,7 +10125,8 @@ concepts:
       en: stirling number of first kind of $1
       property: function
       area: "special functions"
-      notation: "mi s"
+      comments:
+        - "<math><mrow><mi>s</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind"
@@ -9923,7 +10137,8 @@ concepts:
       en: stirling number of second kind of $1
       property: function
       area: "special functions"
-      notation: "mi S"
+      comments:
+        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind"
@@ -9934,7 +10149,8 @@ concepts:
       en: strength of a graph of $1
       property: function
       area: "graph theory"
-      notation: "mi σ"
+      comments:
+        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Strength_of_a_graph"
       alias:
@@ -9967,7 +10183,8 @@ concepts:
       en: struve function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi H"
+      comments:
+        - "<math><mrow><mi>H</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StruveFunction.html"
        - "https://en.wikipedia.org/wiki/Struve_function"
@@ -9980,7 +10197,8 @@ concepts:
       en: stufe of $1
       property: function
       area: "field theory"
-      notation: "mi s"
+      comments:
+        - "<math><mrow><mi>s</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stufe_(algebra)"
     
@@ -10074,7 +10292,8 @@ concepts:
       en: support of $1
       property: function
       area: "analysis"
-      notation: "mi supp"
+      comments:
+        - "<math><mrow><mi>supp</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Support.html"
        - "https://en.wikipedia.org/wiki/Support_(mathematics)"
@@ -10141,7 +10360,8 @@ concepts:
       en: suspension of $1
       property: function
       area: "topology"
-      notation: "mi S"
+      comments:
+        - "<math><mrow><mi>S</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Suspension.html"
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
@@ -10195,7 +10415,8 @@ concepts:
       en: symplectic group of $1
       property: function
       area: "group theory"
-      notation: "mi Sp"
+      comments:
+        - "<math><mrow><mi>Sp</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymplecticGroup.html"
        - "https://en.wikipedia.org/wiki/Symplectic_group"
@@ -10219,7 +10440,8 @@ concepts:
       en: tangent bundle of $1
       property: function
       area: "differential geometry"
-      notation: "mi T"
+      comments:
+        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentBundle.html"
        - "https://en.wikipedia.org/wiki/Tangent_bundle"
@@ -10274,7 +10496,8 @@ concepts:
       en: taxicab number of $1
       property: function
       area: "number theory"
-      notation: "mi Ta"
+      comments:
+        - "<math><mrow><mi>Ta</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaxicabNumber.html"
        - "https://en.wikipedia.org/wiki/Taxicab_number"
@@ -10284,7 +10507,8 @@ concepts:
       en: taylor polynomial of $1
       property: function
       area: "number theory"
-      notation: "mi Ta"
+      comments:
+        - "<math><mrow><mi>Ta</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaylorPolynomial.html"
        - "https://en.wikipedia.org/wiki/Taylor%27s_theorem"
@@ -10295,7 +10519,8 @@ concepts:
       en: teichmuller space of $1
       property: function
       area: "differential geometry"
-      notation: "mi T"
+      comments:
+        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TeichmuellerSpace.html"
        - "https://en.wikipedia.org/wiki/Teichm%C3%BCller_space"
@@ -10377,7 +10602,8 @@ concepts:
       en: thom space of $1
       property: function
       area: "algebraic topology"
-      notation: "mi T"
+      comments:
+        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Thom_space"
        - "https://ncatlab.org/nlab/show/Thom+space"
@@ -10420,7 +10646,8 @@ concepts:
       en: topological entropy of $1
       property: function
       area: "topology"
-      notation: "mi h"
+      comments:
+        - "<math><mrow><mi>h</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TopologicalEntropy.html"
        - "https://en.wikipedia.org/wiki/Topological_entropy"
@@ -10465,7 +10692,8 @@ concepts:
       en: torsion submodule of $1
       property: function
       area: "abstract algebra"
-      notation: "mi T"
+      comments:
+        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_(algebra)"
     
@@ -10484,7 +10712,8 @@ concepts:
       en: torsion tensor of $1
       property: function
       area: "differential geometry"
-      notation: "mi T"
+      comments:
+        - "<math><mrow><mi>T</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_tensor"
     
@@ -10517,7 +10746,8 @@ concepts:
       en: trace of $1
       property: function
       area: "linear algebra"
-      notation: "mi tr"
+      comments:
+        - "<math><mrow><mi>tr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trace_(linear_algebra)"
     
@@ -10584,7 +10814,8 @@ concepts:
       en: trimean of $1
       property: function
       area: "statistics"
-      notation: "mi TM"
+      comments:
+        - "<math><mrow><mi>TM</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trimean"
       alias:
@@ -10627,7 +10858,8 @@ concepts:
       en: truncation of $1
       property: function
       area: "numerical analysis"
-      notation: "mi trunc"
+      comments:
+        - "<math><mrow><mi>trunc</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Truncation.html"
        - "https://en.wikipedia.org/wiki/Truncation"
@@ -10904,7 +11136,8 @@ concepts:
       en: variance of $1
       property: function
       area: "statistics"
-      notation: "mi Var"
+      comments:
+        - "<math><mrow><mi>Var</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Variance"
       alias:
@@ -10934,7 +11167,8 @@ concepts:
       en: vector projection of $1
       property: function
       area: "linear algebra"
-      notation: "mi proj"
+      comments:
+        - "<math><mrow><mi>proj</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vector_projection"
       alias:
@@ -10946,7 +11180,8 @@ concepts:
       en: vectorization of $1
       property: function
       area: "linear algebra"
-      notation: "mi vec"
+      comments:
+        - "<math><mrow><mi>vec</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vectorization_(mathematics)"
        - "https://en.wikipedia.org/wiki/Vectorization_(parallel_computing)"
@@ -11024,7 +11259,8 @@ concepts:
       en: walsh function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi W"
+      comments:
+        - "<math><mrow><mi>W</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WalshFunction.html"
        - "https://en.wikipedia.org/wiki/Walsh_function"
@@ -11082,7 +11318,8 @@ concepts:
       en: weierstrass elliptic function of $1
       property: function
       area: "special functions"
-      notation: "mi ℘"
+      comments:
+        - "<math><mrow><mi>℘</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassEllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Weierstrass%27s_elliptic_functions"
@@ -11095,7 +11332,8 @@ concepts:
       en: weierstrass sigma function of $1
       property: function
       area: "special functions"
-      notation: "mi σ"
+      comments:
+        - "<math><mrow><mi>σ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassSigmaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11107,7 +11345,8 @@ concepts:
       en: weierstrass zeta function of $1
       property: function
       area: "special functions"
-      notation: "mi ζ"
+      comments:
+        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassZetaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -11119,7 +11358,8 @@ concepts:
       en: weight of $1
       property: function
       area: "group theory"
-      notation: "mi wt"
+      comments:
+        - "<math><mrow><mi>wt</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Weight_(strings)"
        - "https://ncatlab.org/nlab/show/weight"
@@ -11163,7 +11403,8 @@ concepts:
       en: whitehead group of $1
       property: function
       area: "group theory"
-      notation: "mi Wh"
+      comments:
+        - "<math><mrow><mi>Wh</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadGroup.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11185,7 +11426,8 @@ concepts:
       en: whitehead torsion of $1
       property: function
       area: "geometric topology"
-      notation: "mi τ"
+      comments:
+        - "<math><mrow><mi>τ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadTorsion.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -11252,7 +11494,8 @@ concepts:
       en: wilson quotient of $1
       property: function
       area: "number theory"
-      notation: "mi W"
+      comments:
+        - "<math><mrow><mi>W</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonQuotient.html"
        - "https://en.wikipedia.org/wiki/Wilson_quotient"
@@ -11275,7 +11518,8 @@ concepts:
       en: window function of $1
       property: function
       area: "fourier analysis"
-      notation: "mi w"
+      comments:
+        - "<math><mrow><mi>w</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WindowFunction.html"
        - "https://en.wikipedia.org/wiki/Window_function"
@@ -11328,7 +11572,8 @@ concepts:
       en: wright function of $1
       property: function
       area: "special functions"
-      notation: "mi ϕ"
+      comments:
+        - "<math><mrow><mi>ϕ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WrightFunction.html"
     
@@ -11337,7 +11582,8 @@ concepts:
       en: wright omega function of $1
       property: function
       area: "special functions"
-      notation: "mi ω"
+      comments:
+        - "<math><mrow><mi>ω</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Wright_Omega_function"
       alias:
@@ -11348,7 +11594,8 @@ concepts:
       en: writhe of $1
       property: function
       area: "knot theory"
-      notation: "mi Wr"
+      comments:
+        - "<math><mrow><mi>Wr</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Writhe.html"
        - "https://en.wikipedia.org/wiki/Writhe"
@@ -11372,7 +11619,8 @@ concepts:
       en: yang mill functional of $1
       property: function
       area: "gauge theory"
-      notation: "mi ℒ"
+      comments:
+        - "<math><mrow><mi>ℒ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Yang-MillsFunctional.html"
        - "https://www.encyclopediaofmath.org/index.php/Yang-Mills_functional"
@@ -11402,7 +11650,8 @@ concepts:
       en: z transform of $1
       property: function
       area: "combinatorics"
-      notation: "mi Z"
+      comments:
+        - "<math><mrow><mi>Z</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/z-Transform.html"
        - "https://mathworld.wolfram.com/Z-Transform.html"
@@ -11483,7 +11732,8 @@ concepts:
       en: zeta function of $1
       property: function
       area: "number theory"
-      notation: "mi ζ"
+      comments:
+        - "<math><mrow><mi>ζ</mi><mrow><mi>x</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZetaFunction.html"
        - "https://en.wikipedia.org/wiki/List_of_zeta_functions"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -206,8 +206,9 @@ concepts:
       en: airy function of $1
       property: function
       area: "special functions"
-      notation: "mi Ai"
-      notationa: "mi Bi"
+      comments:
+       - "<math><mi>Ai</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Bi</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AiryFunctions.html"
        - "https://en.wikipedia.org/wiki/Airy_function"
@@ -222,8 +223,9 @@ concepts:
       en: albanese variety of $1
       property: function
       area: "algebraic geometry"
-      notation: "mi A"
-      notationa: "mi Alb"
+      comments:
+       - "<math><mi>A</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Alb</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AlbaneseVariety.html"
        - "https://en.wikipedia.org/wiki/Albanese_variety"
@@ -288,8 +290,9 @@ concepts:
       en: alternating group of $1
       property: function
       area: "group theory"
-      notation: "mi A"
-      notationa: "mi Alt"
+      comments:
+       - "<math><mi>A</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Alt</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AlternatingGroup.html"
        - "https://en.wikipedia.org/wiki/Alternating_group"
@@ -487,8 +490,9 @@ concepts:
       en: arcminute of $1
       property: unit
       area: "SI-mentioned units"
-      notation: "mi arcmin"
-      notationb: "mi amin"
+      comments:
+       - "<math><mi>arcmin</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>amin</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mo ′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -504,8 +508,9 @@ concepts:
       en: arcsecond of $1
       property: unit
       area: "SI-mentioned units"
-      notation: "mi arcsec"
-      notationb: "mi asec"
+      comments:
+       - "<math><mi>arcsec</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>asec</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mo ′′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -552,8 +557,9 @@ concepts:
       en: arithmetic geometric mean of $1
       property: function
       area: "special functions"
-      notation: "mi agm"
-      notationa: "mi AGM"
+      comments:
+       - "<math><mi>agm</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>AGM</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Arithmetic-GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean"
@@ -784,10 +790,11 @@ concepts:
       en: beta distribution of $1
       property: function
       area: "probability theory"
-      notation: "mi B"
-      notationc: "mi Beta"
-      notationb: "mi 𝓑𝓮"
-      notationa: "mi β"
+      comments:
+       - "<math><mi>B</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Beta</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>𝓑𝓮</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>β</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaDistribution.html"
        - "https://en.wikipedia.org/wiki/Beta_distribution"
@@ -797,8 +804,9 @@ concepts:
       en: beta function of $1
       property: function
       area: "special functions"
-      notation: "mi B"
-      notationa: "mi β"
+      comments:
+       - "<math><mi>B</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>β</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%92(x,_y)"
@@ -842,7 +850,8 @@ concepts:
       en: big O of $1
       property: prefix
       area: "complexity"
-      notation: "mi O"
+      comments:
+       - "<math><mi>O</mi><mrow><mi>X</mi></mrow></math>"
       notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
@@ -1001,9 +1010,10 @@ concepts:
       en: boundary of $1
       property: function
       area: "topology"
-      notation: "mi bd"
-      notationb: "mi fr"
-      notationa: "mi ∂"
+      comments:
+       - "<math><mi>bd</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>fr</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>∂</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Boundary.html"
        - "https://en.wikipedia.org/wiki/Boundary_(topology)"
@@ -1217,7 +1227,8 @@ concepts:
       en: cauchy principal value of $1
       property: function
       area: "analysis"
-      notation: "mi p.v."
+      comments:
+       - "<math><mi>p.v.</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CauchyPrincipalValue.html"
        - "https://en.wikipedia.org/wiki/Cauchy_principal_value"
@@ -1300,7 +1311,8 @@ concepts:
       en: chain of $1
       property: unit
       area: "imperial units"
-      notation: "mi chain"
+      comments:
+       - "<math><mi>chain</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chain_(unit)"
     
@@ -1389,9 +1401,10 @@ concepts:
       en: chebyshev polynomial of first kind of $1
       property: function
       area: "number theory"
-      notation: "mi θ"
-      notationb: "mi ϑ"
-      notationa: "mi T"
+      comments:
+       - "<math><mi>θ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ϑ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>T</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1404,8 +1417,9 @@ concepts:
       en: chebyshev polynomial of second kind of $1
       property: function
       area: "number theory"
-      notation: "mi ψ"
-      notationa: "mi U"
+      comments:
+       - "<math><mi>ψ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>U</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1512,8 +1526,9 @@ concepts:
       en: classifying space of $1
       property: function
       area: "group theory"
-      notation: "mi B"
-      notationa: "mi ℬ"
+      comments:
+       - "<math><mi>B</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ℬ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Classifying_space"
        - "https://ncatlab.org/nlab/show/classifying+space"
@@ -1610,8 +1625,9 @@ concepts:
       en: closure of $1
       property: "function, msup"
       area: "abstract algebra,, topology"
-      notation: "mi cl"
-      notationb: "mi Cl"
+      comments:
+       - "<math><mi>cl</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Cl</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msup $1 −"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
@@ -1662,8 +1678,9 @@ concepts:
       en: coherence of $1
       property: "indexed function"
       area: "signal processing, quantum physics"
-      notation: "mi C"
-      notationa: "mi γ"
+      comments:
+       - "<math><mi>C</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>γ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coherence_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Coherence_(physics)"
@@ -2375,8 +2392,9 @@ concepts:
       en: curl of $1
       property: function
       area: "vector calculus"
-      notation: "mi curl"
-      notationb: "mi rot"
+      comments:
+       - "<math><mi>curl</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>rot</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mrow ∇ × $1"
       urls: 
        - "https://mathworld.wolfram.com/Curl.html"
@@ -2486,8 +2504,9 @@ concepts:
       en: dawson function of $1
       property: function
       area: "special-functions"
-      notation: "mi F"
-      notationc: "mi D"
+      comments:
+       - "<math><mi>F</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>D</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "mi sub D -"
       notationa: "mi sub D +"
       urls: 
@@ -2545,8 +2564,9 @@ concepts:
       en: deductive closure of $1
       property: function
       area: "logic"
-      notation: "mi Ded"
-      notationa: "mi Th"
+      comments:
+       - "<math><mi>Ded</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Th</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Deductive_closure"
     
@@ -2704,7 +2724,8 @@ concepts:
       en: diameter of $1
       property: symbol, prefix unit
       area: "geometry"
-      notation: "mi d"
+      comments:
+       - "<math><mi>d</mi><mrow><mi>X</mi></mrow></math>"
       notationc: "mo ⌀"
       notationb: "mi DIA"
       notationa: "mi dia"
@@ -2755,7 +2776,8 @@ concepts:
       en: differential operator of $1
       property: prefix
       area: "calculus"
-      notation: "mi D"
+      comments:
+       - "<math><mi>D</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "mo ∂"
       notationa: "mfrac d mrow d $1"
       urls: 
@@ -2822,7 +2844,8 @@ concepts:
       en: dimension of $1
       property: "function, fenced"
       area: "linear algebra, graph theory"
-      notation: "mi dim"
+      comments:
+       - "<math><mi>dim</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mrow [ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
@@ -3034,9 +3057,10 @@ concepts:
       en: discriminant of $1
       property: function
       area: "polynomials"
-      notation: "mi Disc"
-      notationb: "mi D"
-      notationa: "mi Δ"
+      comments:
+       - "<math><mi>Disc</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>D</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Δ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Discriminant.html"
        - "https://en.wikipedia.org/wiki/Discriminant"
@@ -3082,7 +3106,8 @@ concepts:
       en: divergence of $1
       property: "function, mixfix"
       area: "vector calculus"
-      notation: "mi div"
+      comments:
+       - "<math><mi>div</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mrow ∇ ⋅ $1"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
@@ -3376,9 +3401,10 @@ concepts:
       en: elliptic function of $1
       property: function
       area: "special functions"
-      notation: "mi cn"
-      notationb: "mi sn"
-      notationa: "mi dn"
+      comments:
+       - "<math><mi>cn</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>sn</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>dn</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Elliptic_function"
@@ -3534,9 +3560,10 @@ concepts:
       en: error function of $1
       property: function
       area: "special functions"
-      notation: "mi erf"
-      notationb: "mi erfc"
-      notationa: "mi w"
+      comments:
+       - "<math><mi>erf</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>erfc</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>w</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ErrorFunction.html"
        - "https://en.wikipedia.org/wiki/Error_function"
@@ -3618,7 +3645,8 @@ concepts:
       en: euclidean distance of $1
       property: function
       area: "geometry"
-      notation: "mi d"
+      comments:
+       - "<math><mi>d</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msub d $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Euclidean_distance"
@@ -3713,8 +3741,9 @@ concepts:
       en: euler totient function of $1
       property: function
       area: "number theory"
-      notation: "mi φ"
-      notationa: "mi ϕ"
+      comments:
+       - "<math><mi>φ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ϕ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerTotientFunction.html"
        - "https://en.wikipedia.org/wiki/Euler%27s_totient_function"
@@ -3780,8 +3809,9 @@ concepts:
       en: expected value of $1
       property: function
       area: "probability theory"
-      notation: "mi E"
-      notationc: "mi M"
+      comments:
+       - "<math><mi>E</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>M</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "msub μ $1"
       notationa: ""
       urls: 
@@ -3824,7 +3854,8 @@ concepts:
       en: exterior of $1
       property: "function, msup"
       area: "topology"
-      notation: "mi ext"
+      comments:
+       - "<math><mi>ext</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msup $1 e"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
@@ -4203,7 +4234,8 @@ concepts:
       en: fractional part of $1
       property: "function, fenced"
       area: "arithmetic"
-      notation: "mi frac"
+      comments:
+       - "<math><mi>frac</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "mrow ⟦ $1 ⟧"
       notationa: "mrow { $1 }"
       urls: 
@@ -4229,8 +4261,9 @@ concepts:
       en: frattini subgroup of $1
       property: function
       area: "group theory"
-      notation: "mi φ"
-      notationa: "mi ϕ"
+      comments:
+       - "<math><mi>φ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ϕ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrattiniSubgroup.html"
        - "https://en.wikipedia.org/wiki/Frattini_subgroup"
@@ -4325,9 +4358,10 @@ concepts:
       en: fresnel integral of $1
       property: operator
       area: "special functions"
-      notation: "mi ℱ"
-      notationb: "mi C"
-      notationa: "mi S"
+      comments:
+       - "<math><mi>ℱ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>C</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>S</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FresnelIntegrals.html"
        - "https://en.wikipedia.org/wiki/Fresnel_integral"
@@ -4617,8 +4651,9 @@ concepts:
       en: general linear group of $1
       property: function
       area: "group theory"
-      notation: "mi GL"
-      notationa: "mi Aut"
+      comments:
+       - "<math><mi>GL</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Aut</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeneralLinearGroup.html"
        - "https://en.wikipedia.org/wiki/General_linear_group"
@@ -4813,8 +4848,9 @@ concepts:
       en: gram determinant of $1
       property: function
       area: "linear algebra"
-      notation: "mi G"
-      notationa: "mi Γ"
+      comments:
+       - "<math><mi>G</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Γ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramDeterminant.html"
        - "https://www.encyclopediaofmath.org/index.php/Gram_determinant"
@@ -4954,7 +4990,8 @@ concepts:
       en: hamiltonian of $1
       property: operator
       area: "quantum mechanics"
-      notation: "mi H"
+      comments:
+       - "<math><mi>H</mi><mrow><mi>X</mi></mrow></math>"
       notationc: "mover H ˇ"
       notationb: "mover H ^"
       notationa: "mrow < H >"
@@ -5109,8 +5146,9 @@ concepts:
       en: height function of $1
       property: function
       area: "algebra"
-      notation: "mi H"
-      notationa: "mi h"
+      comments:
+       - "<math><mi>H</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>h</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_of_a_polynomial"
     
@@ -5154,8 +5192,9 @@ concepts:
       en: hermite polynomial of $1
       property: function
       area: "special functions"
-      notation: "mi H"
-      notationa: "mi He"
+      comments:
+       - "<math><mi>H</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>He</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HermitePolynomial.html"
        - "https://en.wikipedia.org/wiki/Hermite_polynomials"
@@ -5217,8 +5256,9 @@ concepts:
       en: heun function of $1
       property: function
       area: "special functions"
-      notation: "mi Hf"
-      notationa: "mi H⁢ℓ"
+      comments:
+       - "<math><mi>Hf</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>H⁢ℓ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.1"
@@ -5242,7 +5282,8 @@ concepts:
       en: hexadecimal of $1
       property: unit
       area: "arithmetic"
-      notation: "mi hex"
+      comments:
+       - "<math><mi>hex</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "msub $1 hex"
       notationa: "msub $1 16"
       urls: 
@@ -5373,12 +5414,13 @@ concepts:
       en: horsepower metric of $1
       property: unit
       area: "metric unit"
-      notation: "mi PS"
-      notatione: "mi cv"
-      notationd: "mi hk"
-      notationc: "mi pk"
-      notationb: "mi ks"
-      notationa: "mi ch"
+      comments:
+       - "<math><mi>PS</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>cv</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>hk</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>pk</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ks</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ch</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Metric_horsepower"
       alias:
@@ -5480,7 +5522,8 @@ concepts:
       en: hyperdeterminant of $1
       property: "function, fenced"
       area: "multilinear algebra"
-      notation: "mi det"
+      comments:
+       - "<math><mi>det</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mrow | $1 |"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
@@ -5521,7 +5564,8 @@ concepts:
       en: identity function of $1
       property: function
       area: "algebra"
-      notation: "mi id"
+      comments:
+       - "<math><mi>id</mi><mrow><mi>X</mi></mrow></math>"
       notationb: "msub id $1"
       notationa: "msub I $1"
       urls: 
@@ -5744,7 +5788,8 @@ concepts:
       en: infimum of $1
       property: "function, largeop"
       area: "order theory"
-      notation: "mi inf"
+      comments:
+       - "<math><mi>inf</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mo ⋀"
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
@@ -5855,7 +5900,8 @@ concepts:
       en: integer part of $1
       property: "function, fenced"
       area: "number theory"
-      notation: "mi int"
+      comments:
+       - "<math><mi>int</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "[ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/IntegerPart.html"
@@ -6087,12 +6133,13 @@ concepts:
       en: jacobian elliptic function of $1
       property: function
       area: "special-functions"
-      notation: "mi sn"
-      notatione: "mi cn"
-      notationd: "mi dn"
-      notationc: "mi sd"
-      notationb: "mi cd"
-      notationa: "mi sc"
+      comments:
+       - "<math><mi>sn</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>cn</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>dn</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>sd</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>cd</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>sc</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/22.2"
        - "https://dlmf.nist.gov/22.2#E5"
@@ -6107,8 +6154,9 @@ concepts:
       en: jacobson radical of $1
       property: function
       area: "ring theory"
-      notation: "mi J"
-      notationa: "mi rad"
+      comments:
+       - "<math><mi>J</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>rad</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsonRadical.html"
        - "https://en.wikipedia.org/wiki/Jacobson_radical"
@@ -6338,8 +6386,9 @@ concepts:
       en: kloosterman sum of $1
       property: function
       area: "analytic number theory"
-      notation: "mi S"
-      notationa: "mi K"
+      comments:
+       - "<math><mi>S</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>K</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KloostermansSum.html"
        - "https://en.wikipedia.org/wiki/Kloosterman_sum"
@@ -6497,7 +6546,8 @@ concepts:
       en: kullback leibler distance of $1
       property: function
       area: "mathematical statistics"
-      notation: "mi KL"
+      comments:
+       - "<math><mi>KL</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msub D KL"
       urls: 
        - "http://users.monash.edu/~lloyd/tildeMML/KL/"
@@ -6922,9 +6972,10 @@ concepts:
       en: gunter link of $1
       property: unit
       area: "units"
-      notation: "mi l."
-      notationb: "mi li."
-      notationa: "mi lnk."
+      comments:
+       - "<math><mi>l.</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>li.</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>lnk.</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Link_(unit)"
     
@@ -7070,7 +7121,8 @@ concepts:
       en: lower shadow of $1
       property: function
       area: "combinatorics"
-      notation: "mi 𝜕"
+      comments:
+       - "<math><mi>𝜕</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msub 𝜕 -"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
@@ -7433,8 +7485,9 @@ concepts:
       en: mills ratio of $1
       property: function
       area: "probability theory"
-      notation: "mi m"
-      notationa: "mi M"
+      comments:
+       - "<math><mi>m</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>M</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsRatio.html"
        - "https://en.wikipedia.org/wiki/Mills_ratio"
@@ -8166,7 +8219,8 @@ concepts:
       en: order of group of $1
       property: "function, fenced"
       area: "group theory"
-      notation: "mi ord"
+      comments:
+       - "<math><mi>ord</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mrow | $1 |"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
@@ -8481,8 +8535,9 @@ concepts:
       en: pfaffian of $1
       property: function
       area: "multilinear algebra"
-      notation: "mi Pf"
-      notationa: "mi pf"
+      comments:
+       - "<math><mi>Pf</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>pf</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Pfaffian.html"
        - "https://en.wikipedia.org/wiki/Pfaffian"
@@ -8508,8 +8563,9 @@ concepts:
       en: phase of $1
       property: function
       area: "physics"
-      notation: "mi ϕ"
-      notationa: "mi ph"
+      comments:
+       - "<math><mi>ϕ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ph</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Phase.html"
        - "https://en.wikipedia.org/wiki/Phase_(waves)"
@@ -8760,10 +8816,11 @@ concepts:
       en: power set of $1
       property: "function, msup"
       area: "set theory"
-      notation: "mi P"
-      notationd: "mi 𝒫"
-      notationc: "mi ℙ"
-      notationb: "mi ℘"
+      comments:
+       - "<math><mi>P</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>𝒫</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ℙ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>℘</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msup 2 $1"
       urls: 
        - "https://mathworld.wolfram.com/PowerSet.html"
@@ -8828,8 +8885,9 @@ concepts:
       en: prime gap of $1
       property: "indexed function"
       area: "number theory"
-      notation: "mi G"
-      notationa: "mi g"
+      comments:
+       - "<math><mi>G</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>g</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeGaps.html"
        - "https://en.wikipedia.org/wiki/Prime_gap"
@@ -9137,8 +9195,9 @@ concepts:
       en: radial mathieu function of $1
       property: "indexed function"
       area: "special functions"
-      notation: "mi Mc"
-      notationa: "mi Ms"
+      comments:
+       - "<math><mi>Mc</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Ms</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/28.20#iv"
        - "https://dlmf.nist.gov/28.20#E15"
@@ -9239,9 +9298,10 @@ concepts:
       en: rank of $1
       property: function
       area: "graph theory, linear algebra, "
-      notation: "mi r"
-      notationb: "mi rank"
-      notationa: "mi rk"
+      comments:
+       - "<math><mi>r</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>rank</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>rk</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rank.html"
        - "https://en.wikipedia.org/wiki/Rank_(graph_theory)"
@@ -9266,9 +9326,10 @@ concepts:
       en: real part of $1
       property: function
       area: "complex analysis"
-      notation: "mi ℜ"
-      notationb: "mi Re"
-      notationa: "mi ℛℯ"
+      comments:
+       - "<math><mi>ℜ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Re</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>ℛℯ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RealPart.html"
        - "https://dlmf.nist.gov/1.9#E2"
@@ -9370,8 +9431,9 @@ concepts:
       en: residue of $1
       property: function
       area: "complex analysis"
-      notation: "mi Res"
-      notationa: "mi res"
+      comments:
+       - "<math><mi>Res</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>res</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Residue.html"
        - "https://en.wikipedia.org/wiki/Residue_(complex_analysis)"
@@ -9441,8 +9503,9 @@ concepts:
       en: resultant of $1
       property: function
       area: "polynomials"
-      notation: "mi res"
-      notationa: "mi Res"
+      comments:
+       - "<math><mi>res</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Res</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Resultant.html"
        - "https://en.wikipedia.org/wiki/Resultant"
@@ -9867,8 +9930,9 @@ concepts:
       en: sectional curvature of $1
       property: function
       area: "riemannian geometry"
-      notation: "mi K"
-      notationa: "mi κ"
+      comments:
+       - "<math><mi>K</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>κ</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SectionalCurvature.html"
        - "https://en.wikipedia.org/wiki/Sectional_curvature"
@@ -10058,8 +10122,9 @@ concepts:
       en: sinc function of $1
       property: function
       area: "special functions"
-      notation: "mi S"
-      notationa: "mi sinc"
+      comments:
+       - "<math><mi>S</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>sinc</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SincFunction.html"
        - "https://en.wikipedia.org/wiki/Sinc_function"
@@ -10678,7 +10743,8 @@ concepts:
       en: supremum of $1
       property: "function, largeop"
       area: "order theory, lattice theory"
-      notation: "mi sup"
+      comments:
+       - "<math><mi>sup</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
@@ -10744,8 +10810,9 @@ concepts:
       en: symmetric algebra of $1
       property: function
       area: "algebra"
-      notation: "mi S"
-      notationa: "mi Sym"
+      comments:
+       - "<math><mi>S</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Sym</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Symmetric_algebra"
        - "https://ncatlab.org/nlab/show/symmetric+algebra"
@@ -10923,7 +10990,8 @@ concepts:
       en: tensor algebra of $1
       property: function
       area: "multilinear algebra"
-      notation: "mi T"
+      comments:
+       - "<math><mi>T</mi><mrow><mi>X</mi></mrow></math>"
       notationa: "msup T •"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_algebra"
@@ -11018,8 +11086,9 @@ concepts:
       en: todd class of $1
       property: function
       area: "characteristic classes"
-      notation: "mi td"
-      notationa: "mi Td"
+      comments:
+       - "<math><mi>td</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>Td</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Todd_class"
        - "https://ncatlab.org/nlab/show/Todd+class"
@@ -11164,8 +11233,9 @@ concepts:
       en: triangle function of $1
       property: function
       area: "special functions"
-      notation: "mi Λ"
-      notationa: "mi tri"
+      comments:
+       - "<math><mi>Λ</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>tri</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TriangleFunction.html"
        - "https://en.wikipedia.org/wiki/Triangular_function"
@@ -11291,10 +11361,11 @@ concepts:
       en: turn of $1
       property: unit
       area: "geometry"
-      notation: "mi cyc"
-      notationc: "mi rev"
-      notationb: "mi tr"
-      notationa: "mi pla"
+      comments:
+       - "<math><mi>cyc</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>rev</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>tr</mi><mrow><mi>X</mi></mrow></math>"
+       - "<math><mi>pla</mi><mrow><mi>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Turn_(geometry)"
       alias:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1292,10 +1292,11 @@ concepts:
       en: ceiling of $1
       property: fenced, function
       area: "number theory"
-      notation: "⌈ $1 ⌉"
-      notationc: "〛 $1 〚"
-      notationb: "] $1 ["
-      notationa: "ceil ($1"
+      comments:
+       - "<math><mo>⌈</mo><mi>X</mi><mo>Y</mo></math>"
+       - "<math><mo>&#x27e7;</mo><mi>X</mi><mo>&#x27e6;</mo></math>"
+       - "<math><mo>]</mo><mi>X</mi><mo>[</mo></math>"
+       - "<math><mi>ceil</mi><mrow><mo>(</mo><mi>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -1344,7 +1345,7 @@ concepts:
       area: "number theory"
       comments:
        - "<math><mi>C</mi></math>"
-      notationa: "msub C 10"
+       - "<math><msup><mi>C</mi><mn>10</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChampernowneConstant.html"
        - "https://en.wikipedia.org/wiki/Champernowne_constant"
@@ -1383,8 +1384,8 @@ concepts:
       property: "indexed function, function"
       area: "probability theory"
       comments:
-       - "<math><msub><mi>𝟏</mi><mi>x</mi></msub></math>"
-      notationa: "mrow 𝟏 { $1 }"
+       - "<math><msub><mi>𝟏</mi><mi>X</mi></msub></math>"
+       - "<math><mn>1</mn><mrow><mo>{</mo><mi>X</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CharacteristicFunction.html"
        - "https://en.wikipedia.org/wiki/Characteristic_function_(probability_theory)"
@@ -1492,7 +1493,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msup><mi>χ</mi><mn>2</mn>></msup></math>"
+       - "<math><msup><mi>χ</mi><mn>2</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Chi-SquaredDistribution.html"
        - "https://en.wikipedia.org/wiki/Chi-squared_distribution"
@@ -1565,7 +1566,9 @@ concepts:
       en: clausen function of $1
       property: function
       area: "special functions"
-      notation: "msub Cl 2"
+      comments:
+       - "<math><msub><mi>Cl</mi><mn>2</mn></msub><mrow><mo>(</mo><mi>&#x03c6;</mi><mo>)</mo></mrow></math>"
+       notation: "msub Cl 2"
       urls: 
        - "https://en.wikipedia.org/wiki/Clausen_function"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -294,7 +294,8 @@ concepts:
       en: $1 alternation $2
       property: infix
       area: "logic"
-      notation: "mo |"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>|</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Alternation_(formal_language_theory)"
        - "https://en.wikipedia.org/wiki/%E2%88%A8"
@@ -454,7 +455,8 @@ concepts:
       en: $1 apartness relation $2
       property: infix
       area: "constructive mathematics"
-      notation: "mo #"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>#</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Apartness_relation"
        - "https://ncatlab.org/nlab/show/apartness+relation"
@@ -1002,7 +1004,8 @@ concepts:
       en: $1 box product $2
       property: infix
       area: "graph theory"
-      notation: "mo ☐"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>☐</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cartesian_product_of_graphs"
       alias:
@@ -1076,7 +1079,8 @@ concepts:
       en: $1 cap product $2
       property: infix
       area: "algebraic topology"
-      notation: "mo ⌣"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⌣</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cap_product"
        - "https://ncatlab.org/nlab/show/cap+product"
@@ -1110,7 +1114,8 @@ concepts:
       en: $1 cartesian product $2
       property: infix
       area: "set theory"
-      notation: "mo ×"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>×</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CartesianProduct.html"
        - "https://en.wikipedia.org/wiki/Cartesian_product"
@@ -1198,7 +1203,8 @@ concepts:
       en: $1 cauchy product $2
       property: infix
       area: "analysis"
-      notation: "mo ⋅"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⋅</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CauchyProduct.html"
        - "https://en.wikipedia.org/wiki/Cauchy_product"
@@ -1329,7 +1335,8 @@ concepts:
       en: $1 characteristic subgroup $2
       property: infix
       area: "group theory"
-      notation: "mo char"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>char</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Characteristic_subgroup"
        - "https://www.encyclopediaofmath.org/index.php/Characteristic_subgroup"
@@ -1400,7 +1407,8 @@ concepts:
       en: $1 chemical equilibrium $2
       property: infix
       area: "chemistry"
-      notation: "mo ⇌"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⇌</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chemical_equilibrium"
       alias:
@@ -1783,7 +1791,8 @@ concepts:
       en: $1 composition $2
       property: infix
       area: "algebra"
-      notation: "mo ∘"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∘</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Composition.html"
        - "https://ncatlab.org/nlab/show/composition"
@@ -1860,7 +1869,8 @@ concepts:
       en: $1 contraction operator $2
       property: infix
       area: "algebraic geometry"
-      notation: "mo ⌟"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⌟</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/abs/1104.1240"
     
@@ -1933,7 +1943,8 @@ concepts:
       en: $1 connected sum $2
       property: infix
       area: "topology"
-      notation: "mo #"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>#</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConnectedSum.html"
        - "https://en.wikipedia.org/wiki/Connected_sum"
@@ -1967,7 +1978,8 @@ concepts:
       en: $1 containment $2
       property: infix
       area: "computer science"
-      notation: "mo ≤"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≤</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Encompassment_ordering"
        - "https://en.wikipedia.org/wiki/Subset"
@@ -2071,7 +2083,8 @@ concepts:
       en: $1 convolution $2
       property: infix
       area: "functional analysis"
-      notation: "mo ∗"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∗</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Convolution.html"
        - "https://en.wikipedia.org/wiki/List_of_convolutions_of_probability_distributions"
@@ -2098,7 +2111,8 @@ concepts:
       en: $1 coprime $2
       property: infix
       area: "number theory"
-      notation: "mo ⊥"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊥</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Coprime.html"
        - "https://en.wikipedia.org/wiki/Coprime_integers"
@@ -2220,7 +2234,8 @@ concepts:
       en: $1 cross product $2
       property: infix
       area: "linear algebra"
-      notation: "mo ×"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>×</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CrossProduct.html"
        - "https://en.wikipedia.org/wiki/Cross_product"
@@ -2295,7 +2310,8 @@ concepts:
       en: $1 cup product $2
       property: infix
       area: "algebraic topology"
-      notation: "mo ⌣"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⌣</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cup_product"
        - "https://ncatlab.org/nlab/show/cup+product"
@@ -2435,7 +2451,8 @@ concepts:
       en: $1 decrease tends to? $2
       property: infix
       area: "calculus"
-      notation: "mo ↘"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>↘</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"
@@ -2550,7 +2567,8 @@ concepts:
       en: $1 dependence relation $2
       property: infix
       area: "linear algebra"
-      notation: "mo ◃"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>◃</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dependence_relation"
     
@@ -2704,7 +2722,8 @@ concepts:
       en: $1 dilation $2
       property: infix
       area: "mathematical morphology"
-      notation: "mo ⊕"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊕</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dilation_(morphology)"
     
@@ -2809,7 +2828,8 @@ concepts:
       en: $1 direct product $2
       property: infix
       area: "abstract algebra"
-      notation: "mo ×"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>×</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectProduct.html"
        - "https://en.wikipedia.org/wiki/Direct_product"
@@ -2822,7 +2842,8 @@ concepts:
       en: $1 direct sum $2
       property: infix
       area: "abstract algebra"
-      notation: "mo ⊕"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊕</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectSum.html"
        - "https://en.wikipedia.org/wiki/Direct_sum"
@@ -2862,7 +2883,8 @@ concepts:
       en: $1 dirichlet convolution $2
       property: infix
       area: "number theory"
-      notation: "mo ∗"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∗</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirichlet_convolution"
        - "https://www.encyclopediaofmath.org/index.php/Dirichlet_convolution"
@@ -3068,7 +3090,8 @@ concepts:
       en: $1 dot product $2
       property: infix
       area: "linear algebra"
-      notation: "mo ⋅"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⋅</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DotProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -3080,7 +3103,8 @@ concepts:
       en: $1 double bond $2
       property: infix
       area: "chemistry"
-      notation: "mo ="
+      comments:
+       - "<math><mrow><mi>X</mi><mo>=</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Double_bond"
     
@@ -3377,7 +3401,8 @@ concepts:
       en: $1 equivalence relation $2
       property: infix
       area: "set theory"
-      notation: "mo ~"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>~</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EquivalenceRelation.html"
        - "https://en.wikipedia.org/wiki/Equivalence_relation"
@@ -3718,7 +3743,8 @@ concepts:
       en: $1 exterior product $2
       property: infix
       area: "multilinear algebra"
-      notation: "mo ∧"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∧</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorProduct.html"
        - "https://www.encyclopediaofmath.org/index.php/Exterior_product"
@@ -3887,7 +3913,8 @@ concepts:
       en: $1 field extension $2
       property: infix
       area: "algebra"
-      notation: "mo /"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>/</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FieldExtension.html"
        - "https://en.wikipedia.org/wiki/Field_extension"
@@ -4164,7 +4191,8 @@ concepts:
       en: $1 free product $2
       property: infix
       area: "group theory"
-      notation: "mo *"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>*</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeProduct.html"
        - "https://en.wikipedia.org/wiki/Free_product"
@@ -5104,7 +5132,8 @@ concepts:
       en: $1 hit or miss transform $2
       property: infix
       area: "mathematical morphology"
-      notation: "mo ⊙"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊙</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hit-or-miss_transform"
     
@@ -5167,7 +5196,8 @@ concepts:
       en: $1 homomorphic product $2
       property: infix
       area: "graph theory"
-      notation: "mo ⋉"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⋉</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Graph_product"
     
@@ -6230,7 +6260,8 @@ concepts:
       en: $1 kronecker product $2
       property: infix
       area: "matrix theory"
-      notation: "mo ⊗"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊗</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerProduct.html"
        - "https://en.wikipedia.org/wiki/Khatri-Rao_product"
@@ -6459,7 +6490,8 @@ concepts:
       en: $1 left adjoint $2
       property: infix
       area: "category theory"
-      notation: "mo ⊣"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊣</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjoint_functors"
     
@@ -6468,7 +6500,8 @@ concepts:
       en: $1 left composition $2
       property: infix
       area: "algebra"
-      notation: "mo ;"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>;</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Composition_of_relations"
       alias:
@@ -6592,7 +6625,8 @@ concepts:
       en: $1 lexicographic order $2
       property: infix
       area: "discrete mathematics"
-      notation: "mo <"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>&lt;</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lexicographic_order"
        - "https://mathworld.wolfram.com/LexicographicOrder.html"
@@ -6627,7 +6661,8 @@ concepts:
       en: $1 like charge $2
       property: infix
       area: "physics"
-      notation: "mo ⇈"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⇈</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4719"
     
@@ -7205,7 +7240,8 @@ concepts:
       en: $1 minkowski difference $2
       property: infix
       area: "geometry"
-      notation: "mo -"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>-</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
       alias:
@@ -7216,7 +7252,8 @@ concepts:
       en: $1 minkowski sum $2
       property: infix
       area: "geometry"
-      notation: "mo +"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinkowskiSum.html"
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
@@ -7697,7 +7734,8 @@ concepts:
       en: $1 nor $2
       property: infix
       area: "logic"
-      notation: "mo ↓"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>↓</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nor.html"
        - "https://mathworld.wolfram.com/NOR.html"
@@ -7733,7 +7771,8 @@ concepts:
       en: $1 not divisible by $2
       property: infix
       area: "number theory"
-      notation: "mo ∤"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∤</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divisor"
     
@@ -7870,7 +7909,8 @@ concepts:
       en: $1 opposite charge $2
       property: infix
       area: "physics"
-      notation: "mo ⇅"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⇅</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4657"
     
@@ -7879,7 +7919,8 @@ concepts:
       en: $1 or product $2
       property: infix
       area: "graph theory"
-      notation: "mo *"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>*</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
       alias:
@@ -7909,7 +7950,8 @@ concepts:
       en: $1 orthogonal $2
       property: infix
       area: "geometry,<br/>algebra"
-      notation: "mo ⊥"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊥</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Orthogonal.html"
        - "https://en.1wikipedia.org/wiki/Orthogonal_functions"
@@ -7963,7 +8005,8 @@ concepts:
       en: $1 outer product $2
       property: infix
       area: "linear algebra"
-      notation: "mo ⊗"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊗</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterProduct.html"
        - "https://en.wikipedia.org/wiki/Outer_product"
@@ -8021,7 +8064,8 @@ concepts:
       en: $1 parallel $2
       property: infix
       area: "geometry"
-      notation: "mo ∥"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∥</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Parallel.html"
        - "https://en.wikipedia.org/wiki/Parallel_(geometry)"
@@ -8053,7 +8097,8 @@ concepts:
       en: $1 partition $2
       property: infix
       area: "number theory"
-      notation: "mo ⊢"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊢</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Partition.html"
        - "https://mathworld.wolfram.com/FrequencyRepresentation.html"
@@ -8107,7 +8152,8 @@ concepts:
       en: $1 peirce arrow $2
       property: infix
       area: "logic"
-      notation: "mo ↓"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>↓</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Peirce_arrow"
     
@@ -8171,7 +8217,8 @@ concepts:
       en: $1 perpendicular $2
       property: infix
       area: "geometry"
-      notation: "mo ⟂"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⟂</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Perpendicular"
        - "https://www.encyclopediaofmath.org/index.php/Perpendicular"
@@ -8613,7 +8660,8 @@ concepts:
       en: $1 proper subgroup $2
       property: infix
       area: "group theory"
-      notation: "mo <"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>&lt;</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Subgroup"
     
@@ -8686,7 +8734,8 @@ concepts:
       en: $1 pushforward $2
       property: infix
       area: "differential geometry"
-      notation: "mo *"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>*</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/mJ8ZDdA10GY?t=2555"
        - "https://en.wikipedia.org/wiki/Pushforward_(differential)"
@@ -8775,7 +8824,8 @@ concepts:
       en: $1 quotient group $2
       property: infix
       area: "group theory"
-      notation: "mo /"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>/</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/QuotientGroup.html"
        - "https://ncatlab.org/nlab/show/quotient+group"
@@ -8786,7 +8836,8 @@ concepts:
       en: $1 quotient space $2
       property: infix
       area: "topology"
-      notation: "mo /"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>/</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/QuotientSpace.html"
        - "https://en.wikipedia.org/wiki/Quotient_space_(topology)"
@@ -9130,7 +9181,8 @@ concepts:
       en: $1 rewrite rule $2
       property: infix
       area: "logic"
-      notation: "mo →"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>→</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Semi-Thue_system"
       alias:
@@ -9282,7 +9334,8 @@ concepts:
       en: $1 right quotient $2
       property: infix
       area: "formal languages"
-      notation: "mo \\"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>\\</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Quotient_of_a_formal_language"
     
@@ -9366,7 +9419,8 @@ concepts:
       en: $1 rooted product of graphs $2
       property: infix
       area: "graph theory"
-      notation: "mo ∘"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∘</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Rooted_product_of_graphs"
     
@@ -9679,7 +9733,8 @@ concepts:
       en: $1 similar $2
       property: infix
       area: "geometry"
-      notation: "mo ~"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>~</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Similar.html"
        - "https://en.wikipedia.org/wiki/Matrix_similarity"
@@ -10171,7 +10226,8 @@ concepts:
       en: $1 strong product $2
       property: infix
       area: "graph theory"
-      notation: "mo ⊠"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊠</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
       alias:
@@ -10219,7 +10275,8 @@ concepts:
       en: $1 subgroup $2
       property: infix
       area: "group theory"
-      notation: "mo ≤"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≤</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Subgroup.html"
        - "https://en.wikipedia.org/wiki/Subgroup"
@@ -10231,7 +10288,8 @@ concepts:
       en: $1 succeeds $2
       property: infix
       area: "set theory"
-      notation: "mo ≻"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≻</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Succeeds.html"
        - "https://en.wikipedia.org/wiki/Ordered_set_operators"
@@ -10241,7 +10299,8 @@ concepts:
       en: $1 succeeds or equals $2
       property: infix
       area: "set theory"
-      notation: "mo ≽"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≽</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ordered_set_operators"
     
@@ -10271,7 +10330,8 @@ concepts:
       en: $1 sumset $2
       property: infix
       area: "set theory"
-      notation: "mo +"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>+</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Sumset.html"
        - "https://en.wikipedia.org/wiki/Sumset"
@@ -10552,7 +10612,8 @@ concepts:
       en: $1 tensor product $2
       property: infix
       area: "algebra"
-      notation: "mo ⊗"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>⊗</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TensorProduct.html"
        - "https://en.wikipedia.org/wiki/Tensor_product"
@@ -10565,7 +10626,8 @@ concepts:
       en: $1 tensor product of graphs $2
       property: infix
       area: "graph theory"
-      notation: "mo ×"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>×</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_product_of_graphs"
       alias:
@@ -10826,7 +10888,8 @@ concepts:
       en: $1 triple bond $2
       property: infix
       area: "chemistry"
-      notation: "mo ≡"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≡</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Triple_bond"
     
@@ -11065,7 +11128,8 @@ concepts:
       en: $1 unnatural isomorphism $2
       property: infix
       area: "set theory"
-      notation: "mo ≈"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>≈</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Isomorphism#Relation_with_equality"
     
@@ -11214,7 +11278,8 @@ concepts:
       en: $1 vertical composition $2
       property: infix
       area: "category theory"
-      notation: "mo ∘"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∘</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/vertical+composition"
        - "https://proofwiki.org/wiki/Definition: Vertical_Composition_of_Natural_Transformations"
@@ -11745,7 +11810,8 @@ concepts:
       en: $1 zig zag product $2
       property: infix
       area: "graph theory"
-      notation: "mo ∘"
+      comments:
+       - "<math><mrow><mi>X</mi><mo>∘</mo><mi>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -958,7 +958,8 @@ concepts:
       en: biquaternion of $1
       property: mtable
       area: "ring theory"
-      notation: "mtable 2x2"
+      comments:
+       - "<math><mrow><mo>(</mo><mtable rowspacing='4pt' columnspacing='1em'><mtr><mtd><mi>u</mi><mo>+</mo><mi>h</mi><mi>v</mi></mtd><mtd><mi>w</mi><mo>+</mo><mi>h</mi><mi>x</mi></mtd></mtr><mtr><mtd><mo>−</mo><mi>w</mi><mo>+</mo><mi>h</mi><mi>x</mi></mtd><mtd><mi>u</mi><mo>−</mo><mi>h</mi><mi>v</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Biquaternion#Linear_representation"
     
@@ -1283,7 +1284,8 @@ concepts:
       en: cayley table of $1
       property: mtable
       area: "group theory"
-      notation: "mtable"
+      comments:
+       - "<math><mtable><mtr><mtd><mo>×</mo></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>1</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>−1</mn></mtd><mtd><mn>−1</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable>"
       urls: 
        - "https://mathworld.wolfram.com/CayleyTable.html"
        - "https://en.wikipedia.org/wiki/Cayley_table"

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -116,12 +116,12 @@ Additional contributions are welcome:
 {% endif %}
 </td>
 {%- endfor -%}
-{%- if forloop.first-%}<td style="width:auto" rowspan="{{c.conditions.size}}">{%- for com in c.comment -%}
+{%- if forloop.first-%}<td style="width:auto" rowspan="{{c.conditions.size}}">{%- for com in c.comments -%}
 {{com | markdownify | replace: "<p>", "<span>" | replace: "</p>", "</span>" }}
 {%- unless forloop.last -%}<br>{% endunless -%}
 {% endfor %}
 {%- if c.alias -%}
-{%- if c.comment -%}<br>{%- endif -%}
+{%- if c.comments -%}<br>{%- endif -%}
 Aliases: {% for al in c.alias -%}{{al}}{%- unless forloop.last -%}<br>{% endunless -%}{%- endfor -%}
 {%-endif -%}
 </td>{%- endif -%}
@@ -171,12 +171,12 @@ arXiv
 {% endif %}
 </td>
 {%- endfor -%}
-<td style="width:auto">{%- for com in c.comment -%}
+<td style="width:auto">{%- for com in c.comments -%}
 {{com | markdownify | replace: "<p>", "<span>" | replace: "</p>", "</span>" }}
 {%- unless forloop.last -%}<br>{% endunless -%}
 {% endfor %}
 {%- if c.alias -%}
-{%- if c.comment -%}<br>{%- endif -%}
+{%- if c.comments -%}<br>{%- endif -%}
 Aliases: {% for al in c.alias -%}{{al}}{%- unless forloop.last -%}, {% endunless -%}{%- endfor -%}
 {%-endif -%}
 </td>

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -122,7 +122,7 @@ Additional contributions are welcome:
 {% endfor %}
 {%- if c.alias -%}
 {%- if c.comment -%}<br>{%- endif -%}
-Aliases: {% for al in c.alias -%}{{al}} {%- endfor -%}
+Aliases: {% for al in c.alias -%}{{al}}{%- unless forloop.last -%}<br>{% endunless -%}{%- endfor -%}
 {%-endif -%}
 </td>{%- endif -%}
 {%- if forloop.first-%}<td rowspan="{{c.conditions.size}}">{{c.area}}</td>{%-endif -%}
@@ -177,7 +177,7 @@ arXiv
 {% endfor %}
 {%- if c.alias -%}
 {%- if c.comment -%}<br>{%- endif -%}
-Aliases: {% for al in c.alias -%}{{al}} {%- endfor -%}
+Aliases: {% for al in c.alias -%}{{al}}{%- unless forloop.last -%}, {% endunless -%}{%- endfor -%}
 {%-endif -%}
 </td>
 <td>{{c.area}}</td>

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -122,7 +122,7 @@ Additional contributions are welcome:
 {% endfor %}
 {%- if c.alias -%}
 {%- if c.comment -%}<br>{%- endif -%}
-Aliases: {{c.alias}}
+Aliases: {% for al in c.alias -%}{{al}} {%- endfor -%}
 {%-endif -%}
 </td>{%- endif -%}
 {%- if forloop.first-%}<td rowspan="{{c.conditions.size}}">{{c.area}}</td>{%-endif -%}
@@ -177,7 +177,7 @@ arXiv
 {% endfor %}
 {%- if c.alias -%}
 {%- if c.comment -%}<br>{%- endif -%}
-Aliases: {{c.alias}}
+Aliases: {% for al in c.alias -%}{{al}} {%- endfor -%}
 {%-endif -%}
 </td>
 <td>{{c.area}}</td>


### PR DESCRIPTION
As agreed on the call of 2024-06-06 I took an action item to update the format used for the open list to be closer to that of the core list, for easier comparison, and to make it easier to move symbols from open to core if widely accepted.

This  done as a PR from my fork rather than from a branch so that the HTML renderings can be compared

OLD

https://w3c.github.io/mathml-docs/intent-open-concepts

NEW

https://davidcarlisle.github.io/mathml-docs/intent-open-concepts

All data in the current yaml is preserved, the form field renamed to property, and new `en` field for a (English) speech template added.

The `notation` field with approximate text indication of mathml is still there but not 
currently displayed although it was used to inform the initial speech templates and in some cases added as real mathml in the comments field eg

https://davidcarlisle.github.io/mathml-docs/intent-open-concepts/#amalgamated-product3indexed%20infix

There will need to be review of almost all the speech templates which were mostly auto-generated from the concept name and arity, however that can be done on the main site not part of this PR which is just really asking about the format.

One specific question abut the table format. In the core list we split it by sections

eg calculus is

https://w3c.github.io/mathml-docs/intent-core-concepts/#calculus

The open list has a single table but has a column for **subject**

Should we split up the open list with sections for subject (replacing the subject column)??

**Pro:** makes it more like core, makes the table less wide, groups related symbols

**Con:** makes it a bit harder to check when adding a new symbol for name clashes as you need to check all the sections, perhaps makes it a bit harder to add new concepts if it means generating a new section (technically that is not hard, but it may be an extra mental barrier discouraging submission)

If we decide to keep a single list with a subject column for open should we revert to that format for core  or does it not matter if the tables are diferent?

In addition  to **Subject**, this open list has additional columns for **Sources** (a list of URL) and **Aliases** (alternative suggested names), and the yaml has an undisplayed "notation" field that can be used to help author comments and/or the speech templates.

I don't want a long term branch collecting merge conflicts so if this is thought to be more or less in the right direction, I suggest we merge and then edit the individual entries at w3c, but obviously if there are other suggested structural changes (in particular if we decide to split by section on subject area) then we can do that first in this fork...

I pinged a few people as reviewers who commented on the call, but comments welcome from anyone:-)