### PR TITLE
arg attributes in MathML examples in open concept list

### DIFF
--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10519,9 +10519,8 @@ concepts:
       property: fenced
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='seminorm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mo ‖ $1 ‖"
-      notationa: "mo | $1"
+       - "<math><mrow intent='seminorm($a1)'><mo>‖</mo><mi arg='a1'>X</mi><mo>‖</mo></mrow></math>"
+       - "<math><mrow intent='seminorm($a1)'><mo>|</mo><mi arg='a1'>X</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Seminorm.html"
        - "https://en.wikipedia.org/wiki/Norm_(mathematics)"
@@ -10587,7 +10586,7 @@ concepts:
       property: mixfix
       area: "group theory"
       comments:
-       - "<math><mrow intent='short-exact-sequence($a1,$a2,$a3)'><mn>0</mn><mo>&rightarrow;</mo><mi arg='a1'>X</mi><mo>&rightarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi><mo>&rightarrow;</mo><mn>0</mn></mrow></math>"
+       - "<math><mrow intent='short-exact-sequence($a1,$a2,$a3)'><mn>0</mn><mo>&rightarrow;</mo><mi arg='a1'>X</mi><mo>&rightarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi arg='a3'>Z</mi><mo>&rightarrow;</mo><mn>0</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShortExactSequence.html"
        - "https://en.wikipedia.org/wiki/Exact_sequence"
@@ -10996,8 +10995,7 @@ concepts:
       property: msub
       area: "sheaf theory"
       comments:
-       - "<math><mrow intent='stalk($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub $1 $2"
+       - "<math><msub intent='stalk($a1,$a2)'><mi arg='a1'>ℱ</mi><mi arg='a2'>x</mi></msub></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stalk_(sheaf)"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -421,7 +421,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='anharmonic-ratio($a1,$a2,$a3,$a4)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -1998,7 +1998,7 @@ concepts:
       property: mixfix
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></mrow></math>"     
+       - "<math><mrow intent='configuration($a1,$a2,$a3,$a4)'><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></mrow></math>"     
       urls: 
        - "https://mathworld.wolfram.com/Configuration.html"
        - "https://en.wikipedia.org/wiki/Configuration_(geometry)"
@@ -2372,7 +2372,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='cross-ratio($a1,$a2,$a3,$a4)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -10648,7 +10648,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></mrow></math>"
+       - "<math><mrow intent='square($a1,$a2,$a3,$a4)'><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Square.html"
        - "https://en.wikipedia.org/wiki/Square"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12064,8 +12064,8 @@ concepts:
       property: infix
       area: "analysis"
       comments:
-       - <math><mi arg='a1'>X</mi><mover><mo>→</mo><mi>w</mi></mover><mi arg='a2'>Y</mi></math>"
-       - <math><mi arg='a1'>X</mi><mo>⇀</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mi arg='a1'>X</mi><mover><mo>→</mo><mi>w</mi></mover><mi arg='a2'>Y</mi></math>"
+       - "<math><mi arg='a1'>X</mi><mo>⇀</mo><mi arg='a2'>Y</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeakConvergence.html"
        - "https://en.wikipedia.org/wiki/Weak_convergence_(Hilbert_space)"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10723,8 +10723,7 @@ concepts:
       property: "indexed symbol"
       area: "fourier analysis"
       comments:
-       - "<math><mrow intent='sobolev-space($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msubsup W $1 $2"
+       - "<math><mrow intent='sobolev-space($a1,$a2)'><msup><mi>W</mi><mrow><mi arg='a1'>k</mi><mi arg='a2'>p</mi></mrow></msup></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SobolevSpace.html"
        - "https://en.wikipedia.org/wiki/Sobolev_space"
@@ -11000,8 +10999,7 @@ concepts:
       property: mixfix
       area: "commutative algebra"
       comments:
-       - "<math><mrow intent='stanley-reisner-ring($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow $1 [ $2 ]"
+       - "<math><mrow intent='stanley-reisner-ring($a1,$a2)'><mi arg='a1'>k</mi><mrow><mo>[</mo><mi arg='a2'>Δ</mi><mo>]</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/Stanley-Reisner_ring"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -3634,7 +3634,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><mrow intent='equivariant-cohomology($a1,$a2)'><msubsup><mi>H</mi><mi>G</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>;</mo><mo>&#x039b;</mo><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='equivariant-cohomology($a1,$a2)'><msubsup><mi>H</mi><mi>G</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>;</mo><mo arg='a2'>&#x039b;</mo><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Equivariant_cohomology"
        - "https://ncatlab.org/nlab/show/equivariant+cohomology"
@@ -4015,10 +4015,12 @@ concepts:
     
     - concept: faber-polynomial
       arity: 1
-      en: faber polynomial of $1
+      en: $1 th faber polynomial
       property: function
       area: "polynomials"
       notation: "msub P m"
+      comments:
+       - "<math><msub intent='faber-polynomial($a1)'><mi mathvariant='normal'>P</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FaberPolynomial.html"
        - "https://en.wikipedia.org/wiki/Faber_polynomials"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -725,7 +725,7 @@ concepts:
       property: "indexed function"
       area: "complex analysis"
       comments:
-       - "<math><msup><mi>A</mi><mi arg='a1'>n</mi></msup><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='bergman-space($a1,$a2)'><msup><mi>A</mi><mi arg='a1'>n</mi></msup><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BergmanSpace.html"
        - "https://en.wikipedia.org/wiki/Bergman_space"
@@ -752,7 +752,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><msub><mi>B</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='bernoulli-polynomial($a1,$a2)'><msub><mi>B</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BernoulliPolynomial.html"
        - "https://en.wikipedia.org/wiki/Bernoulli_polynomials"
@@ -766,7 +766,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>J</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='bessel-function($a1,$a2)'><msub><mi>J</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselFunction.html"
        - "https://en.wikipedia.org/wiki/Bessel_function"
@@ -779,7 +779,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>Y</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='bessel-function-of-second-kind($a1,$a2)'><msub><mi>Y</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselFunctionoftheSecondKind.html"
        - "https://dlmf.nist.gov/10.2#E3"
@@ -791,7 +791,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>y</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='bessel-polynomial($a1,$a2)'><msub><mi>y</mi><mi arg='a1'>n</mi></msub><mrow><mo>(</mo><mi arg='a2'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BesselPolynomial.html"
        - "https://en.wikipedia.org/wiki/Bessel_polynomials"
@@ -934,8 +934,8 @@ concepts:
       property: symbol
       area: "computer science"
       comments:
-       - "<math><mrow><mn>0</mn></mrow></math>"
-       - "<math><mrow><mn>1</mn></mrow></math>"
+       - "<math><mn intent='bit'>0</mn></math>"
+       - "<math><mn intent='bit'>1</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/Bit.html"
        - "https://en.wikipedia.org/wiki/Bit"
@@ -1519,7 +1519,7 @@ concepts:
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:
-       - "<math><msub><mi>&Gamma;</mi><mrow><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></math>"
+       - "<math><mrow intent='christoffel-symbol-of-first-kind($a1,$a2,$a3)'><msub><mi>&Gamma;</mi><mrow><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -2148,7 +2148,7 @@ concepts:
       property: constant
       area: "logic"
       comments:
-       - "<math><mrow><mo>⊥</mo></mrow></math>"
+       - "<math><mo>⊥</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2333,7 +2333,7 @@ concepts:
       property: indexed fenced
       area: "stochastic processes"
       comments:
-       - "<math><msub><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>,</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi>t</mi></msub></math>"
+       - "<math><mrow intent='covariation($a1,$a2,$a3)'><msub><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>,</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi arg='a3'>t</mi></msub></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_variation"
       alias:
@@ -3631,7 +3631,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><msubsup><mi>H</mi><mi>G</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>;</mo><mo>&#x039b;</mo><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='equivariant-cohomology($a1,$a2)'><msubsup><mi>H</mi><mi>G</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>;</mo><mo>&#x039b;</mo><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Equivariant_cohomology"
        - "https://ncatlab.org/nlab/show/equivariant+cohomology"
@@ -3721,7 +3721,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><msubsup><mi>H</mi><mi>et</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='etale-cohomology($a1)'><msubsup><mi>H</mi><mi>et</mi><mo>*</mo></msubsup><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/%C3%89tale_cohomology"
        - "https://ncatlab.org/nlab/show/etale+cohomology"
@@ -4257,7 +4257,7 @@ concepts:
       property: operator
       area: "numerical analysis"
       comments:
-       - "<math><msubsup><mi>&Delta;</mi><mi arg='a2'>x</mi><mi arg='a1'>n</mi></msubsup><mrow><mi arg='a3'>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='forward-difference($a1,$a2,$a3)'><msubsup><mi>&Delta;</mi><mi arg='a2'>x</mi><mi arg='a1'>n</mi></msubsup><mrow><mi arg='a3'>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ForwardDifference.html)"
        - "https://dlmf.nist.gov/18.1#EGx1"
@@ -4280,7 +4280,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><msub><mi>ℱ</mi><mi>s</mi></msub><mi>f</mi></math>"
+       - "<math><mrow intent='fourier-sine-transform($a1)'><msub><mi>ℱ</mi><mi>s</mi></msub><mi>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierSineTransform.html"
        - "https://dlmf.nist.gov/1.14#E10"
@@ -6425,7 +6425,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mrow><mn>6174</mn></mrow></math>"
+       - "<math><mn intent='kaprekar-constant'>6174</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/KaprekarConstant.html"
        - "https://en.wikipedia.org/wiki/6174_(number)"
@@ -8508,7 +8508,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi>G</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='p-core($a1)'><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi>G</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Core_(group)"
        - "https://en.wikipedia.org/wiki/P-soluble_group"
@@ -9322,8 +9322,8 @@ concepts:
       property: symbol
       area: "mathematical symbols"
       comments:
-       - "<math><mrow><mo>□</mo></mrow></math>"
-       - "<math><mrow><mo>∎</mo></mrow></math>"
+       - "<math><mo>□</mo></math>"
+       - "<math><mo>∎</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -9450,7 +9450,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><mi arg='a1'>x</mi></math>"
        - "<math><mi intent='radius-vector'>r</mi></math>"
        - "<math><mi intent='radius-vector'>s</mi></math>"
       urls: 
@@ -9962,7 +9962,7 @@ concepts:
        - "<math><mi intent='roman-numeral'>vii</mi></math>"
        - "<math><mi intent='roman-numeral'>viii</mi></math>"
        - "<math><mi intent='roman-numeral'>ix</mi></math>"
-       - "<math><mrow><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><mi intent='roman-numeral'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RomanNumerals.html"
        - "https://en.wikipedia.org/wiki/Roman_numerals"
@@ -12245,7 +12245,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><msub><mi>W</mi><mi>&delta;</mi></msub><mrow><mo>(</mo><mi>t</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi>&delta;</mi></msub><mrow><mo>(</mo><mi>t</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerSausage.html"
        - "https://en.wikipedia.org/wiki/Wiener_sausage"
@@ -12457,7 +12457,7 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='zero-ideal'><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroIdeal.html"
        - "https://ncatlab.org/nlab/show/zero+ideal"
@@ -12488,7 +12488,7 @@ concepts:
       property: symbol
       area: "algebra"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='zero-object'><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_object_(algebra)"
        - "https://ncatlab.org/nlab/show/zero+object"
@@ -12499,8 +12499,8 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
-       - "<math><mrow><mn>0</mn></mrow></math>"
+       - "<math><mrow intent='zero-ring'><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
+       - "<math><mn intent='zero-ring'>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroRing.html"
        - "https://en.wikipedia.org/wiki/Zero_ring"
@@ -12511,7 +12511,7 @@ concepts:
       property: constant
       area: "linear algebra"
       comments:
-       - "<math><mrow><mn>0</mn></mrow></math>"
+       - "<math><mn intent='zero-vector'>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroVector.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4131,11 +4131,11 @@ concepts:
     
     - concept: fibonacci-number
       arity: 1
-      en: fibonacci number of $1
+      en: $1 th fibonacci number
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub intent='fibonacci-number($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fibonacci-number($a1)'><mi>F</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FibonacciNumber.html"
        - "https://en.wikipedia.org/wiki/Fibonacci_number"
@@ -4188,7 +4188,8 @@ concepts:
       en: field of sets
       property: fenced
       area: "boolean algebra"
-      notation: "⟨$1, $2⟩"
+      comments:
+       - "<math><mrow intent='field-of-sets($a1,$a2)'><mo>(</mo><mi arg='a1'>X</mi><mo>,</mo><mi arg='a2'>F</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Field_of_sets"
        - "https://www.encyclopediaofmath.org/index.php/Field_of_sets"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -663,8 +663,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='bateman-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow msub k $1 ( $2"
+       - "<math><mrow intent='bateman-function($a1,$a2)'><msub><mi>k</mi><mi arg='a1'>v</mi></msub><mrow><mo>(</mo><mi arg='a2'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BatemanFunction.html"
        - "https://en.wikipedia.org/wiki/Bateman_function"
@@ -1657,8 +1656,7 @@ concepts:
       property: mixfix
       area: "topology"
       comments:
-       - "<math><mrow intent='closed-ball($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow msub B $1 /msub [ $2 ]"
+       - "<math><mrow intent='closed-ball($a1,$a2)'><msub><mi>B</mi><mi arg='a1'>r</mi></msub><mrow><mo>[</mo><mi arg='a2'>p</mi><mo>]</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
        - "https://en.wikipedia.org/wiki/Ball_(mathematics)"
@@ -8567,8 +8565,7 @@ concepts:
       property: mixfix
       area: "topology"
       comments:
-       - "<math><mrow intent='open-ball($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow msub B $1 /msub ( $2"
+       - "<math><mrow intent='open-ball($a1,$a2)'><msub><mi>B</mi><mi arg='a1'>r</mi></msub><mrow><mo>(</mo><mi arg='a2'>p</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
        - "https://en.wikipedia.org/wiki/Ball_(mathematics)"
@@ -9992,9 +9989,8 @@ concepts:
       property: indexed postfix
       area: "elementary mathematics"
       comments:
-       - "<math><mrow intent='restriction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "$1 mo msub ↾ $2 /mo"
-      notationa: "$1 mo msub | $2 /mo"
+        - "<math><mrow intent='restriction($a1,$a2)'><mi arg='a1'>f</mi><msub><mo>↾</mo><mi arg='a2'>A</mi></msub></mrow></math>"
+        - "<math><mrow intent='restriction($a1,$a2)'><mi arg='a1'>f</mi><msub><mo>|</mo><mi arg='a2'>A</mi></msub></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Restricted_representation"
        - "https://en.wikipedia.org/wiki/Restriction_(mathematics)"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -11678,7 +11678,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='toroidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>σ</mi><mo>,</mo><mi arg='a2'>τ</mi><mo>,</mo><mi arg='a3'>ϕ"</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='toroidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>σ</mi><mo>,</mo><mi arg='a2'>τ</mi><mo>,</mo><mi arg='a3'>ϕ</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ToroidalCoordinates.html"
        - "https://en.wikipedia.org/wiki/Toroidal_coordinates"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4410,8 +4410,7 @@ concepts:
       property: operator
       area: "fractional caclulus"
       comments:
-       - "<math><mrow intent='fractional-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup D $1"
+       - "<math><msup intent='fractional-derivative($a1)'><mi>D</mi><mi arg='a1'>f</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/FractionalDerivative.html"
        - "https://dlmf.nist.gov/1.15#E51"
@@ -4422,8 +4421,7 @@ concepts:
       property: operator
       area: "fractional caclulus"
       comments:
-       - "<math><mrow intent='fractional-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup I $1"
+       - "<math><msup intent='fractional-integral($a1)'><mi>I</mi><mi arg='a1'>f</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/FractionalIntegral.html"
        - "https://dlmf.nist.gov/1.15#E47"
@@ -5259,8 +5257,7 @@ concepts:
       property: "indexed symbol"
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='hardy-class($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup H $1"
+       - "<math><msup intent='hardy-class($a1)'><mi>H</mi><mi arg='a1'>x</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy_space"
        - "https://www.encyclopediaofmath.org/index.php/Hardy_classes"
@@ -5312,8 +5309,7 @@ concepts:
       property: "indexed function"
       area: "metric geometry"
       comments:
-       - "<math><mrow intent='hausdorff-measure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup H $1"
+       - "<math><msup intent='hausdorff-measure($a1)'><mi>H</mi><mi arg='a1'>d</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/HausdorffMeasure.html"
        - "https://en.wikipedia.org/wiki/Hausdorff_measure"
@@ -6970,10 +6966,9 @@ concepts:
       property: "embellished operator"
       area: "differential operators"
       comments:
-       - "<math><mrow intent='laplace-operator($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup ∇ 2"
-      notationb: "mrow ∇ · ∇"
-      notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='laplace-operator($a1)'><msup>m<mo>∇</mo><mn>2</mn></msup><mi arg='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='laplace-operator($a1)'><mo>∇</mo><mo>·</mo><mo>∇</mo><mi arg='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>f</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Laplace_operator"
        - "https://ncatlab.org/nlab/show/Laplace+operator"
@@ -9291,10 +9286,11 @@ concepts:
       property: "function, msup"
       area: "set theory"
       comments:
-       - "<math><mrow intent='power-set($a1)'><mi>P</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>𝒫</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>ℙ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>℘</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>P</mi><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>𝒫</mi><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>ℙ</mi><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>℘</mi><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><msup intent='power-set($a1)'><mn>2</mn><mi arg='a1'>X</mi></msup></math>"
       notationa: "msup 2 $1"
       urls: 
        - "https://mathworld.wolfram.com/PowerSet.html"
@@ -11578,7 +11574,7 @@ concepts:
       area: "multilinear algebra"
       comments:
        - "<math><mrow intent='tensor-algebra($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
-      notationa: "msup T •"
+       - "<math><mrow intent='tensor-algebra($a1)'><msup><mi>T</mi><mo>•</mo></msup><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_algebra"
     
@@ -11897,13 +11893,12 @@ concepts:
        - scalar-triple-product
     
     - concept: triple-torus
-      arity: 1
-      en: triple torus of $1
+      arity: 0
+      en: triple torus
       property: "indexed symbol"
       area: "topology"
       comments:
-       - "<math><mrow intent='triple-torus($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup 𝕋 3"
+       - "<math><msup intent='triple-torus($a1)'><mi>𝕋</mi><mn>3</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/TripleTorus.html"
        - "https://en.wikipedia.org/wiki/Three-torus"
@@ -12218,7 +12213,7 @@ concepts:
       area: "complex analysis"
       comments:
        - "<math><mi intent='upper-half-plane'>ℍ</mi></math>"
-      notationa: "msup ℍ +"
+       - "<math><msup intent='upper-half-plane'><mi>ℍ</mi><mo>+</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/UpperHalf-Plane.html"
        - "https://en.wikipedia.org/wiki/Upper_half-plane"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -348,7 +348,7 @@ concepts:
       property: fenced, 5-tuple
       area: "model theory"
       comments:
-       - "<math><mrow intent='amalgam($a1,$a2,$a2,$a3,$a4,$a5)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>f</mi><mo>,</mo><mi arg='a3'>B</mi><mo>,</mo><mi arg='a4'>g</mi><mo>,</mo><mi arg='a5'>C</mi>><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='amalgam($a1,$a2,$a2,$a3,$a4,$a5)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>f</mi><mo>,</mo><mi arg='a3'>B</mi><mo>,</mo><mi arg='a4'>g</mi><mo>,</mo><mi arg='a5'>C</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Amalgamation_property"
        - "https://ncatlab.org/nlab/show/amalgamation+property"
@@ -4806,7 +4806,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mrow intent='gaussian-integers'><mi>ℤ</mi><mo>[</mo><mi>i</mi>><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='gaussian-integers'><mi>ℤ</mi><mo>[</mo><mi>i</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianInteger.html"
        - "https://en.wikipedia.org/wiki/Gaussian_integer"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2791,13 +2791,12 @@ concepts:
        - "https://arxiv.org/pdf/1208.5915.pdf"
     
     - concept: derivation-tree
-      arity: 1
-      en: derivation tree of $1
+      arity: 2
+      en: derivation  $1, $2
       property: mfrac
       area: "logic"
       comments:
-       - "<math><mrow intent='derivation-tree($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mfrac"
+       - "<math><mfrac intent='derivation-tree($a1,$a2)'><mrow arg='a1'><mi>P</mi><mi>Q</mi></mrow><mi arg='a2'>R</mi></mfrac></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Derivation_tree"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -675,7 +675,7 @@ concepts:
     
     - concept: beatty-sequence
       arity: 1
-      en: beatty sequence of $1
+      en: $1 th beatty sequence
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -686,7 +686,7 @@ concepts:
     
     - concept: bell-number
       arity: 1
-      en: bell number of $1
+      en: $1 th bell number
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -721,7 +721,7 @@ concepts:
     
     - concept: bergman-space
       arity: 2
-      en: bergman space
+      en: $1 th bergman space of $2
       property: "indexed function"
       area: "complex analysis"
       comments:
@@ -733,7 +733,7 @@ concepts:
     
     - concept: bernoulli-number
       arity: 1
-      en: bernoulli number of $1
+      en: $1 th bernoulli number
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -833,7 +833,7 @@ concepts:
     
     - concept: betti-number
       arity: 1
-      en: betti number of $1
+      en: $1 th betti number
       property: "indexed symbol"
       area: "graph theory"
       comments:
@@ -1203,7 +1203,7 @@ concepts:
     
     - concept: catalan-number
       arity: 1
-      en: catalan number of $1
+      en: $1 th catalan number
       property: "indexed symbol"
       area: "combinatorics"
       comments:
@@ -2393,7 +2393,7 @@ concepts:
     
     - concept: cullen-number
       arity: 1
-      en: cullen number of $1
+      en: #1th cullen number
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -2518,7 +2518,7 @@ concepts:
     
     - concept: cyclotomic-polynomial
       arity: 1
-      en: cyclotomic polynomial of $1
+      en: $1 th cyclotomic polynomial
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -4088,7 +4088,7 @@ concepts:
     
     - concept: fermat-number
       arity: 1
-      en: fermat number of $1
+      en: #1th fermat number
       property: "indexed symbol"
       area: "number theory"
       comments:
@@ -4369,7 +4369,7 @@ concepts:
     
     - concept: franel-number
       arity: 1
-      en: franel number of $1
+      en: $1 th franel number
       property: "indexed symbol"
       area: "combinatorics"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -22,6 +22,8 @@ concepts:
       en: abelian integral of $1
       property: indexed
       area: "complex analysis"
+      comments:
+       - "<math><mrow intent='abelian-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/AbelianIntegral.html"
@@ -43,6 +45,8 @@ concepts:
       en: abundancy of $1
       property: mixfix
       area: "number theory"
+      comments:
+       - "<math><mrow intent='abundancy($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "sigma (n) / n"
       urls: 
        - "https://mathworld.wolfram.com/Abundancy.html"
@@ -125,6 +129,8 @@ concepts:
       en: adjoint of $1
       property: 
       area: 
+      comments:
+       - "<math><mrow intent='adjoint($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: 
       urls: 
        - "https://mathworld.wolfram.com/Adjoint.html"
@@ -136,6 +142,8 @@ concepts:
       en: adjoint action of $1
       property: "function/msub"
       area: "lie algebra"
+      comments:
+       - "<math><mrow intent='adjoint-action($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi ad $1"
       notationa: "msub ad $1"
       urls: 
@@ -260,6 +268,8 @@ concepts:
       en: algebraic closure of $1
       property: mover/msup
       area: "algebra"
+      comments:
+       - "<math><mrow intent='algebraic-closure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ¯"
       notationa: "msup alg"
       urls: 
@@ -272,6 +282,8 @@ concepts:
       en: almost surely of $1
       property: 
       area: "probability theory"
+      comments:
+       - "<math><mrow intent='almost-surely($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtext a.s."
       urls: 
        - "https://en.wikipedia.org/wiki/Almost_surely"
@@ -337,6 +349,8 @@ concepts:
       en: amalgam of $1
       property: fenced, 5-tuple
       area: "model theory"
+      comments:
+       - "<math><mrow intent='amalgam($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow (A,f,B,g,C)"
       urls: 
        - "https://en.wikipedia.org/wiki/Amalgamation_property"
@@ -458,6 +472,8 @@ concepts:
       en: antiparticle of $1
       property: mover
       area: "particle physics"
+      comments:
+       - "<math><mrow intent='antiparticle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Antimatter"
@@ -575,6 +591,8 @@ concepts:
       en: associated legendre polynomial of $1
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='associated-legendre-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P l m"
       urls: 
        - "https://mathworld.wolfram.com/AssociatedLegendrePolynomial.html"
@@ -719,6 +737,8 @@ concepts:
       en: berezin integral of $1
       property: indexed
       area: "mathematical physics"
+      comments:
+       - "<math><mrow intent='berezin-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://en.wikipedia.org/wiki/Berezin_integral"
@@ -883,6 +903,8 @@ concepts:
       en: bigeometric integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='bigeometric-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -913,6 +935,8 @@ concepts:
       en: binomial coefficient of $1
       property: "indexed function"
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='binomial-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup C"
       urls: 
        - "https://mathworld.wolfram.com/BinomialCoefficient.html"
@@ -928,6 +952,8 @@ concepts:
       en: binomial distribution of $1
       property: function
       area: "probability theory"
+      comments:
+       - "<math><mrow intent='binomial-distribution($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow B(n,p"
       urls: 
        - "https://mathworld.wolfram.com/BinomialDistribution.html"
@@ -1152,6 +1178,8 @@ concepts:
       en: cardinality of $1
       property: many
       area: "set theory"
+      comments:
+       - "<math><mrow intent='cardinality($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow | mo #"
       notationb: "mi card"
       notationa: "<math><mrow intent='cardinality($a1)'><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
@@ -1759,6 +1787,8 @@ concepts:
       en: column vector of $1
       property: mtable
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='column-vector($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/ColumnVector.html"
@@ -1844,6 +1874,8 @@ concepts:
       en: complementary nome of $1
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='complementary-nome($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub q 1"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
@@ -2124,6 +2156,8 @@ concepts:
       en: contingency table of $1
       property: mtable
       area: "statistics"
+      comments:
+       - "<math><mrow intent='contingency-table($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/ContingencyTable.html"
@@ -2136,6 +2170,8 @@ concepts:
       en: continued fraction of $1
       property: mixfix
       area: "number theory"
+      comments:
+       - "<math><mrow intent='continued-fraction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac"
       urls: 
        - "https://mathworld.wolfram.com/ContinuedFraction.html"
@@ -2266,6 +2302,8 @@ concepts:
       en: coproduct of $1
       property: indexed
       area: "topology, category theory"
+      comments:
+       - "<math><mrow intent='coproduct($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∐"
       urls: 
        - "https://mathworld.wolfram.com/Coproduct.html"
@@ -2483,6 +2521,8 @@ concepts:
       en: current of $1
       property: fenced
       area: "differential topology"
+      comments:
+       - "<math><mrow intent='current($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [[ $1 ]]"
       notationa: "<math><mrow intent='current($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
@@ -2509,6 +2549,8 @@ concepts:
       en: cycle of $1
       property: fenced
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='cycle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Permutation#Cycle_notation"
@@ -2530,6 +2572,8 @@ concepts:
       en: cyclotomic field of $1
       property: embellished symbol
       area: "number theory"
+      comments:
+       - "<math><mrow intent='cyclotomic-field($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow Q( ζ )"
       notationa: "mrow Q( msub ζ $1"
       urls: 
@@ -2754,6 +2798,8 @@ concepts:
       en: derivation tree of $1
       property: mfrac
       area: "logic"
+      comments:
+       - "<math><mrow intent='derivation-tree($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Derivation_tree"
@@ -2914,6 +2960,8 @@ concepts:
       en: dilogarithm of $1
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='dilogarithm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub Li 2"
       comments:
        - "<math><mrow intent='dilogarithm($a1)'><msub><mi>L</mi><mn>2</mn></msub><mi arg='a1'>z</mi></mrow></math>"
@@ -3229,6 +3277,8 @@ concepts:
       en: divided difference of $1
       property: "fenced, mixfix"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='divided-difference($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [ $1, ... $n ]"
       notationb: "mrow #f [$1, ..., $n ]"
       notationa: "mrow D [ $1, ... $n ] #f"
@@ -4040,6 +4090,8 @@ concepts:
       en: $1 th faber polynomial
       property: function
       area: "polynomials"
+      comments:
+       - "<math><mrow intent='faber-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub P m"
       comments:
        - "<math><msub intent='faber-polynomial($a1)'><mi mathvariant='normal'>P</mi><mi arg='a1'>n</mi></msub></math>"
@@ -4137,6 +4189,8 @@ concepts:
       en: fermi dirac distribution of $1
       property: function
       area: "quantum statistics"
+      comments:
+       - "<math><mrow intent='fermi-dirac-distribution($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover n ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Fermi%E2%80%93Dirac_distribution"
@@ -4149,6 +4203,8 @@ concepts:
       en: feynman slash of $1
       property: menclose
       area: "quantum field theory"
+      comments:
+       - "<math><mrow intent='feynman-slash($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "menclose notation=updiagonalstrike $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Feynman_slash_notation"
@@ -4337,6 +4393,8 @@ concepts:
       en: fox derivative of $1
       property: mfrac
       area: "geometric topology"
+      comments:
+       - "<math><mrow intent='fox-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac ∂..."
       urls: 
        - "https://mathworld.wolfram.com/FoxDerivative.html"
@@ -4348,6 +4406,8 @@ concepts:
       en: fox wright function of $1
       property: mmultiscripts
       area: "special functions"
+      comments:
+       - "<math><mrow intent='fox-wright-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mmultiscripts Ψ q none mprescripts p none"
       urls: 
        - "https://en.wikipedia.org/wiki/Fox%E2%80%93Wright_function"
@@ -4359,6 +4419,8 @@ concepts:
       en: fractional derivative of $1
       property: operator
       area: "fractional caclulus"
+      comments:
+       - "<math><mrow intent='fractional-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup D $1"
       urls: 
        - "https://mathworld.wolfram.com/FractionalDerivative.html"
@@ -4369,6 +4431,8 @@ concepts:
       en: fractional integral of $1
       property: operator
       area: "fractional caclulus"
+      comments:
+       - "<math><mrow intent='fractional-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup I $1"
       urls: 
        - "https://mathworld.wolfram.com/FractionalIntegral.html"
@@ -4527,6 +4591,8 @@ concepts:
       en: frobenius norm of $1
       property: indexed fenced
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='frobenius-norm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow | $1 F"
       urls: 
        - "https://mathworld.wolfram.com/FrobeniusNorm.html"
@@ -4634,6 +4700,8 @@ concepts:
       en: galois field of $1
       property: function
       area: "finite fields"
+      comments:
+       - "<math><mrow intent='galois-field($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow GF ($1)"
       notationb: "msub F $1"
       notationa: "msub 𝔽 $1"
@@ -4825,6 +4893,8 @@ concepts:
       en: generalized hypergeometric function of $1
       property: mmultiscripts
       area: "special functions"
+      comments:
+       - "<math><mrow intent='generalized-hypergeometric-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mmultiscripts F q none mprescripts p none"
       urls: 
        - "https://mathworld.wolfram.com/GeneralizedHypergeometricFunction.html"
@@ -4899,6 +4969,8 @@ concepts:
       en: geometric genus of $1
       property: function
       area: "algebraic geometry"
+      comments:
+       - "<math><mrow intent='geometric-genus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub p g"
       urls: 
        - "https://mathworld.wolfram.com/GeometricGenus.html"
@@ -4910,6 +4982,8 @@ concepts:
       en: geometric integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='geometric-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -4968,6 +5042,8 @@ concepts:
       en: global dimension of $1
       property: function
       area: "ring theory"
+      comments:
+       - "<math><mrow intent='global-dimension($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi gl dim"
       urls: 
        - "https://en.wikipedia.org/wiki/Global_dimension"
@@ -5192,6 +5268,8 @@ concepts:
       en: hardy class of $1
       property: "indexed symbol"
       area: "complex analysis"
+      comments:
+       - "<math><mrow intent='hardy-class($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy_space"
@@ -5204,6 +5282,8 @@ concepts:
       en: hardy space of $1
       property: mixfix
       area: "complex analysis"
+      comments:
+       - "<math><mrow intent='hardy-space($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H p ($1"
       urls: 
        - "https://mathworld.wolfram.com/HardySpace.html"
@@ -5241,6 +5321,8 @@ concepts:
       en: hausdorff measure of $1
       property: "indexed function"
       area: "metric geometry"
+      comments:
+       - "<math><mrow intent='hausdorff-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H $1"
       urls: 
        - "https://mathworld.wolfram.com/HausdorffMeasure.html"
@@ -5251,6 +5333,8 @@ concepts:
       en: hausdorff metric of $1
       property: function
       area: "metric geometry"
+      comments:
+       - "<math><mrow intent='hausdorff-metric($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub d H"
       urls: 
        - "https://en.wikipedia.org/wiki/Hausdorff_distance"
@@ -5383,6 +5467,8 @@ concepts:
       en: hermitian adjoint of $1
       property: msup
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='hermitian-adjoint($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup †,"
       notationa: "msup *"
       urls: 
@@ -5395,6 +5481,8 @@ concepts:
       en: hermitian conjugate of $1
       property: msup
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='hermitian-conjugate($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H"
       urls: 
        - "https://mathworld.wolfram.com/HermitianConjugate.html"
@@ -5482,6 +5570,8 @@ concepts:
       en: hilbert schmidt norm of $1
       property: fenced
       area: "matrix norms"
+      comments:
+       - "<math><mrow intent='hilbert-schmidt-norm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow | $1 | HS"
       urls: 
        - "https://mathworld.wolfram.com/Hilbert-SchmidtNorm.html"
@@ -5998,6 +6088,8 @@ concepts:
       en: infimum limit of $1
       property: indexed
       area: "limits"
+      comments:
+       - "<math><mrow intent='infimum-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi lim inf"
       notationa: "munder lim ¯"
       urls: 
@@ -6016,6 +6108,8 @@ concepts:
       en: infinite product of $1
       property: indexed
       area: "mathematical analysis"
+      comments:
+       - "<math><mrow intent='infinite-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munderover Π $1∞"
       urls: 
        - "https://mathworld.wolfram.com/InfiniteProduct.html"
@@ -6062,6 +6156,8 @@ concepts:
       en: inner jordan measure of $1
       property: function
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='inner-jordan-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub m *"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
@@ -6126,6 +6222,8 @@ concepts:
       en: interior product of $1
       property: "infix, indexed function"
       area: "differential forms"
+      comments:
+       - "<math><mrow intent='interior-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⨼"
       notationa: "msub ι $1"
       urls: 
@@ -6161,6 +6259,8 @@ concepts:
       en: inverse limit of $1
       property: prefix
       area: "category theory"
+      comments:
+       - "<math><mrow intent='inverse-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munder lim ←"
       urls: 
        - "https://mathworld.wolfram.com/InverseLimit.html"
@@ -6297,6 +6397,8 @@ concepts:
       en: jacobi polynomial of $1
       property: function
       area: "orthogonal polynomials"
+      comments:
+       - "<math><mrow intent='jacobi-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P"
       urls: 
        - "https://mathworld.wolfram.com/JacobiPolynomial.html"
@@ -6409,6 +6511,8 @@ concepts:
       en: jet of $1
       property: function
       area: "differential geometry"
+      comments:
+       - "<math><mrow intent='jet($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup J"
       urls: 
        - "https://en.wikipedia.org/wiki/Jet_(mathematics)"
@@ -6419,6 +6523,8 @@ concepts:
       en: join of $1
       property: indexed
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='join($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Join.html"
@@ -6517,6 +6623,8 @@ concepts:
       en: kelvin function of $1
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='kelvin-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub ber ν⁡"
       notationa: "msub bei ν⁡"
       urls: 
@@ -6580,6 +6688,8 @@ concepts:
       en: kleene star of $1
       property: msup
       area: "formal languages"
+      comments:
+       - "<math><mrow intent='kleene-star($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup *"
       urls: 
        - "https://en.wikipedia.org/wiki/Kleene_star"
@@ -6589,6 +6699,8 @@ concepts:
       en: kleene plus of $1
       property: msup
       area: "formal languages"
+      comments:
+       - "<math><mrow intent='kleene-plus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup +"
       urls: 
        - "https://en.wikipedia.org/wiki/Kleene_star"
@@ -6769,6 +6881,8 @@ concepts:
       en: kulkarni nomizu product of $1
       property: embellished infix
       area: "differential geometry"
+      comments:
+       - "<math><mrow intent='kulkarni-nomizu-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∧ /mo mspace=negative.../mspace mo ◯ /mo"
       urls: 
        - "https://en.wikipedia.org/wiki/Kulkarni%E2%80%93Nomizu_product"
@@ -6868,6 +6982,8 @@ concepts:
       en: laplace operator of $1
       property: "embellished operator"
       area: "differential operators"
+      comments:
+       - "<math><mrow intent='laplace-operator($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup ∇ 2"
       notationb: "mrow ∇ · ∇"
       notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
@@ -6905,6 +7021,8 @@ concepts:
       en: latin rectangle of $1
       property: mtable
       area: "combinatorial mathematics"
+      comments:
+       - "<math><mrow intent='latin-rectangle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/LatinRectangle.html"
@@ -6916,6 +7034,8 @@ concepts:
       en: latin square of $1
       property: mtable
       area: "combinatorial mathematics"
+      comments:
+       - "<math><mrow intent='latin-square($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/LatinSquare.html"
@@ -6952,6 +7072,8 @@ concepts:
       en: lebesgue integral of $1
       property: indexed
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='lebesgue-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/LebesgueIntegral.html"
@@ -6996,6 +7118,8 @@ concepts:
       en: left derivative of $1
       property: operator
       area: "calculus"
+      comments:
+       - "<math><mrow intent='left-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub ∂ –"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
@@ -7178,6 +7302,8 @@ concepts:
       en: line integral of $1
       property: indexed
       area: "analysis"
+      comments:
+       - "<math><mrow intent='line-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/LineIntegral.html"
@@ -7320,6 +7446,8 @@ concepts:
       en: long division of $1
       property: mfrac
       area: "arithmetic"
+      comments:
+       - "<math><mrow intent='long-division($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac?"
       urls: 
        - "https://mathworld.wolfram.com/LongDivision.html"
@@ -7352,6 +7480,8 @@ concepts:
       en: lower darboux integral of $1
       property: indexed
       area: "real analysis"
+      comments:
+       - "<math><mrow intent='lower-darboux-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munder ¯"
       urls: 
        - "https://mathworld.wolfram.com/DarbouxIntegral.html"
@@ -7363,6 +7493,8 @@ concepts:
       en: lower dini derivative of $1
       property: decorated function
       area: "analysis"
+      comments:
+       - "<math><mrow intent='lower-dini-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup $1 - '"
       urls: 
        - "https://mathworld.wolfram.com/DiniDerivative.html"
@@ -7425,6 +7557,8 @@ concepts:
       en: macdonald polynomial of $1
       property: function
       area: "orthogonal polynomials"
+      comments:
+       - "<math><mrow intent='macdonald-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub P λ"
       urls: 
        - "https://en.wikipedia.org/wiki/Macdonald_polynomials"
@@ -7549,6 +7683,8 @@ concepts:
       en: mathieu group of $1
       property: "indexed symbol"
       area: "group theory"
+      comments:
+       - "<math><mrow intent='mathieu-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub M 11"
       notationd: "msub M 12"
       notationc: "msub M 22"
@@ -7571,6 +7707,8 @@ concepts:
       en: matrix of $1
       property: mtable, fenced
       area: "algebra"
+      comments:
+       - "<math><mrow intent='matrix($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       notationb: "<math><mrow intent='matrix($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       notationa: "mrow ( $1"
@@ -7873,6 +8011,8 @@ concepts:
       en: modified spherical bessel function of $1
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='modified-spherical-bessel-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup i $1 (1)"
       notationb: "msubsup i $1 (2)"
       notationa: "msub k $1"
@@ -8022,6 +8162,8 @@ concepts:
       en: moore smith sequence of $1
       property: fenced
       area: "topology"
+      comments:
+       - "<math><mrow intent='moore-smith-sequence($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Smith_limit"
@@ -8048,6 +8190,8 @@ concepts:
       en: multiple integral of $1
       property: indexed
       area: "multivariable calculus"
+      comments:
+       - "<math><mrow intent='multiple-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫ ⋯ ∫"
       notationa: "mo ∫"
       urls: 
@@ -8091,6 +8235,8 @@ concepts:
       en: multiplier algebra of $1
       property: function
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='multiplier-algebra($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow M($1"
       urls: 
        - "https://mathworld.wolfram.com/MultiplierAlgebra.html"
@@ -8181,6 +8327,8 @@ concepts:
       en: narrow denjoy integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='narrow-denjoy-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/DenjoyIntegral.html"
@@ -8355,6 +8503,8 @@ concepts:
       en: null graph
       property: symbol
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='null-graph($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mover K ¯ /mover $1"
       urls: 
        - "https://mathworld.wolfram.com/NullGraph.html"
@@ -8581,6 +8731,8 @@ concepts:
       en: outer jordan measure of $1
       property: function
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='outer-jordan-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup m *"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
@@ -8679,6 +8831,8 @@ concepts:
       en: partial charge
       property: symbol
       area: "chemistry"
+      comments:
+       - "<math><mrow intent='partial-charge($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup δ $1"
       notationa: "mrow δ $1"
       urls: 
@@ -8781,6 +8935,8 @@ concepts:
       en: periodic continued fraction of $1
       property: mfrac
       area: "mathematical analysis"
+      comments:
+       - "<math><mrow intent='periodic-continued-fraction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac with ellipses"
       urls: 
        - "https://mathworld.wolfram.com/PeriodicContinuedFraction.html"
@@ -8803,6 +8959,8 @@ concepts:
       en: permutation of $1
       property: fenced, mtable, mixfix
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='permutation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ($1, ... $n)"
       notationb: "mtable"
       notationa: "mrow (312)(54)(8)(976"
@@ -8981,6 +9139,8 @@ concepts:
       en: pointwise convergent of $1
       property: postfix
       area: "convergence"
+      comments:
+       - "<math><mrow intent='pointwise-convergent($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtext pointwise"
       urls: 
        - "https://mathworld.wolfram.com/PointwiseConvergence.html"
@@ -9029,6 +9189,8 @@ concepts:
       en: pollaczek polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
+      comments:
+       - "<math><mrow intent='pollaczek-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P n (λ"
       urls: 
        - "https://mathworld.wolfram.com/PollaczekPolynomial.html"
@@ -9080,6 +9242,8 @@ concepts:
       en: pontrjagin dual of $1
       property: mover
       area: "harmonic analysis"
+      comments:
+       - "<math><mrow intent='pontrjagin-dual($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ^"
       urls: 
        - "https://ncatlab.org/nlab/show/Pontrjagin+dual"
@@ -9126,6 +9290,8 @@ concepts:
       en: post canonical system of $1
       property: fenced
       area: "formal languages"
+      comments:
+       - "<math><mrow intent='post-canonical-system($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow (A,I,R"
       urls: 
        - "https://en.wikipedia.org/wiki/Post_canonical_system"
@@ -9254,6 +9420,8 @@ concepts:
       en: product integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='product-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∏"
       urls: 
        - "https://en.wikipedia.org/wiki/Continuous_product"
@@ -9340,6 +9508,8 @@ concepts:
       en: prufer group of $1
       property: mixfix
       area: "group theory"
+      comments:
+       - "<math><mrow intent='prufer-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow Z ( msup $1 ∞ /msup"
       urls: 
        - "https://en.wikipedia.org/wiki/Pr%C3%BCfer_group"
@@ -9422,6 +9592,8 @@ concepts:
       en: q binomial coefficient of $1
       property: fenced-stacked
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='q-binomial-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow [ stacked mfrac ] q"
       urls: 
        - "https://mathworld.wolfram.com/q-BinomialCoefficient.html"
@@ -9445,6 +9617,8 @@ concepts:
       en: quadratic differential of $1
       property: mixfix
       area: "complex manifolds"
+      comments:
+       - "<math><mrow intent='quadratic-differential($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow d $1 ⊗ d $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_differential"
@@ -9656,6 +9830,8 @@ concepts:
       en: real bipolar of $1
       property: msup
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='real-bipolar($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 r r"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
@@ -9681,6 +9857,8 @@ concepts:
       en: real prepolar of $1
       property: prescript
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='real-prepolar($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup <mrow/> r /msup $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
@@ -9917,6 +10095,8 @@ concepts:
       en: riemann integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='riemann-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/RiemannIntegral.html"
@@ -9993,6 +10173,8 @@ concepts:
       en: riemann stieltje integral of $1
       property: indexed
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='riemann-stieltje-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-StieltjesIntegral.html"
@@ -10121,6 +10303,8 @@ concepts:
       en: root mean square of $1
       property: msub
       area: "means"
+      comments:
+       - "<math><mrow intent='root-mean-square($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub $1 RMS"
       urls: 
        - "https://mathworld.wolfram.com/Root-Mean-Square.html"
@@ -10187,6 +10371,8 @@ concepts:
       en: sample variance of $1
       property: embellished symbol
       area: "probability theory"
+      comments:
+       - "<math><mrow intent='sample-variance($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub m 2"
       notationc: "msup s 2"
       notationb: "msubsup s $1 2"
@@ -10213,6 +10399,8 @@ concepts:
       en: scaled riemann theta function of $1
       property: mover
       area: "special functions"
+      comments:
+       - "<math><mrow intent='scaled-riemann-theta-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover θ⁡ ^"
       urls: 
        - "https://dlmf.nist.gov/21.2#i"
@@ -10223,6 +10411,8 @@ concepts:
       en: schlaefli symbol of $1
       property: fenced
       area: "geometry"
+      comments:
+       - "<math><mrow intent='schlaefli-symbol($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow { $1 , ..., $n }"
       urls: 
        - "https://en.wikipedia.org/wiki/Schl%C3%A4fli_symbol"
@@ -10285,6 +10475,8 @@ concepts:
       en: second carmichael function of $1
       property: function
       area: "number theory"
+      comments:
+       - "<math><mrow intent='second-carmichael-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup λ '"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
@@ -10329,6 +10521,8 @@ concepts:
       en: seminorm of $1
       property: fenced
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='seminorm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ‖ $1 ‖"
       notationa: "mo | $1"
       urls: 
@@ -10367,6 +10561,8 @@ concepts:
       en: shift operator of $1
       property: operator
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='shift-operator($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup T t"
       urls: 
        - "https://mathworld.wolfram.com/ShiftOperator.html"
@@ -10478,6 +10674,8 @@ concepts:
       en: simplex of $1
       property: "indexed symbol"
       area: "geometry"
+      comments:
+       - "<math><mrow intent='simplex($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup Δ $1"
       urls: 
        - "https://mathworld.wolfram.com/Simplex.html"
@@ -10697,6 +10895,8 @@ concepts:
       en: spectrum of algebra of $1
       property: mover
       area: "algebra"
+      comments:
+       - "<math><mrow intent='spectrum-of-algebra($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ˆ"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_C*-algebra"
@@ -10822,6 +11022,8 @@ concepts:
       en: standard flattening of $1
       property: "indexed symbol"
       area: "multilinear algebra"
+      comments:
+       - "<math><mrow intent='standard-flattening($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub 𝒜 ($1"
       urls: 
        - "https://en.wikipedia.org/wiki/Matricization"
@@ -11148,6 +11350,8 @@ concepts:
       en: supremum limit of $1
       property: indexed
       area: "limits"
+      comments:
+       - "<math><mrow intent='supremum-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi lim sup"
       notationa: "mover lim ¯"
       urls: 
@@ -11166,6 +11370,8 @@ concepts:
       en: surface integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='surface-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/SurfaceIntegral.html"
@@ -11512,6 +11718,8 @@ concepts:
       en: toroidal coordinate of $1
       property: fenced
       area: "geometry"
+      comments:
+       - "<math><mrow intent='toroidal-coordinate($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( σ , τ , ϕ"
       urls: 
        - "https://mathworld.wolfram.com/ToroidalCoordinates.html"
@@ -11711,6 +11919,8 @@ concepts:
       en: triple torus of $1
       property: "indexed symbol"
       area: "topology"
+      comments:
+       - "<math><mrow intent='triple-torus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup 𝕋 3"
       urls: 
        - "https://mathworld.wolfram.com/TripleTorus.html"
@@ -11858,6 +12068,8 @@ concepts:
       en: uniformly convergent of $1
       property: infix, indexed, postfix
       area: "convergence"
+      comments:
+       - "<math><mrow intent='uniformly-convergent($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⇉"
       notationc: "mover ⟶ unif."
       notationb: "mo unif lim"
@@ -11881,6 +12093,8 @@ concepts:
       en: unit vector of $1
       property: mover
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='unit-vector($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ^"
       urls: 
        - "https://mathworld.wolfram.com/UnitVector.html"
@@ -11947,6 +12161,8 @@ concepts:
       en: unique existential of $1
       property: prefix
       area: "logic"
+      comments:
+       - "<math><mrow intent='unique-existential($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∃ !"
       notationa: "msub ∃ mrow =1 /mrow"
       urls: 
@@ -11993,6 +12209,8 @@ concepts:
       en: upper darboux integral of $1
       property: indexed
       area: "real analysis"
+      comments:
+       - "<math><mrow intent='upper-darboux-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Darboux_integral"
@@ -12003,6 +12221,8 @@ concepts:
       en: upper dini derivative of $1
       property: decorated function
       area: "analysis"
+      comments:
+       - "<math><mrow intent='upper-dini-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup $1 + '"
       urls: 
        - "https://mathworld.wolfram.com/DiniDerivative.html"
@@ -12027,6 +12247,8 @@ concepts:
       en: upper shadow of $1
       property: function
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='upper-shadow($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup 𝜕 +"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
@@ -12107,6 +12329,8 @@ concepts:
       en: vertical of $1
       property: 
       area: 
+      comments:
+       - "<math><mrow intent='vertical($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: 
       urls: 
        - "https://mathworld.wolfram.com/Vertical.html"
@@ -12129,6 +12353,8 @@ concepts:
       en: volterra integral of $1
       property: indexed
       area: "calculus"
+      comments:
+       - "<math><mrow intent='volterra-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -12218,6 +12444,8 @@ concepts:
       en: weber function of $1
       property: "indexed function"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='weber-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub E ν"
       urls: 
        - "https://mathworld.wolfram.com/WeberFunctions.html"
@@ -12573,6 +12801,8 @@ concepts:
       en: z matrix molecule of $1
       property: mtable
       area: "chemistry"
+      comments:
+       - "<math><mrow intent='z-matrix-molecule($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(chemistry)"
@@ -12595,6 +12825,8 @@ concepts:
       en: zernike polynomial of $1
       property: "indexed function"
       area: "orthogonal polynomials"
+      comments:
+       - "<math><mrow intent='zernike-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup Z"
       urls: 
        - "https://mathworld.wolfram.com/ZernikePolynomial.html"
@@ -12627,6 +12859,8 @@ concepts:
       en: zero morphism of $1
       property: "indexed symbol"
       area: "category theory"
+      comments:
+       - "<math><mrow intent='zero-morphism($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mn 0 mrow X,Y"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_morphism"
@@ -12687,3 +12921,4 @@ concepts:
        - "<math><mrow intent='zig-zag-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
+ 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2865,14 +2865,14 @@ concepts:
        - "https://en.wikipedia.org/wiki/Digamma_function"
     
     - concept: dihedral-group
-      arity: 0
-      en: dihedral group
+      arity: 1
+      en: $1 th dihedral group
       property: symbol
       area: "group theory"
       comments:
-       - "<math><msub intent='dihedral-group'><mi>D</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub intent='dihedral-group'><mi>Dih</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub intent='dihedral-group'><mi>D2</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>D</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>Dih</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>D</mi><mrow><mn>2</mn><mi arg='a1'>n</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/DihedralGroup.html"
        - "https://en.wikipedia.org/wiki/Dihedral_group"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12478,7 +12478,7 @@ concepts:
       property: "indexed function"
       area: "means"
       comments:
-       - "<math><mrow intent='weighted-lehmer-mean($a1,$a2,$a3)'><msub><mi>L</mi><mi>p</mi></msub><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>,</mo><mi arg='a3'>z</mi><mo>)</mo></mrow></mrow></math>
+       - "<math><mrow intent='weighted-lehmer-mean($a1,$a2,$a3)'><msub><mi>L</mi><mi>p</mi></msub><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>,</mo><mi arg='a3'>z</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerMean.html"
        - "https://en.wikipedia.org/wiki/Lehmer_mean"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1986,8 +1986,7 @@ concepts:
       property: mixfix
       area: "probability theory"
       comments:
-       - "<math><mrow intent='conditional-expectation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow E ( $1 | $2 )"
+       - "<math><mrow intent='conditional-expectation($a1,$a2)'><mi>E</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Conditional_expectation"
        - "https://ncatlab.org/nlab/show/conditional+expectation"
@@ -1998,8 +1997,7 @@ concepts:
       property: mixfix
       area: "probability theory"
       comments:
-       - "<math><mrow intent='conditional-probability($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow P ( $1 | $2 )"
+       - "<math><mrow intent='conditional-probability($a1,$a2)'><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConditionalProbability.html"
        - "https://en.wikipedia.org/wiki/Conditional_probability"
@@ -2031,8 +2029,7 @@ concepts:
       property: mixfix
       area: "statistics"
       comments:
-       - "<math><mrow intent='contrast-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "D ( $1 | $2)"
+       - "<math><mrow intent='contrast-function($a1,$a2)'><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(statistics)"
       alias:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1778,13 +1778,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Cokernel"
     
     - concept: column-vector
-      arity: 1
-      en: column vector of $1
+      arity: "*"
+      en: column vector of $1 $2 ...
       property: mtable
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='column-vector($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
+       - "<math><mrow intent='column-vector($a1,a2,a3)'><mo>(</mo><mtable><mtr><mtd><mi arg='a1'>x</mi></mtd></mtr><mtr><mtd><mi arg='a2'>y</mi></mtd></mtr><mtr><mtd><mi arg='a3'>z</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ColumnVector.html"
        - "https://en.wikipedia.org/wiki/Column_vector"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -5681,7 +5681,7 @@ concepts:
       property: "indexed symbol"
       area: "topology"
       comments:
-       - "<math><msup intent='ypertorus($a1)'><mi>T</mi><mi arg='a1'>n</mi></msup></math>"
+       - "<math><msup intent='hypertorus($a1)'><mi>T</mi><mi arg='a1'>n</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torus#n-dimensional_torus"
       alias:
@@ -6255,7 +6255,7 @@ concepts:
     - concept: jacobi-symbol
       arity: 2
       en: jacobi symbol
-      property: mixfix$1 $2
+      property: mixfix
       area: "number theory"
       comments:
        - "<math><mrow intent='jacobi-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2892,12 +2892,13 @@ concepts:
     
     - concept: differential-operator
       arity: 1
-      en: differential operator of $1
+      en: differential operator with respect to $1
       property: prefix
       area: "calculus"
       comments:
-       - "<math><mrow intent='differential-operator($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
-       - "<math><mrow intent='differential-operator($a1)'><mo>∂</mo><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><msub intent='differential-operator($a1)'><mi>D</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='differential-operator($a1)'><mo>∂</mo><mi arg='a1'>x</mi></msub></math>"
+       - "<math><mfrac intent='differential-operator($a1)'><mi>d</mi><mrow><mi>d</mi><mi arg='a1'>x</mi></mrow></mfrac></math>"
       notationa: "mfrac d mrow d $1"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialOperator.html"
@@ -4384,8 +4385,7 @@ concepts:
       property: mfrac
       area: "geometric topology"
       comments:
-       - "<math><mrow intent='fox-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mfrac ∂..."
+      - "<math><mfrac intent='fox-derivative(($a1)'><mi>∂</mi><mrow><mi>∂</mi><msub arg='a1'><mi>g</mi><mi>i</mi></msub></mrow></mfrac></math>"
       urls: 
        - "https://mathworld.wolfram.com/FoxDerivative.html"
        - "https://en.wikipedia.org/wiki/Fox_derivative"
@@ -6839,7 +6839,7 @@ concepts:
       area: "number theory"
       comments:
        - "<math><mrow intent='kronecker-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
-      notationa: "( mfrac $1 $2 )"
+       - "<math><mrow intent='kronecker-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>x</mi><mi arg='a2'>y</mi></mfrac><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerSymbol.html"
        - "https://en.wikipedia.org/wiki/Kronecker_symbol"
@@ -8231,8 +8231,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multichoose($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow ( mfrac $1 $2"
+       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Multiset.html"
     
@@ -8242,8 +8241,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multiset-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow ( ( mfrac $1 $2 )"
+       - "<math><mrow intent='multiset-coefficient($a1,$a2)'><mo>⦅</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo>⦆</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Multiset"
       alias:
@@ -9571,13 +9569,12 @@ concepts:
        - "https://en.wikipedia.org/wiki/Pythagorean_triple"
     
     - concept: q-binomial-coefficient
-      arity: 1
-      en: q binomial coefficient of $1
+      arity: 3
+      en: $3 q binomial coefficient of $1, $2
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='q-binomial-coefficient($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub mrow [ stacked mfrac ] q"
+       - "<math><msub intent='q-binomial-coefficient($a1,$a2,$a3)'><mrow><mo>[</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>m</mi></mfrac><mo>]</mo></mrow><mi arg='a3'>q</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/q-BinomialCoefficient.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2589,7 +2589,7 @@ concepts:
       property: infix
       area: "calculus"
       comments:
-       - "<math><mrow intent='decrease-tends-to($a1,$a2)''><mi arg='a1'>X</mi><mo>↘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='decrease-tends-to($a1,$a2)'><mi arg='a1'>X</mi><mo>↘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -8217,7 +8217,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness='0pt'><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
+       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness='0pt'><mi arg='a1'>m</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Multiset.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12463,7 +12463,7 @@ concepts:
        - "https://ncatlab.org/nlab/show/zero+ideal"
     
     - concept: zero-matrix
-      arity: 1
+      arity: 2
       en: $1 $2 zero matrix
       property: "indexed symbol"
       area: "linear algebra"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -23,8 +23,7 @@ concepts:
       property: indexed
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='abelian-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mo ∫"
+       - "<math><mrow intent='abelian-integral($a1)'><mo>∫</mo><mi arg='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AbelianIntegral.html"
        - "https://en.wikipedia.org/wiki/Abelian_integral"
@@ -46,7 +45,7 @@ concepts:
       property: mixfix
       area: "number theory"
       comments:
-       - "<math><mrow intent='abundancy($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='abundancy($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "sigma (n) / n"
       urls: 
        - "https://mathworld.wolfram.com/Abundancy.html"
@@ -130,7 +129,7 @@ concepts:
       property: 
       area: 
       comments:
-       - "<math><mrow intent='adjoint($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='adjoint($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: 
       urls: 
        - "https://mathworld.wolfram.com/Adjoint.html"
@@ -143,7 +142,7 @@ concepts:
       property: "function/msub"
       area: "lie algebra"
       comments:
-       - "<math><mrow intent='adjoint-action($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='adjoint-action($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi ad $1"
       notationa: "msub ad $1"
       urls: 
@@ -269,7 +268,7 @@ concepts:
       property: mover/msup
       area: "algebra"
       comments:
-       - "<math><mrow intent='algebraic-closure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='algebraic-closure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ¯"
       notationa: "msup alg"
       urls: 
@@ -283,7 +282,7 @@ concepts:
       property: 
       area: "probability theory"
       comments:
-       - "<math><mrow intent='almost-surely($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='almost-surely($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtext a.s."
       urls: 
        - "https://en.wikipedia.org/wiki/Almost_surely"
@@ -345,13 +344,12 @@ concepts:
        - nand
     
     - concept: amalgam
-      arity: 1
-      en: amalgam of $1
+      arity: 5
+      en: amalgam of $1 $2 $3 $4 $5
       property: fenced, 5-tuple
       area: "model theory"
       comments:
-       - "<math><mrow intent='amalgam($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow (A,f,B,g,C)"
+       - "<math><mrow intent='amalgam($a1,$a2,$a2,$a3,$a4,$a5)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>f</mi><mo>,</mo><mi arg='a3'>B</mi><mo>,</mo><mi arg='a4'>g</mi><mo>,</mo><mi arg='a5'>C</mi>><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Amalgamation_property"
        - "https://ncatlab.org/nlab/show/amalgamation+property"
@@ -473,7 +471,7 @@ concepts:
       property: mover
       area: "particle physics"
       comments:
-       - "<math><mrow intent='antiparticle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='antiparticle($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Antimatter"
@@ -592,7 +590,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='associated-legendre-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='associated-legendre-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P l m"
       urls: 
        - "https://mathworld.wolfram.com/AssociatedLegendrePolynomial.html"
@@ -738,7 +736,7 @@ concepts:
       property: indexed
       area: "mathematical physics"
       comments:
-       - "<math><mrow intent='berezin-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='berezin-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://en.wikipedia.org/wiki/Berezin_integral"
@@ -904,7 +902,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='bigeometric-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='bigeometric-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -936,7 +934,7 @@ concepts:
       property: "indexed function"
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='binomial-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='binomial-coefficient($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup C"
       urls: 
        - "https://mathworld.wolfram.com/BinomialCoefficient.html"
@@ -953,7 +951,7 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mrow intent='binomial-distribution($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='binomial-distribution($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow B(n,p"
       urls: 
        - "https://mathworld.wolfram.com/BinomialDistribution.html"
@@ -1179,7 +1177,7 @@ concepts:
       property: many
       area: "set theory"
       comments:
-       - "<math><mrow intent='cardinality($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cardinality($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow | mo #"
       notationb: "mi card"
       notationa: "<math><mrow intent='cardinality($a1)'><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
@@ -1788,7 +1786,7 @@ concepts:
       property: mtable
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='column-vector($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='column-vector($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/ColumnVector.html"
@@ -1875,7 +1873,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='complementary-nome($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='complementary-nome($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub q 1"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
@@ -2157,7 +2155,7 @@ concepts:
       property: mtable
       area: "statistics"
       comments:
-       - "<math><mrow intent='contingency-table($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='contingency-table($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/ContingencyTable.html"
@@ -2171,7 +2169,7 @@ concepts:
       property: mixfix
       area: "number theory"
       comments:
-       - "<math><mrow intent='continued-fraction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='continued-fraction($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac"
       urls: 
        - "https://mathworld.wolfram.com/ContinuedFraction.html"
@@ -2303,7 +2301,7 @@ concepts:
       property: indexed
       area: "topology, category theory"
       comments:
-       - "<math><mrow intent='coproduct($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='coproduct($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∐"
       urls: 
        - "https://mathworld.wolfram.com/Coproduct.html"
@@ -2522,7 +2520,7 @@ concepts:
       property: fenced
       area: "differential topology"
       comments:
-       - "<math><mrow intent='current($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='current($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [[ $1 ]]"
       notationa: "<math><mrow intent='current($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
@@ -2550,7 +2548,7 @@ concepts:
       property: fenced
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='cycle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cycle($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Permutation#Cycle_notation"
@@ -2573,7 +2571,7 @@ concepts:
       property: embellished symbol
       area: "number theory"
       comments:
-       - "<math><mrow intent='cyclotomic-field($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cyclotomic-field($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow Q( ζ )"
       notationa: "mrow Q( msub ζ $1"
       urls: 
@@ -2799,7 +2797,7 @@ concepts:
       property: mfrac
       area: "logic"
       comments:
-       - "<math><mrow intent='derivation-tree($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='derivation-tree($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Derivation_tree"
@@ -2961,7 +2959,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='dilogarithm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dilogarithm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub Li 2"
       comments:
        - "<math><mrow intent='dilogarithm($a1)'><msub><mi>L</mi><mn>2</mn></msub><mi arg='a1'>z</mi></mrow></math>"
@@ -3278,7 +3276,7 @@ concepts:
       property: "fenced, mixfix"
       area: "special functions"
       comments:
-       - "<math><mrow intent='divided-difference($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='divided-difference($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [ $1, ... $n ]"
       notationb: "mrow #f [$1, ..., $n ]"
       notationa: "mrow D [ $1, ... $n ] #f"
@@ -4091,7 +4089,7 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mrow intent='faber-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='faber-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub P m"
       comments:
        - "<math><msub intent='faber-polynomial($a1)'><mi mathvariant='normal'>P</mi><mi arg='a1'>n</mi></msub></math>"
@@ -4190,7 +4188,7 @@ concepts:
       property: function
       area: "quantum statistics"
       comments:
-       - "<math><mrow intent='fermi-dirac-distribution($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fermi-dirac-distribution($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover n ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Fermi%E2%80%93Dirac_distribution"
@@ -4204,7 +4202,7 @@ concepts:
       property: menclose
       area: "quantum field theory"
       comments:
-       - "<math><mrow intent='feynman-slash($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='feynman-slash($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "menclose notation=updiagonalstrike $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Feynman_slash_notation"
@@ -4394,7 +4392,7 @@ concepts:
       property: mfrac
       area: "geometric topology"
       comments:
-       - "<math><mrow intent='fox-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fox-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac ∂..."
       urls: 
        - "https://mathworld.wolfram.com/FoxDerivative.html"
@@ -4407,7 +4405,7 @@ concepts:
       property: mmultiscripts
       area: "special functions"
       comments:
-       - "<math><mrow intent='fox-wright-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fox-wright-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mmultiscripts Ψ q none mprescripts p none"
       urls: 
        - "https://en.wikipedia.org/wiki/Fox%E2%80%93Wright_function"
@@ -4420,7 +4418,7 @@ concepts:
       property: operator
       area: "fractional caclulus"
       comments:
-       - "<math><mrow intent='fractional-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fractional-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup D $1"
       urls: 
        - "https://mathworld.wolfram.com/FractionalDerivative.html"
@@ -4432,7 +4430,7 @@ concepts:
       property: operator
       area: "fractional caclulus"
       comments:
-       - "<math><mrow intent='fractional-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fractional-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup I $1"
       urls: 
        - "https://mathworld.wolfram.com/FractionalIntegral.html"
@@ -4592,7 +4590,7 @@ concepts:
       property: indexed fenced
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='frobenius-norm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='frobenius-norm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow | $1 F"
       urls: 
        - "https://mathworld.wolfram.com/FrobeniusNorm.html"
@@ -4701,7 +4699,7 @@ concepts:
       property: function
       area: "finite fields"
       comments:
-       - "<math><mrow intent='galois-field($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='galois-field($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow GF ($1)"
       notationb: "msub F $1"
       notationa: "msub 𝔽 $1"
@@ -4894,7 +4892,7 @@ concepts:
       property: mmultiscripts
       area: "special functions"
       comments:
-       - "<math><mrow intent='generalized-hypergeometric-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='generalized-hypergeometric-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mmultiscripts F q none mprescripts p none"
       urls: 
        - "https://mathworld.wolfram.com/GeneralizedHypergeometricFunction.html"
@@ -4970,7 +4968,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-       - "<math><mrow intent='geometric-genus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='geometric-genus($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub p g"
       urls: 
        - "https://mathworld.wolfram.com/GeometricGenus.html"
@@ -4983,7 +4981,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='geometric-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='geometric-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -5043,7 +5041,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-       - "<math><mrow intent='global-dimension($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='global-dimension($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi gl dim"
       urls: 
        - "https://en.wikipedia.org/wiki/Global_dimension"
@@ -5269,7 +5267,7 @@ concepts:
       property: "indexed symbol"
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='hardy-class($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hardy-class($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy_space"
@@ -5283,7 +5281,7 @@ concepts:
       property: mixfix
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='hardy-space($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hardy-space($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H p ($1"
       urls: 
        - "https://mathworld.wolfram.com/HardySpace.html"
@@ -5322,7 +5320,7 @@ concepts:
       property: "indexed function"
       area: "metric geometry"
       comments:
-       - "<math><mrow intent='hausdorff-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hausdorff-measure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H $1"
       urls: 
        - "https://mathworld.wolfram.com/HausdorffMeasure.html"
@@ -5334,7 +5332,7 @@ concepts:
       property: function
       area: "metric geometry"
       comments:
-       - "<math><mrow intent='hausdorff-metric($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hausdorff-metric($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub d H"
       urls: 
        - "https://en.wikipedia.org/wiki/Hausdorff_distance"
@@ -5468,7 +5466,7 @@ concepts:
       property: msup
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='hermitian-adjoint($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hermitian-adjoint($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup †,"
       notationa: "msup *"
       urls: 
@@ -5482,7 +5480,7 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='hermitian-conjugate($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hermitian-conjugate($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup H"
       urls: 
        - "https://mathworld.wolfram.com/HermitianConjugate.html"
@@ -5571,7 +5569,7 @@ concepts:
       property: fenced
       area: "matrix norms"
       comments:
-       - "<math><mrow intent='hilbert-schmidt-norm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hilbert-schmidt-norm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow | $1 | HS"
       urls: 
        - "https://mathworld.wolfram.com/Hilbert-SchmidtNorm.html"
@@ -6089,7 +6087,7 @@ concepts:
       property: indexed
       area: "limits"
       comments:
-       - "<math><mrow intent='infimum-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='infimum-limit($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi lim inf"
       notationa: "munder lim ¯"
       urls: 
@@ -6109,7 +6107,7 @@ concepts:
       property: indexed
       area: "mathematical analysis"
       comments:
-       - "<math><mrow intent='infinite-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='infinite-product($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munderover Π $1∞"
       urls: 
        - "https://mathworld.wolfram.com/InfiniteProduct.html"
@@ -6157,7 +6155,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow intent='inner-jordan-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='inner-jordan-measure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub m *"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
@@ -6223,7 +6221,7 @@ concepts:
       property: "infix, indexed function"
       area: "differential forms"
       comments:
-       - "<math><mrow intent='interior-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='interior-product($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⨼"
       notationa: "msub ι $1"
       urls: 
@@ -6260,7 +6258,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-       - "<math><mrow intent='inverse-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='inverse-limit($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munder lim ←"
       urls: 
        - "https://mathworld.wolfram.com/InverseLimit.html"
@@ -6398,7 +6396,7 @@ concepts:
       property: function
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow intent='jacobi-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jacobi-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P"
       urls: 
        - "https://mathworld.wolfram.com/JacobiPolynomial.html"
@@ -6512,7 +6510,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow intent='jet($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jet($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup J"
       urls: 
        - "https://en.wikipedia.org/wiki/Jet_(mathematics)"
@@ -6524,7 +6522,7 @@ concepts:
       property: indexed
       area: "measure theory"
       comments:
-       - "<math><mrow intent='join($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='join($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⋁"
       urls: 
        - "https://mathworld.wolfram.com/Join.html"
@@ -6624,7 +6622,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='kelvin-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kelvin-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub ber ν⁡"
       notationa: "msub bei ν⁡"
       urls: 
@@ -6689,7 +6687,7 @@ concepts:
       property: msup
       area: "formal languages"
       comments:
-       - "<math><mrow intent='kleene-star($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kleene-star($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup *"
       urls: 
        - "https://en.wikipedia.org/wiki/Kleene_star"
@@ -6700,7 +6698,7 @@ concepts:
       property: msup
       area: "formal languages"
       comments:
-       - "<math><mrow intent='kleene-plus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kleene-plus($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup +"
       urls: 
        - "https://en.wikipedia.org/wiki/Kleene_star"
@@ -6882,7 +6880,7 @@ concepts:
       property: embellished infix
       area: "differential geometry"
       comments:
-       - "<math><mrow intent='kulkarni-nomizu-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kulkarni-nomizu-product($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∧ /mo mspace=negative.../mspace mo ◯ /mo"
       urls: 
        - "https://en.wikipedia.org/wiki/Kulkarni%E2%80%93Nomizu_product"
@@ -6983,7 +6981,7 @@ concepts:
       property: "embellished operator"
       area: "differential operators"
       comments:
-       - "<math><mrow intent='laplace-operator($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='laplace-operator($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup ∇ 2"
       notationb: "mrow ∇ · ∇"
       notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
@@ -7022,7 +7020,7 @@ concepts:
       property: mtable
       area: "combinatorial mathematics"
       comments:
-       - "<math><mrow intent='latin-rectangle($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='latin-rectangle($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/LatinRectangle.html"
@@ -7035,7 +7033,7 @@ concepts:
       property: mtable
       area: "combinatorial mathematics"
       comments:
-       - "<math><mrow intent='latin-square($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='latin-square($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://mathworld.wolfram.com/LatinSquare.html"
@@ -7073,7 +7071,7 @@ concepts:
       property: indexed
       area: "measure theory"
       comments:
-       - "<math><mrow intent='lebesgue-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='lebesgue-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/LebesgueIntegral.html"
@@ -7119,7 +7117,7 @@ concepts:
       property: operator
       area: "calculus"
       comments:
-       - "<math><mrow intent='left-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='left-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub ∂ –"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
@@ -7303,7 +7301,7 @@ concepts:
       property: indexed
       area: "analysis"
       comments:
-       - "<math><mrow intent='line-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='line-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/LineIntegral.html"
@@ -7447,7 +7445,7 @@ concepts:
       property: mfrac
       area: "arithmetic"
       comments:
-       - "<math><mrow intent='long-division($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='long-division($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac?"
       urls: 
        - "https://mathworld.wolfram.com/LongDivision.html"
@@ -7481,7 +7479,7 @@ concepts:
       property: indexed
       area: "real analysis"
       comments:
-       - "<math><mrow intent='lower-darboux-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='lower-darboux-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "munder ¯"
       urls: 
        - "https://mathworld.wolfram.com/DarbouxIntegral.html"
@@ -7494,7 +7492,7 @@ concepts:
       property: decorated function
       area: "analysis"
       comments:
-       - "<math><mrow intent='lower-dini-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='lower-dini-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup $1 - '"
       urls: 
        - "https://mathworld.wolfram.com/DiniDerivative.html"
@@ -7558,7 +7556,7 @@ concepts:
       property: function
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow intent='macdonald-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='macdonald-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub P λ"
       urls: 
        - "https://en.wikipedia.org/wiki/Macdonald_polynomials"
@@ -7684,7 +7682,7 @@ concepts:
       property: "indexed symbol"
       area: "group theory"
       comments:
-       - "<math><mrow intent='mathieu-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mathieu-group($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub M 11"
       notationd: "msub M 12"
       notationc: "msub M 22"
@@ -8012,7 +8010,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='modified-spherical-bessel-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='modified-spherical-bessel-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup i $1 (1)"
       notationb: "msubsup i $1 (2)"
       notationa: "msub k $1"
@@ -8163,7 +8161,7 @@ concepts:
       property: fenced
       area: "topology"
       comments:
-       - "<math><mrow intent='moore-smith-sequence($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='moore-smith-sequence($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Smith_limit"
@@ -8191,7 +8189,7 @@ concepts:
       property: indexed
       area: "multivariable calculus"
       comments:
-       - "<math><mrow intent='multiple-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='multiple-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫ ⋯ ∫"
       notationa: "mo ∫"
       urls: 
@@ -8236,7 +8234,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='multiplier-algebra($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='multiplier-algebra($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow M($1"
       urls: 
        - "https://mathworld.wolfram.com/MultiplierAlgebra.html"
@@ -8328,7 +8326,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='narrow-denjoy-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='narrow-denjoy-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/DenjoyIntegral.html"
@@ -8504,7 +8502,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-       - "<math><mrow intent='null-graph($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='null-graph($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mover K ¯ /mover $1"
       urls: 
        - "https://mathworld.wolfram.com/NullGraph.html"
@@ -8732,7 +8730,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow intent='outer-jordan-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='outer-jordan-measure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup m *"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
@@ -8832,7 +8830,7 @@ concepts:
       property: symbol
       area: "chemistry"
       comments:
-       - "<math><mrow intent='partial-charge($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='partial-charge($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup δ $1"
       notationa: "mrow δ $1"
       urls: 
@@ -8936,7 +8934,7 @@ concepts:
       property: mfrac
       area: "mathematical analysis"
       comments:
-       - "<math><mrow intent='periodic-continued-fraction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='periodic-continued-fraction($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mfrac with ellipses"
       urls: 
        - "https://mathworld.wolfram.com/PeriodicContinuedFraction.html"
@@ -8960,7 +8958,7 @@ concepts:
       property: fenced, mtable, mixfix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='permutation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='permutation($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ($1, ... $n)"
       notationb: "mtable"
       notationa: "mrow (312)(54)(8)(976"
@@ -9140,7 +9138,7 @@ concepts:
       property: postfix
       area: "convergence"
       comments:
-       - "<math><mrow intent='pointwise-convergent($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='pointwise-convergent($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtext pointwise"
       urls: 
        - "https://mathworld.wolfram.com/PointwiseConvergence.html"
@@ -9190,7 +9188,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow intent='pollaczek-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='pollaczek-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup P n (λ"
       urls: 
        - "https://mathworld.wolfram.com/PollaczekPolynomial.html"
@@ -9243,7 +9241,7 @@ concepts:
       property: mover
       area: "harmonic analysis"
       comments:
-       - "<math><mrow intent='pontrjagin-dual($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='pontrjagin-dual($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ^"
       urls: 
        - "https://ncatlab.org/nlab/show/Pontrjagin+dual"
@@ -9291,7 +9289,7 @@ concepts:
       property: fenced
       area: "formal languages"
       comments:
-       - "<math><mrow intent='post-canonical-system($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='post-canonical-system($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow (A,I,R"
       urls: 
        - "https://en.wikipedia.org/wiki/Post_canonical_system"
@@ -9421,7 +9419,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='product-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='product-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∏"
       urls: 
        - "https://en.wikipedia.org/wiki/Continuous_product"
@@ -9509,7 +9507,7 @@ concepts:
       property: mixfix
       area: "group theory"
       comments:
-       - "<math><mrow intent='prufer-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='prufer-group($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow Z ( msup $1 ∞ /msup"
       urls: 
        - "https://en.wikipedia.org/wiki/Pr%C3%BCfer_group"
@@ -9593,7 +9591,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='q-binomial-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='q-binomial-coefficient($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow [ stacked mfrac ] q"
       urls: 
        - "https://mathworld.wolfram.com/q-BinomialCoefficient.html"
@@ -9618,7 +9616,7 @@ concepts:
       property: mixfix
       area: "complex manifolds"
       comments:
-       - "<math><mrow intent='quadratic-differential($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='quadratic-differential($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow d $1 ⊗ d $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_differential"
@@ -9831,7 +9829,7 @@ concepts:
       property: msup
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='real-bipolar($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='real-bipolar($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 r r"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
@@ -9858,7 +9856,7 @@ concepts:
       property: prescript
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='real-prepolar($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='real-prepolar($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup <mrow/> r /msup $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
@@ -10096,7 +10094,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='riemann-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='riemann-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/RiemannIntegral.html"
@@ -10174,7 +10172,7 @@ concepts:
       property: indexed
       area: "measure theory"
       comments:
-       - "<math><mrow intent='riemann-stieltje-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='riemann-stieltje-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-StieltjesIntegral.html"
@@ -10304,7 +10302,7 @@ concepts:
       property: msub
       area: "means"
       comments:
-       - "<math><mrow intent='root-mean-square($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='root-mean-square($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub $1 RMS"
       urls: 
        - "https://mathworld.wolfram.com/Root-Mean-Square.html"
@@ -10372,7 +10370,7 @@ concepts:
       property: embellished symbol
       area: "probability theory"
       comments:
-       - "<math><mrow intent='sample-variance($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sample-variance($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub m 2"
       notationc: "msup s 2"
       notationb: "msubsup s $1 2"
@@ -10400,7 +10398,7 @@ concepts:
       property: mover
       area: "special functions"
       comments:
-       - "<math><mrow intent='scaled-riemann-theta-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='scaled-riemann-theta-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover θ⁡ ^"
       urls: 
        - "https://dlmf.nist.gov/21.2#i"
@@ -10412,7 +10410,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='schlaefli-symbol($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='schlaefli-symbol($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow { $1 , ..., $n }"
       urls: 
        - "https://en.wikipedia.org/wiki/Schl%C3%A4fli_symbol"
@@ -10476,7 +10474,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow intent='second-carmichael-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='second-carmichael-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup λ '"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
@@ -10522,7 +10520,7 @@ concepts:
       property: fenced
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='seminorm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='seminorm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ‖ $1 ‖"
       notationa: "mo | $1"
       urls: 
@@ -10562,7 +10560,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='shift-operator($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='shift-operator($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup T t"
       urls: 
        - "https://mathworld.wolfram.com/ShiftOperator.html"
@@ -10675,7 +10673,7 @@ concepts:
       property: "indexed symbol"
       area: "geometry"
       comments:
-       - "<math><mrow intent='simplex($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='simplex($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup Δ $1"
       urls: 
        - "https://mathworld.wolfram.com/Simplex.html"
@@ -10896,7 +10894,7 @@ concepts:
       property: mover
       area: "algebra"
       comments:
-       - "<math><mrow intent='spectrum-of-algebra($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='spectrum-of-algebra($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ˆ"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_C*-algebra"
@@ -11023,7 +11021,7 @@ concepts:
       property: "indexed symbol"
       area: "multilinear algebra"
       comments:
-       - "<math><mrow intent='standard-flattening($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='standard-flattening($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub 𝒜 ($1"
       urls: 
        - "https://en.wikipedia.org/wiki/Matricization"
@@ -11351,7 +11349,7 @@ concepts:
       property: indexed
       area: "limits"
       comments:
-       - "<math><mrow intent='supremum-limit($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='supremum-limit($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi lim sup"
       notationa: "mover lim ¯"
       urls: 
@@ -11371,7 +11369,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='surface-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='surface-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∫"
       urls: 
        - "https://mathworld.wolfram.com/SurfaceIntegral.html"
@@ -11719,7 +11717,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='toroidal-coordinate($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='toroidal-coordinate($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( σ , τ , ϕ"
       urls: 
        - "https://mathworld.wolfram.com/ToroidalCoordinates.html"
@@ -11920,7 +11918,7 @@ concepts:
       property: "indexed symbol"
       area: "topology"
       comments:
-       - "<math><mrow intent='triple-torus($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='triple-torus($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup 𝕋 3"
       urls: 
        - "https://mathworld.wolfram.com/TripleTorus.html"
@@ -12069,7 +12067,7 @@ concepts:
       property: infix, indexed, postfix
       area: "convergence"
       comments:
-       - "<math><mrow intent='uniformly-convergent($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='uniformly-convergent($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⇉"
       notationc: "mover ⟶ unif."
       notationb: "mo unif lim"
@@ -12094,7 +12092,7 @@ concepts:
       property: mover
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='unit-vector($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='unit-vector($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover $1 ^"
       urls: 
        - "https://mathworld.wolfram.com/UnitVector.html"
@@ -12162,7 +12160,7 @@ concepts:
       property: prefix
       area: "logic"
       comments:
-       - "<math><mrow intent='unique-existential($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='unique-existential($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∃ !"
       notationa: "msub ∃ mrow =1 /mrow"
       urls: 
@@ -12210,7 +12208,7 @@ concepts:
       property: indexed
       area: "real analysis"
       comments:
-       - "<math><mrow intent='upper-darboux-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='upper-darboux-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mover ¯"
       urls: 
        - "https://en.wikipedia.org/wiki/Darboux_integral"
@@ -12222,7 +12220,7 @@ concepts:
       property: decorated function
       area: "analysis"
       comments:
-       - "<math><mrow intent='upper-dini-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='upper-dini-derivative($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup $1 + '"
       urls: 
        - "https://mathworld.wolfram.com/DiniDerivative.html"
@@ -12248,7 +12246,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='upper-shadow($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='upper-shadow($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup 𝜕 +"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
@@ -12330,7 +12328,7 @@ concepts:
       property: 
       area: 
       comments:
-       - "<math><mrow intent='vertical($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='vertical($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: 
       urls: 
        - "https://mathworld.wolfram.com/Vertical.html"
@@ -12354,7 +12352,7 @@ concepts:
       property: indexed
       area: "calculus"
       comments:
-       - "<math><mrow intent='volterra-integral($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='volterra-integral($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo Π"
       urls: 
        - "https://en.wikipedia.org/wiki/Product_integral"
@@ -12445,7 +12443,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow intent='weber-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='weber-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub E ν"
       urls: 
        - "https://mathworld.wolfram.com/WeberFunctions.html"
@@ -12802,7 +12800,7 @@ concepts:
       property: mtable
       area: "chemistry"
       comments:
-       - "<math><mrow intent='z-matrix-molecule($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='z-matrix-molecule($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(chemistry)"
@@ -12826,7 +12824,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow intent='zernike-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='zernike-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup Z"
       urls: 
        - "https://mathworld.wolfram.com/ZernikePolynomial.html"
@@ -12860,7 +12858,7 @@ concepts:
       property: "indexed symbol"
       area: "category theory"
       comments:
-       - "<math><mrow intent='zero-morphism($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='zero-morphism($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mn 0 mrow X,Y"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_morphism"
@@ -12921,4 +12919,3 @@ concepts:
        - "<math><mrow intent='zig-zag-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
- 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12551,9 +12551,20 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow intent='whittaker-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub M mrow $1, $2 /mrow"
-      notationa: "msub W mrow $1, $2 /mrow"
+       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi></mrow></mrow></math>"
+      urls: 
+       - "https://mathworld.wolfram.com/WhittakerFunction.html"
+       - "https://en.wikipedia.org/wiki/Whittaker_function"
+       - "https://dlmf.nist.gov/13#PT3"
+       - "https://www.encyclopediaofmath.org/index.php/Whittaker_functions"
+
+    - concept: whittaker-function
+      arity: 3
+      en: whittaker function $1 $2 of $3
+      property: "indexed function"
+      area: "special functions"
+      comments:
+       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12551,8 +12551,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi></mrow></mrow></math>"
-       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi></mrow></mrow></math>"
+       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"
@@ -12565,8 +12565,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi></mrow></mrow></math>"
-       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi></mrow></mrow></math>"
+       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10380,7 +10380,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='schlaefli-symbol($a1,$a2,$a3)'><mo>{</mo><mi arg='a1'>p</mi><mo>,</mo><mi arg='a2'>r</mi><mo>,</mo><mi arg='a3'>r</mi><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='schlaefli-symbol($a1,$a2,$a3)'><mo>{</mo><mi arg='a1'>p</mi><mo>,</mo><mi arg='a2'>q</mi><mo>,</mo><mi arg='a3'>r</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Schl%C3%A4fli_symbol"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1550,7 +1550,7 @@ concepts:
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:
-       - "<math><mrow intent='christoffel-symbol-of-first-kind($a1,$a2,$a3)'><msub><mi>&Gamma;</mi><mrow><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></mrow></math>"
+       - "<math><mrow intent='christoffel-symbol-of-first-kind($a1,$a2,$a3)'><msub><mi>&#x0393;</mi><mrow><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -1563,7 +1563,7 @@ concepts:
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:
-       - "<math><mmultiscripts intent='christoffel-symbol-of-second-kind($a1,$a2,$a3)'><mi>&Gamma;</mi><mrow/><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mrow/><mi arg='a2'>j</mi><mrow/></mmultiscripts></math>"
+       - "<math><mmultiscripts intent='christoffel-symbol-of-second-kind($a1,$a2,$a3)'><mi>&#x0393;</mi><mrow/><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mrow/><mi arg='a2'>j</mi><mrow/></mmultiscripts></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -4330,7 +4330,7 @@ concepts:
       property: operator
       area: "numerical analysis"
       comments:
-       - "<math><mrow intent='forward-difference($a1,$a2,$a3)'><msubsup><mi>&Delta;</mi><mi arg='a2'>x</mi><mi arg='a1'>n</mi></msubsup><mrow><mi arg='a3'>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='forward-difference($a1,$a2,$a3)'><msubsup><mi>&#x0394;</mi><mi arg='a2'>x</mi><mi arg='a1'>n</mi></msubsup><mrow><mi arg='a3'>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ForwardDifference.html)"
        - "https://dlmf.nist.gov/18.1#EGx1"
@@ -5226,7 +5226,7 @@ concepts:
        - "<math><mrow intent='hamiltonian($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationc: "mover H ˇ"
       notationb: "mover H ^"
-      notationa: "mrow < H >"
+      notationa: "mrow &lt; H &gt;"
       urls: 
        - "https://en.wikipedia.org/wiki/Hamiltonian_(quantum_mechanics)"
        - "https://en.wikipedia.org/wiki/Hamiltonian_vector_field"
@@ -5934,7 +5934,7 @@ concepts:
       area: "order theory"
       comments:
        - "<math><mrow intent='incomparability($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "menclose notation='updiagonalstrike' munderover = > <"
+      notation: "menclose notation='updiagonalstrike' munderover = &gt; &lt;"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
       alias:
@@ -10253,7 +10253,7 @@ concepts:
       property: mixfix
       area: "category theory"
       comments:
-       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi arg='a3'>Z</mi></mrow></math>"
+       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>←</mo><mi arg='a2'>Y</mi><mo>→</mo><mi arg='a3'>Z</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
@@ -10362,7 +10362,7 @@ concepts:
       property: mixfix, fenced
       area: "vector algebra"
       comments:
-       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mi arg='a1'>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi arg='a2'>B</mi><mo>&middot;</mo><mi arg='a3'>C</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mi arg='a1'>A</mi><mo>·</mo><mrow><mo>(</mo><mi arg='a2'>B</mi><mo>·</mo><mi arg='a3'>C</mi><mo>)</mo></mrow></mrow></math>"
        - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>,</mo><mi arg='a3'>C</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ScalarTripleProduct.html"
@@ -10486,7 +10486,7 @@ concepts:
       property: "indexed function"
       area: "relational algebra"
       comments:
-       - "<math><msub intent='selection($a1,$a2,$a3)'><mi>&sigma;</mi><mrow><mi arg='a1'>a</mi><mi arg='a2'>&theta;</mi><mi arg='a3'>b</mi></mrow></msub></math>"
+       - "<math><msub intent='selection($a1,$a2,$a3)'><mi>&#x03c3;</mi><mrow><mi arg='a1'>a</mi><mi arg='a2'>&#x03b8;</mi><mi arg='a3'>b</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Selection_(relational_algebra)"
     
@@ -10563,7 +10563,7 @@ concepts:
       property: mixfix
       area: "group theory"
       comments:
-       - "<math><mrow intent='short-exact-sequence($a1,$a2,$a3)'><mn>0</mn><mo>&rightarrow;</mo><mi arg='a1'>X</mi><mo>&rightarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi arg='a3'>Z</mi><mo>&rightarrow;</mo><mn>0</mn></mrow></math>"
+       - "<math><mrow intent='short-exact-sequence($a1,$a2,$a3)'><mn>0</mn><mo>→</mo><mi arg='a1'>X</mi><mo>→</mo><mi arg='a2'>Y</mi><mo>→</mo><mi arg='a3'>Z</mi><mo>→</mo><mn>0</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShortExactSequence.html"
        - "https://en.wikipedia.org/wiki/Exact_sequence"
@@ -10948,7 +10948,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='square($a1,$a2,$a3,$a4)'><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></mrow></math>"
+       - "<math><mrow intent='square($a1,$a2,$a3,$a4)'><mo>□</mo><mrow><mi arg='a1'>A</mi><mo>&#x2009;</mo><mi arg='a2'>B</mi><mo>&#x2009;</mo><mi arg='a3'>C</mi><mo>&#x2009;</mo><mi arg='a4'>D</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Square.html"
        - "https://en.wikipedia.org/wiki/Square"
@@ -11805,7 +11805,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='triangle($a1,$a2,$a3)'><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi></mrow></mrow></math>"
+       - "<math><mrow intent='triangle($a1,$a2,$a3)'><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&#x2009;</mo><mi arg='a2'>B</mi><mo>&#x2009;</mo><mi arg='a3'>C</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Triangle.html"
        - "https://en.wikipedia.org/wiki/Triangle"
@@ -12601,7 +12601,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi arg='a1'>&delta;</mi></msub><mrow><mo>(</mo><mi arg='a2'>t</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi arg='a1'>&#x03b4;</mi></msub><mrow><mo>(</mo><mi arg='a2'>t</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerSausage.html"
        - "https://en.wikipedia.org/wiki/Wiener_sausage"
@@ -12899,3 +12899,4 @@ concepts:
        - "<math><mrow intent='zig-zag-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
+

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2146,8 +2146,7 @@ concepts:
       property: mtable
       area: "statistics"
       comments:
-       - "<math><mrow intent='contingency-table($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
+       - "<math><mrow intent='contingency-table($a1)'><mtable arg='a1'><mtr><mtd><mtext>...</mtext></mtd></mtr><mtr><mtd><mtext>...</mtext></mtd></mtr></mtable></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ContingencyTable.html"
        - "https://en.wikipedia.org/wiki/Contingency_table"
@@ -6990,12 +6989,12 @@ concepts:
     
     - concept: latin-rectangle
       arity: 1
-      en: latin rectangle of $1
+      en: latin rectangle $1
       property: mtable
       area: "combinatorial mathematics"
       comments:
-       - "<math><mrow intent='latin-rectangle($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
+       - "<math><mrow intent='latin-rectangle($a1)'><mtable arg='a1'><mtr><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>4</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>3</mn></mtd><mtd><mn>2</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable></mrow></math>"
+
       urls: 
        - "https://mathworld.wolfram.com/LatinRectangle.html"
        - "https://en.wikipedia.org/wiki/Latin_rectangle"
@@ -7003,12 +7002,11 @@ concepts:
     
     - concept: latin-square
       arity: 1
-      en: latin square of $1
+      en: latin square $1
       property: mtable
       area: "combinatorial mathematics"
       comments:
-       - "<math><mrow intent='latin-square($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
+       - "<math><mrow intent='latin-square($a1)'><mtable arg='a1'><mtr><mtd><mi>A</mi></mtd><mtd><mi>B</mi></mtd><mtd><mi>C</mi></mtd></mtr><mtr><mtd><mi>C</mi></mtd><mtd><mi>A</mi></mtd><mtd><mi>B</mi></mtd></mtr><mtr><mtd><mi>B</mi></mtd><mtd><mi>C</mi></mtd><mtd><mi>A</mi></mtd></mtr></mtable></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LatinSquare.html"
        - "https://en.wikipedia.org/wiki/Latin_square"
@@ -7680,10 +7678,8 @@ concepts:
       property: mtable, fenced
       area: "algebra"
       comments:
-       - "<math><mrow intent='matrix($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
-      notationb: "<math><mrow intent='matrix($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
-      notationa: "mrow ( $1"
+       - "<math><mrow intent='matrix($a1)'><mo>(</mo><mtable arg='a1'><mtr><mtd><mtext>...</mtext></mtd></mtr><mtr><mtd><mtext>...</mtext></mtd></mtr></mtable><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='matrix($a1)'><mo>[</mo><mtable arg='a1'><mtr><mtd><mtext>...</mtext></mtd></mtr><mtr><mtd><mtext>...</mtext></mtd></mtr></mtable><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Matrix.html"
        - "https://mathworld.wolfram.com/SquareBracket.html"
@@ -12766,8 +12762,7 @@ concepts:
       property: mtable
       area: "chemistry"
       comments:
-       - "<math><mrow intent='z-matrix-molecule($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mtable"
+       - "<math><mrow intent='z-matrix-molecule($a1)'><mtable arg='a1'><mtr><mtd><mtext>...</mtext></mtd></mtr><mtr><mtd><mtext>...</mtext></mtd></mtr></mtable></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(chemistry)"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -584,7 +584,7 @@ concepts:
     
     - concept: associated-legendre-polynomial
       arity: 2
-      en: associated legendre polynomial of degree $1 and order $m
+      en: associated legendre polynomial of degree $1 and order $2
       property: function
       area: "special functions"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10,7 +10,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>Ab</mi></math>"
+       - "<math><mi intent='abelian-category'>Ab</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AbelianCategory.html"
        - "https://en.wikipedia.org/wiki/Abelian_category"
@@ -34,7 +34,7 @@ concepts:
       property: prefix
       area: "number theory"
       comments:
-       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='abundance($a1)'><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Abundance.html"
     
@@ -54,7 +54,7 @@ concepts:
       property: function
       area: "computability theory"
       comments:
-       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='ackermann-function($a1)'><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ackermann_function"
        - "https://www.encyclopediaofmath.org/index.php/Ackermann_function"
@@ -90,7 +90,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-       - "<math><mi>μ</mi></math>"
+       - "<math><mi intent='adiabatic-invariant-first'>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -102,7 +102,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-       - "<math><mi>J</mi></math>"
+       - "<math><mi intent='adiabatic-invariant-second'>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -114,7 +114,7 @@ concepts:
       property: symbol
       area: "plasma physics"
       comments:
-       - "<math><mi>Φ</mi></math>"
+       - "<math><mi intent='adiabatic-invariant-third'>Φ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdiabaticInvariant.html"
        - "https://en.wikipedia.org/wiki/Adiabatic_invariant"
@@ -152,7 +152,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-       - "<math><mrow><mi>Ad</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='adjoint-representation($a1)'><mi>Ad</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AdjointRepresentation.html"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -164,7 +164,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>adj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='adjugate($a1)'><mi>adj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjugate_matrix"
     
@@ -174,7 +174,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Aff</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='affine-group($a1)'><mi>Aff</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineGroup.html"
        - "https://en.wikipedia.org/wiki/Affine_group"
@@ -186,7 +186,7 @@ concepts:
       property: function
       area: "affine geometry"
       comments:
-       - "<math><mrow><mi>aff</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='affine-hull($a1)'><mi>aff</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AffineHull.html"
        - "https://en.wikipedia.org/wiki/Affine_hull"
@@ -198,7 +198,7 @@ concepts:
       property: symbol
       area: "universal algebra?"
       comments:
-       - "<math><mi>𝔸</mi></math>"
+       - "<math><mi intent='affine-line'>𝔸</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/affine+line"
     
@@ -239,7 +239,7 @@ concepts:
       property: symbol
       area: "set theory"
       comments:
-       - "<math><mi>ℵ</mi></math>"
+       - "<math><mi intent='aleph'>ℵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Aleph.html"
        - "https://ncatlab.org/nlab/show/aleph"
@@ -251,7 +251,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>𝔸</mi></math>"
+       - "<math><mi intent='algebraics'>𝔸</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Algebraics.html"
     
@@ -282,7 +282,7 @@ concepts:
       property: function
       area: "functions"
       comments:
-       - "<math><mrow><mi>af</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='alternating-factorial($a1)'><mi>af</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Alternating_factorial"
     
@@ -361,7 +361,7 @@ concepts:
       property: symbol
       area: "topology"
       comments:
-       - "<math><msup><mi>C</mi><mi>w</mi></msup></math>"
+       - "<math><msup intent='analytic-manifold'><mi>C</mi><mi>w</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Analytic_manifold"
        - "https://ncatlab.org/nlab/show/analytic+manifold"
@@ -373,7 +373,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='anger-function($a1)'><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngerFunction.html"
        - "https://en.wikipedia.org/wiki/Anger_function"
@@ -386,7 +386,7 @@ concepts:
       property: function
       area: "hyperbolic geometry"
       comments:
-       - "<math><mrow><mi>Π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='angle-of-parallelism($a1)'><mi>Π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngleofParallelism.html"
        - "https://en.wikipedia.org/wiki/Angle_of_parallelism"
@@ -397,7 +397,7 @@ concepts:
       property: symbol
       area: "classical mechanics"
       comments:
-       - "<math><mi>L</mi></math>"
+       - "<math><mi intent='angular-momentum'>L</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Angular_momentum"
        - "https://en.wikipedia.org/wiki/Introduction_to_angular_momentum"
@@ -409,7 +409,7 @@ concepts:
       property: symbol
       area: "classical mechanics"
       comments:
-       - "<math><mi>ω</mi></math>"
+       - "<math><mi intent='angular-velocity'>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/AngularVelocity.html"
        - "https://en.wikipedia.org/wiki/Angular_velocity"
@@ -433,7 +433,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-       - "<math><mrow><mi>Ann</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='annihilator($a1)'><mi>Ann</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Annihilator.html"
        - "https://en.wikipedia.org/wiki/Annihilator_(ring_theory)"
@@ -445,7 +445,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow><mi>ann</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='annulus($a1)'><mi>ann</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Annulus_(mathematics)"
        - "https://ncatlab.org/nlab/show/annulus"
@@ -469,7 +469,7 @@ concepts:
       property: infix
       area: "constructive mathematics"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>#</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='apartness-relation($a1,$a2)'><mi arg='a1'>X</mi><mo>#</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Apartness_relation"
        - "https://ncatlab.org/nlab/show/apartness+relation"
@@ -480,7 +480,7 @@ concepts:
       property: symbol
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mn>3</mn><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='apery-constant'><mi>ζ</mi><mrow><mo>(</mo><mn>3</mn><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AperysConstant.html"
        - "https://en.wikipedia.org/wiki/Zeta(3)"
@@ -526,7 +526,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mi>A</mi></math>"
+       - "<math><mi intent='area'>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Area.html"
        - "https://en.wikipedia.org/wiki/Area"
@@ -538,7 +538,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-       - "<math><mrow><mi>Arf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='arf-invariant($a1)'><mi>Arf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ArfInvariant.html"
        - "https://en.wikipedia.org/wiki/Arf_invariant"
@@ -550,7 +550,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow><mi>Arg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='argument($a1)'><mi>Arg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Argument_(complex_analysis)"
     
@@ -598,7 +598,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Aut</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='automorphism-group($a1)'><mi>Aut</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Automorphism"
@@ -609,7 +609,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow><mi>∇</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='backward-difference($a1)'><mi>∇</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BackwardDifference.html"
        - "https://en.wikipedia.org/wiki/Finite_difference"
@@ -621,8 +621,8 @@ concepts:
       property: symbol
       area: "set theory"
       comments:
-       - "<math><msup><mi>N</mi><mi>N</mi></msup></math>"
-       - "<math><msup><mi>ω</mi><mi>ω</mi></msup></math>"
+       - "<math><msup intent='baire-space'><mi>N</mi><mi>N</mi></msup></math>"
+       - "<math><msup intent='baire-space'><mi>ω</mi><mi>ω</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/BaireSpace.html"
        - "https://en.wikipedia.org/wiki/Baire_space"
@@ -679,7 +679,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>𝓑</mi><mi>r</mi></msub></math>"
+       - "<math><msub intent='beatty-sequence($a1)'><mi>𝓑</mi><mi arg='a1'>r</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BeattySequence.html"
        - "https://en.wikipedia.org/wiki/Beatty_sequence"
@@ -690,7 +690,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>B</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='bell-number($a1)'><mi>B</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BellNumber.html"
        - "https://en.wikipedia.org/wiki/Bell_number"
@@ -737,7 +737,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>B</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='bernoulli-number($a1)'><mi>B</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BernoulliNumber.html"
        - "https://en.wikipedia.org/wiki/Bernoulli_number"
@@ -837,7 +837,7 @@ concepts:
       property: "indexed symbol"
       area: "graph theory"
       comments:
-       - "<math><msub><mi>b</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='betti-number($a1)'><mi>b</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BettiNumber.html"
        - "https://en.wikipedia.org/wiki/Betti_number"
@@ -897,7 +897,7 @@ concepts:
       property: symbol
       area: "coding theory"
       comments:
-       - "<math><msub><mi>G</mi><mn>23</mn></msub></math>"
+       - "<math><msub intent='binary-golay-code'><mi>G</mi><mn>23</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BinaryGolayCode.html"
        - "https://ncatlab.org/nlab/show/binary+Golay+code"
@@ -947,7 +947,7 @@ concepts:
       property: msup
       area: "functional analysis"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>°°</mo></msup></math>"
+       - "<math><msup intent='bipolar-set($a1)'><mi arg='a1'>X</mi><mo>°°</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -959,7 +959,7 @@ concepts:
       property: mtable
       area: "ring theory"
       comments:
-       - "<math><mrow><mo>(</mo><mtable rowspacing='4pt' columnspacing='1em'><mtr><mtd><mi>u</mi><mo>+</mo><mi>h</mi><mi>v</mi></mtd><mtd><mi>w</mi><mo>+</mo><mi>h</mi><mi arg='a1'>x</mi></mtd></mtr><mtr><mtd><mo>−</mo><mi>w</mi><mo>+</mo><mi>h</mi><mi arg='a1'>x</mi></mtd><mtd><mi>u</mi><mo>−</mo><mi>h</mi><mi>v</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='biquaternion($a1)'><mo>(</mo><mtable rowspacing='4pt' columnspacing='1em'><mtr><mtd><mi>u</mi><mo>+</mo><mi>h</mi><mi>v</mi></mtd><mtd><mi>w</mi><mo>+</mo><mi>h</mi><mi arg='a1'>x</mi></mtd></mtr><mtr><mtd><mo>−</mo><mi>w</mi><mo>+</mo><mi>h</mi><mi arg='a1'>x</mi></mtd><mtd><mi>u</mi><mo>−</mo><mi>h</mi><mi>v</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Biquaternion#Linear_representation"
     
@@ -969,7 +969,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='blaschke-product($a1)'><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlaschkeProduct.html"
        - "https://en.wikipedia.org/wiki/Blaschke_product"
@@ -981,7 +981,7 @@ concepts:
       property: symbol
       area: "complex analysis"
       comments:
-       - "<math><mi>B</mi></math>"
+       - "<math><mi intent='bloch-constant'>B</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/BlochConstant.html"
        - "https://www.encyclopediaofmath.org/index.php/Bloch_constant"
@@ -992,7 +992,7 @@ concepts:
       property: symbol
       area: "abstract algebra"
       comments:
-       - "<math><mi>𝔹</mi></math>"
+       - "<math><mi intent='boolean-domain'>𝔹</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Boolean_domain"
        - "https://ncatlab.org/nlab/show/boolean+domain"
@@ -1003,7 +1003,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>⊥</mi></math>"
+       - "<math><mi intent='bottom-type'>⊥</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/bottom"
        - "https://en.wikipedia.org/wiki/Bottom_type"
@@ -1017,7 +1017,7 @@ concepts:
       property: symbol
       area: "order theory"
       comments:
-       - "<math><mi>⊥</mi></math>"
+       - "<math><mi intent='bottom-element'>⊥</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Greatest_element_and_least_element"
       alias:
@@ -1047,7 +1047,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mrow><mi>BV</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='bounded-variation($a1)'><mi>BV</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BoundedVariation.html"
        - "https://en.wikipedia.org/wiki/Bounded_variation"
@@ -1058,7 +1058,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>☐</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='box-product($a1,$a2)'><mi arg='a1'>X</mi><mo>☐</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cartesian_product_of_graphs"
       alias:
@@ -1070,7 +1070,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Br</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='brauer-group($a1)'><mi>Br</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrauerGroup.html"
        - "https://en.wikipedia.org/wiki/Brauer_group"
@@ -1083,7 +1083,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><msub><mi>B</mi><mn>4</mn></msub></math>"
+       - "<math><msub intent='brun-constant'><mi>B</mi><mn>4</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/BrunsConstant.html"
        - "https://en.wikipedia.org/wiki/Brun%27s_theorem"
@@ -1094,7 +1094,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='burnside-group($a1)'><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Burnside_group"
     
@@ -1104,7 +1104,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>C</mi></math>"
+       - "<math><mi intent='cahen-constant'>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CahensConstant.html"
        - "https://en.wikipedia.org/wiki/Cahen%27s_constant"
@@ -1124,7 +1124,7 @@ concepts:
       property: fenced
       area: "quantum mechanics"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='canonical-commutation-relation($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Canonical_commutation_relation"
     
@@ -1134,7 +1134,7 @@ concepts:
       property: infix
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⌣</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cap-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⌣</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cap_product"
        - "https://ncatlab.org/nlab/show/cap+product"
@@ -1160,7 +1160,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='carmichael-function($a1)'><mi>λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
        - "https://en.wikipedia.org/wiki/Carmichael_function"
@@ -1171,7 +1171,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cartesian-product($a1,$a2)'><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CartesianProduct.html"
        - "https://en.wikipedia.org/wiki/Cartesian_product"
@@ -1185,7 +1185,7 @@ concepts:
       property: symbol
       area: "lie algebra"
       comments:
-       - "<math><mi>Ω</mi></math>"
+       - "<math><mi intent='casimir-element'>Ω</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Casimir_element"
     
@@ -1195,7 +1195,7 @@ concepts:
       property: symbol
       area: "combinatorics"
       comments:
-       - "<math><mi>G</mi></math>"
+       - "<math><mi intent='catalan-constant'>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CatalansConstant.html"
        - "https://en.wikipedia.org/wiki/Catalan%27s_constant"
@@ -1207,7 +1207,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-       - "<math><msub><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='catalan-number($a1)'><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CatalanNumber.html"
        - "https://en.wikipedia.org/wiki/Catalan_number"
@@ -1219,7 +1219,7 @@ concepts:
       property: symbol
       area: "universal algebra"
       comments:
-       - "<math><mi>AlgCat</mi></math>"
+       - "<math><mi intent='category-of-algebraic-lattices'>AlgCat</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/algebraic+lattice"
     
@@ -1229,7 +1229,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>Set</mi></math>"
+       - "<math><mi intent='category-of-sets'>Set</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Category_of_sets"
        - "https://www.encyclopediaofmath.org/index.php/Category_of_a_set"
@@ -1241,7 +1241,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>Cat</mi></math>"
+       - "<math><mi intent='category-of-small-categories'>Cat</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Category_of_small_categories"
     
@@ -1264,7 +1264,7 @@ concepts:
       property: infix
       area: "analysis"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cauchy-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CauchyProduct.html"
        - "https://en.wikipedia.org/wiki/Cauchy_product"
@@ -1275,7 +1275,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>Ca</mi></math>"
+       - "<math><mi intent='cavitation-number'>Ca</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)#Cavitation_number"
     
@@ -1311,7 +1311,7 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='center($a1)'><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(group_theory)"
        - "https://en.wikipedia.org/wiki/Center_(algebra)"
@@ -1325,7 +1325,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><msub><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='centralizer($a1)'><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Centralizer.html"
        - "https://en.wikipedia.org/wiki/Centralizer_and_normalizer"
@@ -1348,8 +1348,8 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mi>C</mi></math>"
-       - "<math><msup><mi>C</mi><mn>10</mn></msup></math>"
+       - "<math><mi intent='champernowne-constant'>C</mi></math>"
+       - "<math><msup intent='champernowne-constant'><mi>C</mi><mn>10</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChampernowneConstant.html"
        - "https://en.wikipedia.org/wiki/Champernowne_constant"
@@ -1360,7 +1360,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='character($a1)'><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Character.html"
        - "https://en.wikipedia.org/wiki/Character_(mathematics)"
@@ -1375,7 +1375,7 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-       - "<math><mrow><mi>char</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='characteristic($a1)'><mi>char</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Characteristic.html"
        - "https://en.wikipedia.org/wiki/Characteristic_(algebra)"
@@ -1388,7 +1388,7 @@ concepts:
       property: "indexed function, function"
       area: "probability theory"
       comments:
-       - "<math><msub><mi>𝟏</mi><mi arg='a1'>X</mi></msub></math>"
+       - "<math><msub intent='characteristic-function($a1)'><mi>𝟏</mi><mi arg='a1'>X</mi></msub></math>"
        - "<math><mn>1</mn><mrow><mo>{</mo><mi arg='a1'>X</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CharacteristicFunction.html"
@@ -1407,7 +1407,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>char</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='characteristic-subgroup($a1,$a2)'><mi arg='a1'>X</mi><mo>char</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Characteristic_subgroup"
        - "https://www.encyclopediaofmath.org/index.php/Characteristic_subgroup"
@@ -1418,7 +1418,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='charlier-polynomial($a1)'><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CharlierPolynomial.html"
        - "https://en.wikipedia.org/wiki/Charlier_polynomials"
@@ -1462,7 +1462,7 @@ concepts:
       property: function
       area: "Riemannian geometry"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cheeger-constant($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant"
     
@@ -1472,7 +1472,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cheeger-number($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cheeger_constant_(graph_theory)"
       alias:
@@ -1485,7 +1485,7 @@ concepts:
       property: infix
       area: "chemistry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⇌</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='chemical-equilibrium($a1,$a2)'><mi arg='a1'>X</mi><mo>⇌</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chemical_equilibrium"
       alias:
@@ -1497,7 +1497,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msup><mi>χ</mi><mn>2</mn></msup></math>"
+       - "<math><msup intent='chi-squared-distribution'><mi>χ</mi><mn>2</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Chi-SquaredDistribution.html"
        - "https://en.wikipedia.org/wiki/Chi-squared_distribution"
@@ -1509,7 +1509,7 @@ concepts:
       property: function
       area: "geometry"
       comments:
-       - "<math><mrow><mi>crd</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='chord($a1)'><mi>crd</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chord_(geometry)"
     
@@ -1545,9 +1545,9 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><msub><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>π</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>χ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='chromatic-polynomial($a1)'><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='chromatic-polynomial($a1)'><mi>π</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='chromatic-polynomial($a1)'><mi>χ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChromaticPolynomial.html"
        - "https://en.wikipedia.org/wiki/Chromatic_polynomial"
@@ -1571,7 +1571,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>Cl</mi><mn>2</mn></msub><mrow><mo>(</mo><mi arg='a1'>&#x03c6;</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='clausen-function($a1)'><msub><mi>Cl</mi><mn>2</mn></msub><mrow><mo>(</mo><mi arg='a1'>&#x03c6;</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clausen_function"
     
@@ -1594,7 +1594,7 @@ concepts:
       property: function
       area: "universal algebra"
       comments:
-       - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='clifford-algebra($a1)'><mi>Cl</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clifford_algebra"
     
@@ -1604,7 +1604,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-       - "<math><mi>C</mi></math>"
+       - "<math><mi intent='clique'>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Clique.html"
        - "https://en.wikipedia.org/wiki/Clique_(graph_theory)"
@@ -1616,7 +1616,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='clique-number($a1)'><mi>ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Clique_number"
     
@@ -1638,7 +1638,7 @@ concepts:
       property: fenced
       area: "calculus"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='closed-interval($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ClosedInterval.html"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p1.t1.r29"
@@ -1661,7 +1661,7 @@ concepts:
       comments:
        - "<math><mi>cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><mi>Cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mo>−</mo></msup></math>"
+       - "<math><msup intent='closure($a1)'><mi arg='a1'>X</mi><mo>−</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
        - "https://en.wikipedia.org/wiki/Congruence_closure"
@@ -1675,7 +1675,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>codim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='codimension($a1)'><mi>codim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Codimension.html"
        - "https://en.wikipedia.org/wiki/Codimension"
@@ -1688,7 +1688,7 @@ concepts:
       property: function
       area: "order theory"
       comments:
-       - "<math><mrow><mi>cf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cofinality($a1)'><mi>cf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cofinality"
        - "https://ncatlab.org/nlab/show/cofinality"
@@ -1699,7 +1699,7 @@ concepts:
       property: symbol
       area: "order theory"
       comments:
-       - "<math><mi>F</mi></math>"
+       - "<math><mi intent='cofinite-filter'>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CofiniteFilter.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_filter"
@@ -1724,7 +1724,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi>coim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='coimage($a1)'><mi>coim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coimage"
        - "https://ncatlab.org/nlab/show/coimage"
@@ -1735,7 +1735,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><mrow><mi>coker</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cokernel($a1)'><mi>coker</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cokernel.html"
        - "https://en.wikipedia.org/wiki/Cokernel"
@@ -1758,7 +1758,7 @@ concepts:
       property: mixfix
       area: "category theory"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>↓</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='comma-category($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>↓</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Comma_category"
     
@@ -1781,7 +1781,7 @@ concepts:
       property: msup, fenced
       area: "abstract algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>'</mo></msup></math>"
+       - "<math><msup intent='commutator-subgroup($a1)'><mi arg='a1'>X</mi><mo>'</mo></msup></math>"
       notationb: "msup $1 (1)"
       notationa: "mrow [ $1, $1 ]"
       urls: 
@@ -1799,7 +1799,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><msub><mi>V</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='companion-lehmer-number($a1)'><mi>V</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerNumber.html"
        - "https://mathworld.wolfram.com/LehmersNumber.html"
@@ -1843,7 +1843,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-       - "<math><msub><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='complete-graph($a1)'><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CompleteGraph.html"
        - "https://en.wikipedia.org/wiki/Complete_graph"
@@ -1856,7 +1856,7 @@ concepts:
       property: msup
       area: "complex analysis"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='complex-conjugate($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
       notationa: "mover $1 ¯"
       urls: 
        - "https://mathworld.wolfram.com/ComplexConjugate.html"
@@ -1869,7 +1869,7 @@ concepts:
       property: symbol
       area: "projective geometry"
       comments:
-       - "<math><mi>ℂ⁢</mi><mi>ℙ</mi></math>"
+       - "<math><mi intent='complex-projective-space'>ℂ⁢</mi><mi>ℙ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ProjectiveSpace.html"
        - "https://en.wikipedia.org/wiki/Algebraic_geometry_of_projective_spaces"
@@ -1883,8 +1883,8 @@ concepts:
       property: msup
       area: "complex manifolds"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mi>ℂ</mi></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mi>C</mi></msup></math>"
+       - "<math><msup intent='complexification($a1)'><mi arg='a1'>X</mi><mi>ℂ</mi></msup></math>"
+       - "<math><msup intent='complexification($a1)'><mi arg='a1'>X</mi><mi>C</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complexification"
        - "https://ncatlab.org/nlab/show/complexification"
@@ -1898,7 +1898,7 @@ concepts:
       property: infix
       area: "algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='composition($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Composition.html"
        - "https://ncatlab.org/nlab/show/composition"
@@ -1924,7 +1924,7 @@ concepts:
       property: fenced
       area: "chemistry"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='concentration($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://chem.libretexts.org/Bookshelves/General_Chemistry/Map%3A_Chemistry_-_The_Central_Science_(Brown_et_al.)/04._Reactions_in_Aqueous_Solution/4.5%3A_Concentration_of_Solutions"
     
@@ -1934,7 +1934,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='condition-number($a1)'><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Condition_number"
        - "https://dlmf.nist.gov/3.2#SS5.p1"
@@ -1967,7 +1967,7 @@ concepts:
       property: function
       area: "algebraic number theory"
       comments:
-       - "<math><mrow><mi>𝔣⁢</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='conductor($a1)'><mi>𝔣⁢</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Conductor_(class_field_theory)"
     
@@ -1977,7 +1977,7 @@ concepts:
       property: infix
       area: "algebraic geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⌟</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='contraction-operator($a1,$a2)'><mi arg='a1'>X</mi><mo>⌟</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/abs/1104.1240"
     
@@ -2030,7 +2030,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Cl</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='conjugacy-class($a1)'><mi>Cl</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugacyClass.html"
        - "https://en.wikipedia.org/wiki/Conjugacy_class"
@@ -2042,8 +2042,8 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mi>H</mi></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='conjugate-transpose($a1)'><mi arg='a1'>X</mi><mi>H</mi></msup></math>"
+       - "<math><msup intent='conjugate-transpose($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConjugateTranspose.html"
        - "https://en.wikipedia.org/wiki/Conjugate_transpose"
@@ -2054,7 +2054,7 @@ concepts:
       property: infix
       area: "topology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>#</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='connected-sum($a1,$a2)'><mi arg='a1'>X</mi><mo>#</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConnectedSum.html"
        - "https://en.wikipedia.org/wiki/Connected_sum"
@@ -2066,7 +2066,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='connectivity($a1)'><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Connectivity.html"
        - "https://en.wikipedia.org/wiki/Connectivity_(graph_theory)"
@@ -2078,7 +2078,7 @@ concepts:
       property: constant
       area: "calculus"
       comments:
-       - "<math><mi>C</mi></math>"
+       - "<math><mi intent='constant-of-integration'>C</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConstantofIntegration.html"
        - "https://en.wikipedia.org/wiki/Constant_of_integration"
@@ -2089,7 +2089,7 @@ concepts:
       property: infix
       area: "computer science"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≤</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='containment($a1,$a2)'><mi arg='a1'>X</mi><mo>≤</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Encompassment_ordering"
        - "https://en.wikipedia.org/wiki/Subset"
@@ -2132,7 +2132,7 @@ concepts:
       property: constant
       area: "set theory"
       comments:
-       - "<math><mi>𝔠</mi></math>"
+       - "<math><mi intent='continuum'>𝔠</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Continuum.html"
        - "https://en.wikipedia.org/wiki/List_of_continuity-related_topics"
@@ -2172,7 +2172,7 @@ concepts:
       property: msup
       area: "relational algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>˘</mo></msup></math>"
+       - "<math><msup intent='converse($a1)'><mi arg='a1'>X</mi><mo>˘</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relation_algebra"
       alias:
@@ -2184,9 +2184,9 @@ concepts:
       property: msup
       area: "graph theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>'</mo></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mi>T</mi></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mi>R</mi></msup></math>"
+       - "<math><msup intent='converse-graph($a1)'><mi arg='a1'>X</mi><mo>'</mo></msup></math>"
+       - "<math><msup intent='converse-graph($a1)'><mi arg='a1'>X</mi><mi>T</mi></msup></math>"
+       - "<math><msup intent='converse-graph($a1)'><mi arg='a1'>X</mi><mi>R</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Transpose_graph"
       alias:
@@ -2199,7 +2199,7 @@ concepts:
       property: infix
       area: "functional analysis"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='convolution($a1,$a2)'><mi arg='a1'>X</mi><mo>∗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Convolution.html"
        - "https://en.wikipedia.org/wiki/List_of_convolutions_of_probability_distributions"
@@ -2214,10 +2214,10 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><msub><mi>Co</mi><mn>0</mn></msub></math>"
-       - "<math><msub><mi>Co</mi><mn>1</mn></msub></math>"
-       - "<math><msub><mi>Co</mi><mn>2</mn></msub></math>"
-       - "<math><msub><mi>Co</mi><mn>3</mn></msub></math>"
+       - "<math><msub intent='conway-group'><mi>Co</mi><mn>0</mn></msub></math>"
+       - "<math><msub intent='conway-group'><mi>Co</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='conway-group'><mi>Co</mi><mn>2</mn></msub></math>"
+       - "<math><msub intent='conway-group'><mi>Co</mi><mn>3</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ConwayGroups.html"
        - "https://en.wikipedia.org/wiki/Conway_group"
@@ -2231,7 +2231,7 @@ concepts:
       property: infix
       area: "number theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊥</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='coprime($a1,$a2)'><mi arg='a1'>X</mi><mo>⊥</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Coprime.html"
        - "https://en.wikipedia.org/wiki/Coprime_integers"
@@ -2258,7 +2258,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>corr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='correlation($a1)'><mi>corr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Correlation_and_dependence"
     
@@ -2268,7 +2268,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>η</mi></math>"
+       - "<math><mi intent='correlation-ratio'>η</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/CorrelationRatio.html"
        - "https://en.wikipedia.org/wiki/Correlation_ratio"
@@ -2280,7 +2280,7 @@ concepts:
       property: operator
       area: "special-functions"
       comments:
-       - "<math><mrow><mi>Ci</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='cosine-integral($a1)'><mi>Ci</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -2293,7 +2293,7 @@ concepts:
       property: symbol
       area: "gauge theory"
       comments:
-       - "<math><mi>g</mi></math>"
+       - "<math><mi intent='coupling-constant'>g</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coupling_constant"
       alias:
@@ -2306,7 +2306,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>cov</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='covariance($a1)'><mi>cov</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Covariance.html"
        - "https://en.wikipedia.org/wiki/Covariance_operator"
@@ -2320,7 +2320,7 @@ concepts:
       property: "indexed operator"
       area: "differential geometry"
       comments:
-       - "<math><msub><mi>∇</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='covariant-derivative($a1)'><mi>∇</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CovariantDerivative.html"
        - "https://en.wikipedia.org/wiki/Covariant_derivative"
@@ -2357,7 +2357,7 @@ concepts:
       property: infix
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cross-product($a1,$a2)'><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CrossProduct.html"
        - "https://en.wikipedia.org/wiki/Cross_product"
@@ -2385,7 +2385,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>Cr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='crossing-number($a1)'><mi>Cr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Crossing_number_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Crossing_number_(knot_theory)"
@@ -2397,7 +2397,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='cullen-number($a1)'><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CullenNumber.html"
        - "https://en.wikipedia.org/wiki/Cullen_number"
@@ -2408,7 +2408,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-       - "<math><msub><mi>κ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='cumulant($a1)'><mi>κ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cumulant.html"
        - "https://en.wikipedia.org/wiki/Cumulant"
@@ -2422,7 +2422,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-       - "<math><msub><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='cumulative-distribution-function($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CumulativeDistributionFunction.html"
        - "https://en.wikipedia.org/wiki/Cumulative_distribution_function"
@@ -2436,7 +2436,7 @@ concepts:
       property: infix
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⌣</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cup-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⌣</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cup_product"
        - "https://ncatlab.org/nlab/show/cup+product"
@@ -2462,7 +2462,7 @@ concepts:
       property: fenced
       area: "differential topology"
       notation: "mrow [[ $1 ]]"
-      notationa: "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+      notationa: "<math><mrow intent='current($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Current.html"
        - "https://en.wikipedia.org/wiki/Current_(mathematics)"
@@ -2474,7 +2474,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='curvature($a1)'><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Curvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"
@@ -2499,7 +2499,7 @@ concepts:
       property: symbol
       area: "genetics"
       comments:
-       - "<math><mi>cyc</mi></math>"
+       - "<math><mi intent='cycle-gene'>cyc</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cycle_(gene)"
     
@@ -2522,7 +2522,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>Φ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='cyclotomic-polynomial($a1)'><mi>Φ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/CyclotomicPolynomial.html"
        - "https://en.wikipedia.org/wiki/Cyclotomic_polynomial"
@@ -2549,7 +2549,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='davenport-constant($a1)'><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DavenportConstant.html"
        - "https://en.wikipedia.org/wiki/Davenport_constant"
@@ -2600,7 +2600,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dedekind-eta-function($a1)'><mi>η</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DedekindEtaFunction.html"
        - "https://en.wikipedia.org/wiki/Dedekind_eta_function"
@@ -2612,7 +2612,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dedekind-zeta-function($a1)'><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dedekind_zeta_function"
     
@@ -2665,7 +2665,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='degree-of-graph($a1)'><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
       alias:
@@ -2678,7 +2678,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>ν</mi></math>"
+       - "<math><mi intent='degree-of-freedom'>ν</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DegreeofFreedom.html"
        - "https://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)#Notation"
@@ -2689,7 +2689,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='degree-of-mapping($a1)'><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_continuous_mapping"
       alias:
@@ -2701,7 +2701,7 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mrow><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='degree-of-polynomial($a1)'><mi>deg</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Degree_of_a_polynomial"
       alias:
@@ -2713,7 +2713,7 @@ concepts:
       property: infix
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>◃</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='dependence-relation($a1,$a2)'><mi arg='a1'>X</mi><mo>◃</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dependence_relation"
     
@@ -2742,7 +2742,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='derived-category($a1)'><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derived_category"
        - "https://ncatlab.org/nlab/show/derived+category"
@@ -2754,7 +2754,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>Δ</mi></math>"
+       - "<math><mi intent='diagonal-functor'>Δ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_functor"
        - "https://ncatlab.org/nlab/show/diagonal+functor"
@@ -2765,7 +2765,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='diagonal-intersection($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_intersection"
     
@@ -2775,7 +2775,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>diag</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='diagonal-matrix($a1)'><mi>diag</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Diagonal_matrix"
     
@@ -2798,7 +2798,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dickman-function($a1)'><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DickmanFunction.html"
        - "https://en.wikipedia.org/wiki/Dickman_function"
@@ -2812,7 +2812,7 @@ concepts:
       property: function
       area: "algebraic number theory"
       comments:
-       - "<math><msub><mi>δ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='different-ideal($a1)'><mi>δ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Different_ideal"
       alias:
@@ -2824,7 +2824,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='differential-entropy($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialEntropy.html"
        - "https://en.wikipedia.org/wiki/Differential_entropy"
@@ -2857,9 +2857,9 @@ concepts:
       property: symbol
       area: "special functions"
       comments:
-       - "<math><msub><mi>ψ</mi><mn>0</mn></msub></math>"
-       - "<math><msup><mi>ψ</mi><mrow><mo>(</mo><mn>0</mn><mo>)</mo></mrow></msup></math>"
-       - "<math><mi>F</mi></math>"
+       - "<math><msub intent='digamma-function'><mi>ψ</mi><mn>0</mn></msub></math>"
+       - "<math><msup intent='digamma-function'><mi>ψ</mi><mrow><mo>(</mo><mn>0</mn><mo>)</mo></mrow></msup></math>"
+       - "<math><mi intent='digamma-function'>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DigammaFunction.html"
        - "https://en.wikipedia.org/wiki/Digamma_function"
@@ -2870,9 +2870,9 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><msub><mi>D</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Dih</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>D2</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>D</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>Dih</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='dihedral-group'><mi>D2</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/DihedralGroup.html"
        - "https://en.wikipedia.org/wiki/Dihedral_group"
@@ -2883,7 +2883,7 @@ concepts:
       property: infix
       area: "mathematical morphology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='dilation($a1,$a2)'><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dilation_(morphology)"
     
@@ -2909,7 +2909,7 @@ concepts:
       area: "linear algebra, graph theory"
       comments:
        - "<math><mi>dim</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='dimension($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
        - "https://en.wikipedia.org/wiki/Dimension_(mathematics_and_physics)"
@@ -2932,7 +2932,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirac-delta-function($a1)'><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracDeltaFunction.html"
        - "https://en.wikipedia.org/wiki/Dirac_delta_function"
@@ -2945,10 +2945,10 @@ concepts:
       property: constant
       area: "mathematical physics"
       comments:
-       - "<math><msup><mi>γ</mi><mn>0</mn></msup></math>"
-       - "<math><msup><mi>γ</mi><mn>1</mn></msup></math>"
-       - "<math><msup><mi>γ</mi><mn>2</mn></msup></math>"
-       - "<math><msup><mi>γ</mi><mn>3</mn></msup></math>"
+       - "<math><msup intent='dirac-matrix'><mi>γ</mi><mn>0</mn></msup></math>"
+       - "<math><msup intent='dirac-matrix'><mi>γ</mi><mn>1</mn></msup></math>"
+       - "<math><msup intent='dirac-matrix'><mi>γ</mi><mn>2</mn></msup></math>"
+       - "<math><msup intent='dirac-matrix'><mi>γ</mi><mn>3</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracMatrices.html"
        - "https://en.wikipedia.org/wiki/Gamma_matrices"
@@ -2962,7 +2962,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirac-measure($a1)'><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirac_measure"
     
@@ -2972,7 +2972,7 @@ concepts:
       property: function
       area: "differential operators"
       comments:
-       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirac-operator($a1)'><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DiracOperator.html"
        - "https://en.wikipedia.org/wiki/Dirac_operator"
@@ -2995,7 +2995,7 @@ concepts:
       property: infix
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='direct-product($a1,$a2)'><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectProduct.html"
        - "https://en.wikipedia.org/wiki/Direct_product"
@@ -3009,7 +3009,7 @@ concepts:
       property: infix
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='direct-sum($a1,$a2)'><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectSum.html"
        - "https://en.wikipedia.org/wiki/Direct_sum"
@@ -3026,9 +3026,9 @@ concepts:
       property: "function, mixfix"
       area: "differential calculus"
       comments:
-       - "<math><msup><mi>∇</mi><mi>v</mi></msup><mi>f</mi></math>"
-       - "<math><msup><mi>D</mi><mi>v</mi></msup><mi>f</mi></math>"
-       - "<math><mrow><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>∇</mi><mi>v</mi></msup><mi>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>D</mi><mi>v</mi></msup><mi>f</mi></math>"
+       - "<math><mrow intent='directional-derivative($a1)'><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectionalDerivative.html"
        - "https://en.wikipedia.org/wiki/Directional_derivative"
@@ -3040,7 +3040,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirichlet-character($a1)'><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletCharacter.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_character"
@@ -3053,7 +3053,7 @@ concepts:
       property: infix
       area: "number theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='dirichlet-convolution($a1,$a2)'><mi arg='a1'>X</mi><mo>∗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Dirichlet_convolution"
        - "https://www.encyclopediaofmath.org/index.php/Dirichlet_convolution"
@@ -3064,7 +3064,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>Dir</mi></math>"
+       - "<math><mi intent='dirichlet-distribution'>Dir</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletDistribution.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_distribution"
@@ -3076,7 +3076,7 @@ concepts:
       property: function
       area: "analytic number theory"
       comments:
-       - "<math><mrow><mi>η</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirichlet-eta-function($a1)'><mi>η</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletEtaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%97(x)"
@@ -3088,7 +3088,7 @@ concepts:
       property: function
       area: "mathematical analysis"
       comments:
-       - "<math><msup><mi>D</mi><mi>n</mi></msup><mi arg='a1'>f</mi></math>"
+       - "<math><msup intent='dirichlet-kernel($a1)'><mi>D</mi><mi>n</mi></msup><mi arg='a1'>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletKernel.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_kernel"
@@ -3100,7 +3100,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='dirichlet-l-function($a1)'><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirichletL-Function.html"
        - "https://en.wikipedia.org/wiki/Dirichlet_L-function"
@@ -3113,7 +3113,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-       - "<math><mrow><mi>ν</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='discrete-valuation($a1)'><mi>ν</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Discrete_valuation"
        - "https://ncatlab.org/nlab/show/discrete+valuation"
@@ -3139,7 +3139,7 @@ concepts:
       property: indexed
       area: "set theory"
       comments:
-       - "<math><msub><mo>&#x2a06;</mo><mrow><mi>i</mi><mo>&#x2208;</mo><mi>A</mi></mrow></msub><msup><mi arg='a1'>A</mi><mi>i</mi></msup></math>"
+       - "<math><mrow intent='disjoint-union($a1)'><msub><mo>&#x2a06;</mo><mrow><mi>i</mi><mo>&#x2208;</mo><mi>A</mi></mrow></msub><msup><mi arg='a1'>A</mi><mi>i</mi></msup></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DisjointUnion.html"
        - "https://en.wikipedia.org/wiki/Disjoint_union"
@@ -3236,7 +3236,7 @@ concepts:
       property: indexed
       area: "number theory"
       comments:
-       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='divisor-function($a1)'><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DivisorFunction.html"
        - "https://en.wikipedia.org/wiki/D(n)"
@@ -3251,7 +3251,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-       - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='domain($a1)'><mi>dom</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_a_function"
     
@@ -3261,7 +3261,7 @@ concepts:
       property: symbol
       area: "formal semantics"
       comments:
-       - "<math><mi>𝔻</mi></math>"
+       - "<math><mi intent='domain-of-discourse'>𝔻</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Domain_of_discourse"
       alias:
@@ -3273,7 +3273,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='domination-number($a1)'><mi>γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DominationNumber.html"
        - "https://en.wikipedia.org/wiki/Dominating_set"
@@ -3288,7 +3288,7 @@ concepts:
       property: infix
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='dot-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DotProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -3301,7 +3301,7 @@ concepts:
       property: infix
       area: "chemistry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>=</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='double-bond($a1,$a2)'><mi arg='a1'>X</mi><mo>=</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Double_bond"
     
@@ -3335,7 +3335,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><msub><mi>M</mi><msub><mi>M</mi><mi>p</mi></msub></msub></math>"
+       - "<math><msub intent='double-mersenne-number'><mi>M</mi><msub><mi>M</mi><mi>p</mi></msub></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleMersenneNumber.html"
        - "https://en.wikipedia.org/wiki/Double_Mersenne_number"
@@ -3348,7 +3348,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-       - "<math><mrow><mi>𝒵</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='drinfeld-center($a1)'><mi>𝒵</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Center_(category_theory)"
       alias:
@@ -3360,7 +3360,7 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='dual-basis($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualBasis.html"
        - "https://en.wikipedia.org/wiki/Dual_basis"
@@ -3376,7 +3376,7 @@ concepts:
       property: msup
       area: "vector bundles"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='dual-bundle($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualBundle.html"
        - "https://en.wikipedia.org/wiki/Dual_bundle"
@@ -3390,8 +3390,8 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup><mi>V</mi><mo>*</mo></msup></math>"
-       - "<math><msup><mi>V</mi><mo>&#x2032;</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi>V</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi>V</mi><mo>&#x2032;</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
@@ -3405,9 +3405,9 @@ concepts:
       property: unit
       area: "arithmetic"
       comments:
-       - "<math><msub><mi arg='a1'>n</mi><mi>z</mi></msub></math>"
-       - "<math><msub><mi arg='a1'>n</mi><mn>12</mn></msub></math>"
-       - "<math><msub><mi arg='a1'>n</mi><mi>doz</mi></msub></math>"
+       - "<math><msub intent='duodecimal($a1)'><mi arg='a1'>n</mi><mi>z</mi></msub></math>"
+       - "<math><msub intent='duodecimal($a1)'><mi arg='a1'>n</mi><mn>12</mn></msub></math>"
+       - "<math><msub intent='duodecimal($a1)'><mi arg='a1'>n</mi><mi>doz</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Duodecimal.html"
        - "https://en.wikipedia.org/wiki/Duodecimal#Base_notation"
@@ -3421,7 +3421,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='e-function($a1)'><mi>E</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/E-Function.html"
        - "https://en.wikipedia.org/wiki/E-function"
@@ -3434,8 +3434,8 @@ concepts:
       property: symbol
       area: "analytic geometry, graph theory"
       comments:
-       - "<math><mi>e</mi></math>"
-       - "<math><mi>ϵ</mi></math>"
+       - "<math><mi intent='eccentricity'>e</mi></math>"
+       - "<math><mi intent='eccentricity'>ϵ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Eccentricity.html"
        - "https://en.wikipedia.org/wiki/Eccentricity_(mathematics)"
@@ -3447,7 +3447,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='edge-cover-number($a1)'><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EdgeCoverNumber.html"
        - "https://en.wikipedia.org/wiki/Edge_covering_number"
@@ -3458,7 +3458,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-       - "<math><mrow><mi>dom</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='effective-domain($a1)'><mi>dom</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Effective_domain"
     
@@ -3468,7 +3468,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='efficiency($a1)'><mi>e</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Antenna_efficiency"
        - "https://en.wikipedia.org/wiki/Efficiency_(statistics)"
@@ -3480,7 +3480,7 @@ concepts:
       property: symbol
       area: "general relativity"
       comments:
-       - "<math><mi>G</mi></math>"
+       - "<math><mi intent='einstein-tensor'>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EinsteinTensor.html"
        - "https://en.wikipedia.org/wiki/Einstein_tensor"
@@ -3508,7 +3508,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>e</mi></math>"
+       - "<math><mi intent='end'>e</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/End_(category_theory)"
        - "https://ncatlab.org/nlab/show/end"
@@ -3519,7 +3519,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><mrow><mi>End</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='endomorphism-monoid($a1)'><mi>End</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Endomorphism.html"
        - "https://en.wikipedia.org/wiki/Endomorphism"
@@ -3532,7 +3532,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>E</mi></math>"
+       - "<math><mi intent='energy'>E</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/energy"
     
@@ -3542,7 +3542,7 @@ concepts:
       property: symbol
       area: "signal processing"
       comments:
-       - "<math><msub><mi>E</mi><mi>s</mi></msub></math>"
+       - "<math><msub intent='energy-of-signal'><mi>E</mi><mi>s</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Energy_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Energy_(signal_processing)"
@@ -3553,7 +3553,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='entropy($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Entropy"
        - "https://en.wikipedia.org/wiki/Entropy_(arrow_of_time)"
@@ -3567,7 +3567,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mrow><mi>epi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='epigraph($a1)'><mi>epi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epigraph_(mathematics)"
     
@@ -3577,7 +3577,7 @@ concepts:
       property: symbol
       area: "ordinal numbers"
       comments:
-       - "<math><mi>ε</mi></math>"
+       - "<math><mi intent='epsilon-number'>ε</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Epsilon_numbers_(mathematics)"
     
@@ -3587,7 +3587,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-       - "<math><mrow><mi>Eq</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='equalizer($a1)'><mi>Eq</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Equalizer.html"
        - "https://en.wikipedia.org/wiki/Equaliser_(mathematics)"
@@ -3616,7 +3616,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='equivalence-relation($a1,$a2)'><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EquivalenceRelation.html"
        - "https://en.wikipedia.org/wiki/Equivalence_relation"
@@ -3643,7 +3643,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>E</mi></math>"
+       - "<math><mi intent='erdos-borwein-constant'>E</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Erdos-BorweinConstant.html"
        - "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Borwein_constant"
@@ -3708,7 +3708,7 @@ concepts:
       property: symbol
       area: "symbols"
       comments:
-       - "<math><mi>℮</mi></math>"
+       - "<math><mi intent='estimated'>℮</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Estimation"
       alias:
@@ -3733,7 +3733,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><msub><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='euclid-number($a1)'><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/EuclidNumber.html"
        - "https://en.wikipedia.org/wiki/Euclid_number"
@@ -3744,8 +3744,8 @@ concepts:
       property: function
       area: "geometry"
       comments:
-       - "<math><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><msub><mi>d</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><mrow intent='euclidean-distance($a1)'><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><msub intent='euclidean-distance($a1)'><mi>d</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euclidean_distance"
       alias:
@@ -3757,7 +3757,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><msup><mi>ℝ</mi><mn>2</mn></msup></math>"
+       - "<math><msup intent='euclidean-plane'><mi>ℝ</mi><mn>2</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/EuclideanPlane.html"
       alias:
@@ -3769,7 +3769,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='euler-characteristic($a1)'><mi>χ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerCharacteristic.html"
        - "https://en.wikipedia.org/wiki/Euler_characteristic"
@@ -3782,7 +3782,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>e</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='euler-class($a1)'><mi>e</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_class"
        - "https://ncatlab.org/nlab/show/Euler+class"
@@ -3794,8 +3794,8 @@ concepts:
       property: symbol
       area: "analysis"
       comments:
-       - "<math><mi>γ</mi></math>"
-       - "<math><mi>𝛾</mi></math>"
+       - "<math><mi intent='euler-constant'>γ</mi></math>"
+       - "<math><mi intent='euler-constant'>𝛾</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3811,9 +3811,9 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>Eu</mi></math>"
-       - "<math><mi>e</mi></math>"
-       - "<math><mi>𝑒</mi></math>"
+       - "<math><mi intent='euler-number'>Eu</mi></math>"
+       - "<math><mi intent='euler-number'>e</mi></math>"
+       - "<math><mi intent='euler-number'>𝑒</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerNumber.html"
        - "https://en.wikipedia.org/wiki/Euler_number"
@@ -3831,7 +3831,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><msub><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='euler-polynomial($a1)'><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerPolynomial.html"
        - "https://dlmf.nist.gov/24.1#P2"
@@ -3858,7 +3858,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mi>γ</mi></math>"
+       - "<math><mi intent='euler-mascheroni-constant'>γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Euler-MascheroniConstant.html"
        - "https://en.wikipedia.org/wiki/%CE%93%27(1)"
@@ -3870,7 +3870,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mrow><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='eulerian-number($a1)'><mi>A</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerianNumber.html"
        - "https://en.wikipedia.org/wiki/Eulerian_number"
@@ -3916,7 +3916,7 @@ concepts:
       comments:
        - "<math><mi>E</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><msub><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='expected-value($a1)'><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
       alias:
@@ -3943,7 +3943,7 @@ concepts:
       property: 
       area: 
       comments:
-       - "<math><mrow><mi>Ei</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='exponential-integral($a1)'><mi>Ei</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialIntegral.html"
        - "https://en.wikipedia.org/wiki/Exponential_integral"
@@ -3960,7 +3960,7 @@ concepts:
       area: "topology"
       comments:
        - "<math><mi>ext</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mi>e</mi></msup></math>"
+       - "<math><msup intent='exterior($a1)'><mi arg='a1'>X</mi><mi>e</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
        - "https://en.wikipedia.org/wiki/Exterior_(topology)"
@@ -3971,7 +3971,7 @@ concepts:
       property: operator
       area: "differential forms"
       comments:
-       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='exterior-derivative($a1)'><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorDerivative.html"
        - "https://en.wikipedia.org/wiki/Exterior_derivative"
@@ -3982,7 +3982,7 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-       - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='exterior-algebra($a1)'><mi>Λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Exterior_algebra"
     
@@ -3992,7 +3992,7 @@ concepts:
       property: infix
       area: "multilinear algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∧</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='exterior-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∧</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExteriorProduct.html"
        - "https://www.encyclopediaofmath.org/index.php/Exterior_product"
@@ -4005,7 +4005,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-       - "<math><msub><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='f-distribution($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/F-Distribution.html"
        - "https://www.encyclopediaofmath.org/index.php/F-distribution"
@@ -4045,7 +4045,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fatou-set($a1)'><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Julia_set"
     
@@ -4055,7 +4055,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>F</mi></math>"
+       - "<math><mi intent='farey-sequence'>F</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FareySequence.html"
        - "https://en.wikipedia.org/wiki/Farey_sequence"
@@ -4066,7 +4066,7 @@ concepts:
       property: symbol
       area: "ordinal numbers"
       comments:
-       - "<math><msub><mi>Γ</mi><mn>0</mn></msub></math>"
+       - "<math><msub intent='feferman-schutte-ordinal'><mi>Γ</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Feferman%E2%80%93Sch%C3%BCtte_ordinal"
     
@@ -4076,7 +4076,7 @@ concepts:
       property: symbol
       area: "chaos theory"
       comments:
-       - "<math><mi>δ</mi></math>"
+       - "<math><mi intent='feigenbaum-constant'>δ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/FeigenbaumConstant.html"
        - "https://en.wikipedia.org/wiki/Feigenbaum_constants"
@@ -4087,7 +4087,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fermat-number($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FermatNumber.html"
        - "https://en.wikipedia.org/wiki/Fermat_number"
@@ -4098,7 +4098,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><msub><mi>q</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fermat-quotient($a1)'><mi>q</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FermatQuotient.html"
        - "https://en.wikipedia.org/wiki/Fermat_quotient"
@@ -4130,7 +4130,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fibonacci-number($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FibonacciNumber.html"
        - "https://en.wikipedia.org/wiki/Fibonacci_number"
@@ -4144,7 +4144,7 @@ concepts:
       property: "indexed function"
       area: "polynomials"
       comments:
-       - "<math><msub><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fibonacci-polynomial($a1)'><mi>F</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FibonacciPolynomial.html"
        - "https://en.wikipedia.org/wiki/Fibonacci_polynomials"
@@ -4156,7 +4156,7 @@ concepts:
       property: indexed infix
       area: "category theory"
       comments:
-       - "<math><msub><mi>×</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='fibre-product($a1)'><mi>×</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Pullback_(category_theory)"
        - "https://www.encyclopediaofmath.org/index.php/Fibre_product"
@@ -4171,7 +4171,7 @@ concepts:
       property: infix
       area: "algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='field-extension($a1,$a2)'><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FieldExtension.html"
        - "https://en.wikipedia.org/wiki/Field_extension"
@@ -4203,7 +4203,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fisher-information($a1)'><mi>I</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FisherInformation.html"
        - "https://en.wikipedia.org/wiki/Fisher_information"
@@ -4216,7 +4216,7 @@ concepts:
       property: symbol
       area: "celestial mechanics"
       comments:
-       - "<math><mi>f</mi></math>"
+       - "<math><mi intent='flattening'>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Flattening.html"
        - "https://en.wikipedia.org/wiki/Flattening"
@@ -4245,7 +4245,7 @@ concepts:
       property: function
       area: "quantum mechanics"
       comments:
-       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fock-space($a1)'><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fock_space"
        - "https://ncatlab.org/nlab/show/Fock+space"
@@ -4268,7 +4268,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi>f</mi></math>"
+       - "<math><mrow intent='fourier-cosine-transform($a1)'><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierCosineTransform.html"
        - "https://dlmf.nist.gov/1.14#E9"
@@ -4367,7 +4367,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-       - "<math><mrow><mi>Fr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='franel-number($a1)'><mi>Fr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FranelNumber.html"
     
@@ -4390,7 +4390,7 @@ concepts:
       property: operator
       area: "banach spaces"
       comments:
-       - "<math><mrow><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='frechet-derivative($a1)'><mi>D</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrechetDerivative.html"
        - "https://en.wikipedia.org/wiki/Fr%C3%A9chet_derivative"
@@ -4403,7 +4403,7 @@ concepts:
       property: constant
       area: "topology"
       comments:
-       - "<math><msub><mi>T</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='frechet-topology'><mi>T</mi><mn>1</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
       alias:
@@ -4416,7 +4416,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-       - "<math><mrow><mi>det</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='fredholm-determinant($a1)'><mi>det</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fredholm_determinant"
        - "https://ncatlab.org/nlab/show/Fredholm+determinant"
@@ -4453,7 +4453,7 @@ concepts:
       property: msup
       area: "abstract algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='free-monoid($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Free_monoid"
        - "https://en.wikipedia.org/wiki/Monoid_factorisation"
@@ -4465,7 +4465,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='free-product($a1,$a2)'><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeProduct.html"
        - "https://en.wikipedia.org/wiki/Free_product"
@@ -4519,7 +4519,7 @@ concepts:
       property: mixfix
       area: "number theory"
       comments:
-       - "<math><mrow><mi arg='a1'>f</mi><mo>≡</mo><mi arg='a2'>g</mi></mrow><mrow><mo>(</mo><mi>mod</mi><mi arg='a3'>n</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='functional-congruence($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>≡</mo><mi arg='a2'>g</mi></mrow><mrow><mo>(</mo><mi>mod</mi><mi arg='a3'>n</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FunctionalCongruence.html"
       alias:
@@ -4531,8 +4531,8 @@ concepts:
       property: msup, fenced
       area: "category theory"
       comments:
-       - "<math><msup><mi>f</mi><mi>g</mi></msup></math>"
-       - "<math><mo>[</mo><mi>f</mi><mo>,</mo><mi>g</mi><mo>]</mo></math>"
+       - "<math><msup intent='functor-category($a1,$a2)'><mi arg='a1'>f</mi><mi arg='a1'>g</mi></msup></math>"
+       - "<math><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -4543,7 +4543,7 @@ concepts:
       property: symbol
       area: "computer vision"
       comments:
-       - "<math><mi>F</mi></math>"
+       - "<math><mi intent='fundamental-matrix'>F</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fundamental_matrix_(computer_vision)"
     
@@ -4553,7 +4553,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='g-function($a1)'><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/G-Function.html"
        - "https://en.wikipedia.org/wiki/Meijer_G-function"
@@ -4566,7 +4566,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gabor-transform($a1)'><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gabor_transform"
        - "https://en.wikipedia.org/wiki/Gabor%E2%80%93Wigner_transform"
@@ -4578,7 +4578,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>φ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gain-function($a1)'><mi>φ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gain_graph"
        - "https://en.wikipedia.org/wiki/Gain_group"
@@ -4590,7 +4590,7 @@ concepts:
       property: function
       area: "physics"
       comments:
-       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='galilean-transformation($a1)'><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GalileanTransformation.html"
        - "https://en.wikipedia.org/wiki/Galilean_transformation"
@@ -4630,7 +4630,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>Γ</mi></math>"
+       - "<math><mi intent='gamma-distribution'>Γ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaDistribution.html"
        - "https://en.wikipedia.org/wiki/Gamma_distribution"
@@ -4641,7 +4641,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gamma-function($a1)'><mi>Γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GammaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%93(x)"
@@ -4671,7 +4671,7 @@ concepts:
       property: unit
       area: "physics"
       comments:
-       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gauss($a1)'><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Gauss_(unit)"
     
@@ -4681,7 +4681,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>𝒩</mi></math>"
+       - "<math><mi intent='gaussian-distribution'>𝒩</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Normal_distribution"
       alias:
@@ -4695,7 +4695,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>Κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gaussian-curvature($a1)'><mi>Κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianCurvature.html"
        - "https://en.wikipedia.org/wiki/Gaussian_curvature"
@@ -4740,7 +4740,7 @@ concepts:
       property: constant
       area: "transcendental constants"
       comments:
-       - "<math><msup><mi>e</mi><mi>π</mi></msup></math>"
+       - "<math><msup intent='gelfond-constant'><mi>e</mi><mi>π</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/GelfondsConstant.html"
        - "https://en.wikipedia.org/wiki/Gelfond%27s_constant"
@@ -4761,7 +4761,7 @@ concepts:
       property: symbol
       area: "particle physics"
       comments:
-       - "<math><mi>λ</mi></math>"
+       - "<math><mi intent='gell-mann-matrix'>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Gell-MannMatrix.html"
        - "https://en.wikipedia.org/wiki/Gell-Mann_matrices"
@@ -4807,7 +4807,7 @@ concepts:
       property: function
       area: "means"
       comments:
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='generalized-mean($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeneralizedMean.html"
        - "https://en.wikipedia.org/wiki/Generalized_mean"
@@ -4822,7 +4822,7 @@ concepts:
       property: symbol
       area: "integer sequences"
       comments:
-       - "<math><msub><mi>G</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='genocchi-number($a1)'><mi>G</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GenocchiNumber.html"
        - "https://en.wikipedia.org/wiki/Genocchi_number"
@@ -4835,7 +4835,7 @@ concepts:
       property: symbol
       area: "riemannian geometry"
       comments:
-       - "<math><msub><mi>k</mi><mi>g</mi></msub></math>"
+       - "<math><msub intent='geodesic-curvature'><mi>k</mi><mi>g</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeodesicCurvature.html"
        - "https://en.wikipedia.org/wiki/Geodesic_curvature"
@@ -4847,7 +4847,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='geodesic-distance($a1)'><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance_(graph_theory)"
        - "https://en.wikipedia.org/wiki/Diameter_(graph_theory)"
@@ -4882,7 +4882,7 @@ concepts:
       property: function
       area: "means"
       comments:
-       - "<math><mrow><mi>GM</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='geometric-mean($a1)'><mi>GM</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Geometric_mean"
@@ -4915,7 +4915,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mi>A</mi></math>"
+       - "<math><mi intent='glaisher-constant'>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GlaisherConstant.html"
        - "https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant"
@@ -4941,8 +4941,8 @@ concepts:
       property: constant
       area: "geometry"
       comments:
-       - "<math><mi>φ</mi></math>"
-       - "<math><mi>ϕ</mi></math>"
+       - "<math><mi intent='golden-ratio'>φ</mi></math>"
+       - "<math><mi intent='golden-ratio'>ϕ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GoldenRatio.html"
        - "https://en.wikipedia.org/wiki/Golden_ratio"
@@ -4964,7 +4964,7 @@ concepts:
       property: constant
       area: "ramsey theory"
       comments:
-       - "<math><msub><mi>G</mi><mn>64</mn></msub></math>"
+       - "<math><msub intent='graham-number'><mi>G</mi><mn>64</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/GrahamsNumber.html"
        - "https://en.wikipedia.org/wiki/Graham%27s_number"
@@ -4987,7 +4987,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-       - "<math><mi>G</mi></math>"
+       - "<math><mi intent='gram-matrix'>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramMatrix.html"
        - "https://en.wikipedia.org/wiki/Gramian_matrix"
@@ -5002,7 +5002,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>Gr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='grassmannian($a1)'><mi>Gr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Grassmannian.html"
        - "https://en.wikipedia.org/wiki/Grassmannian"
@@ -5014,7 +5014,7 @@ concepts:
       property: function
       area: "mathematical physics"
       comments:
-       - "<math><mrow><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='green-function($a1)'><mi>G</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GreensFunction.html"
        - "https://en.wikipedia.org/wiki/Green%27s_function_(many-body_theory)"
@@ -5028,7 +5028,7 @@ concepts:
       property: symbol
       area: "computer algebra"
       comments:
-       - "<math><mi>G</mi></math>"
+       - "<math><mi intent='grobner-basis'>G</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GroebnerBasis.html"
        - "https://en.wikipedia.org/wiki/Gr%C3%B6bner_basis"
@@ -5053,8 +5053,8 @@ concepts:
       property: msup, function
       area: "ring theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mo>×</mo></msup></math>"
+       - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>×</mo></msup></math>"
        - "<math><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5077,7 +5077,7 @@ concepts:
       property: function
       area: "trigonometry"
       comments:
-       - "<math><mrow><mi>gd</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='gudermannian-function($a1)'><mi>gd</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GudermannianFunction.html"
        - "https://en.wikipedia.org/wiki/Gudermannian_function"
@@ -5108,7 +5108,7 @@ concepts:
       property: function
       area: "orthogonal polynomials"
       comments:
-       - "<math><msub><mi>q</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='hahn-polynomial($a1)'><mi>q</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HahnPolynomial.html"
        - "https://en.wikipedia.org/wiki/Hahn_polynomials"
@@ -5137,7 +5137,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hankel-function($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HankelFunction.html"
        - "https://dlmf.nist.gov/10.1"
@@ -5172,7 +5172,7 @@ concepts:
       property: operator
       area: "real analysis"
       comments:
-       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hardy-littlewood-maximal-operator($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hardy%E2%80%93Littlewood_maximal_function"
       alias:
@@ -5184,7 +5184,7 @@ concepts:
       property: function
       area: "means"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='harmonic-mean($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HarmonicMean.html"
        - "https://en.wikipedia.org/wiki/Harmonic_mean"
@@ -5218,7 +5218,7 @@ concepts:
       property: constant
       area: "topology"
       comments:
-       - "<math><msub><mi>T</mi><mn>2</mn></msub></math>"
+       - "<math><msub intent='hausdorff-space'><mi>T</mi><mn>2</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
       alias:
@@ -5230,7 +5230,7 @@ concepts:
       property: function
       area: "engineering"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hazard-function($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HazardFunction.html"
       alias:
@@ -5242,7 +5242,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='heaviside-function($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/1.16#E13)[https://en.wikipedia.org/wiki/Heaviside_step_function"
        - "https://en.wikipedia.org/wiki/Heaviside_step_function"
@@ -5257,7 +5257,7 @@ concepts:
       property: function
       area: "topological graph theory"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='heawood-number($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heawood_number"
     
@@ -5267,7 +5267,7 @@ concepts:
       property: operator
       area: "modular forms"
       comments:
-       - "<math><msub><mi>T</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='hecke-operator($a1)'><mi>T</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeckeOperator.html"
        - "https://en.wikipedia.org/wiki/Hecke_operator"
@@ -5289,7 +5289,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><msub><mi>h</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='height-of-abelian-group($a1)'><mi>h</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_(abelian_group)"
     
@@ -5299,7 +5299,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-       - "<math><mrow><mi>ht</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='height-of-prime-ideal($a1)'><mi>ht</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Krull_dimension#height"
       alias:
@@ -5308,12 +5308,12 @@ concepts:
        - altitude-of-prime-ideal
     
     - concept: heisenberg-group
-      arity: 0
+      arity: 1
       en: heisenberg group
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='heisenberg-group($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeisenbergGroup.html"
        - "https://en.wikipedia.org/wiki/Heisenberg_group"
@@ -5364,7 +5364,7 @@ concepts:
       property: function
       area: "means"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='heronian-mean($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HeronianMean.html"
        - "https://en.wikipedia.org/wiki/Heronian_mean"
@@ -5375,7 +5375,7 @@ concepts:
       property: operator
       area: "differential operators"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hessian($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hessian.html"
        - "https://en.wikipedia.org/wiki/Hessian_matrix"
@@ -5403,7 +5403,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Hp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='heun-polynomial($a1)'><mi>Hp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.5#p1"
@@ -5428,7 +5428,7 @@ concepts:
       property: fenced
       area: "quadratic forms"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='hilbert-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HilbertSymbol.html"
        - "https://en.wikipedia.org/wiki/Hilbert_symbol"
@@ -5451,7 +5451,7 @@ concepts:
       property: infix
       area: "mathematical morphology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊙</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='hit-or-miss-transform($a1,$a2)'><mi arg='a1'>X</mi><mo>⊙</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hit-or-miss_transform"
     
@@ -5472,7 +5472,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='holomorph($a1)'><mi>Hol</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Holomorph_(mathematics)"
        - "https://ncatlab.org/nlab/show/holomorph"
@@ -5483,7 +5483,7 @@ concepts:
       property: "indexed symbol"
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>Hol</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='holonomy-group($a1)'><mi>Hol</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Holonomy.html"
        - "https://en.wikipedia.org/wiki/Holonomy"
@@ -5495,7 +5495,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>HP</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='home-prime($a1)'><mi>HP</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomePrime.html"
        - "https://en.wikipedia.org/wiki/Home_prime"
@@ -5506,7 +5506,7 @@ concepts:
       property: function
       area: "homology theory"
       comments:
-       - "<math><msub><mi>H</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='homology-group($a1)'><mi>H</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/HomologyGroup.html"
        - "https://en.wikipedia.org/wiki/Singular_homology"
@@ -5517,7 +5517,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⋉</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='homomorphic-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⋉</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Graph_product"
     
@@ -5528,7 +5528,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><mrow><mi>Ho</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='homotopy-category($a1)'><mi>Ho</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/homotopy+category"
     
@@ -5567,7 +5567,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hurwitz-zeta-function($a1)'><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HurwitzZetaFunction.html"
        - "https://en.wikipedia.org/wiki/Hurwitz_zeta_function"
@@ -5580,7 +5580,7 @@ concepts:
       property: unit
       area: "customary units"
       comments:
-       - "<math><mrow><mi>hvat</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hvat($a1)'><mi>hvat</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kubni_hvat"
        - "https://en.wikipedia.org/wiki/%C4%8Cetvorni_hvat"
@@ -5606,7 +5606,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Chi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hyperbolic-cosine-integral($a1)'><mi>Chi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicCosineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E16"
@@ -5627,7 +5627,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Shi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='hyperbolic-sine-integral($a1)'><mi>Shi</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicSineIntegral.html"
        - "https://dlmf.nist.gov/6.2#E15"
@@ -5660,7 +5660,7 @@ concepts:
       area: "multilinear algebra"
       comments:
        - "<math><mi>det</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
+       - "<math><mrow intent='hyperdeterminant($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
        - "https://en.wikipedia.org/wiki/Hyperdeterminant"
@@ -5684,9 +5684,9 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mi>e</mi></math>"
-       - "<math><mi>I</mi></math>"
-       - "<math><mi>E</mi></math>"
+       - "<math><mi intent='identity-element'>e</mi></math>"
+       - "<math><mi intent='identity-element'>I</mi></math>"
+       - "<math><mi intent='identity-element'>E</mi></math>"
       notationa: "mn 1"
       urls: 
        - "https://mathworld.wolfram.com/IdentityElement.html"
@@ -5703,8 +5703,8 @@ concepts:
       area: "algebra"
       comments:
        - "<math><mi>id</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><msub><mi>id</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='identity-function($a1)'><mi>id</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='identity-function($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/IdentityFunction.html"
        - "https://en.wikipedia.org/wiki/Identity_function"
@@ -5720,9 +5720,9 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><msub><mi>1</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Id</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='identity-functor($a1)'><mi>1</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='identity-functor($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='identity-functor($a1)'><mi>Id</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/identity+functor"
        - "https://en.wikipedia.org/wiki/Functor"
@@ -5733,7 +5733,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-       - "<math><mi>I</mi></math>"
+       - "<math><mi intent='identity-matrix'>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/IdentityMatrix.html"
        - "https://en.wikipedia.org/wiki/Identity_matrix"
@@ -5747,7 +5747,7 @@ concepts:
       area: "set theory"
       notation: "$1 [ $2 ]"
       notationc: "msub $1 *"
-      notationb: "<math><msup><mi arg='a1'>X</mi><mo>→</mo></msup></math>"
+      notationb: "<math><msup><mi>X</mi><mo>→</mo></msup></math>"
       notationa: "$1 '' $2"
       urls: 
        - "https://mathworld.wolfram.com/Image.html"
@@ -5763,7 +5763,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mi>I</mi></math>"
+       - "<math><mi intent='incenter'>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Incenter.html"
        - "https://en.wikipedia.org/wiki/Incircle_and_excircles_of_a_triangle"
@@ -5798,7 +5798,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-       - "<math><mrow><mi>ι</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='inclusion-map($a1)'><mi>ι</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Inclusion_map"
       alias:
@@ -5823,7 +5823,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='incomplete-beta-function($a1)'><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteBetaFunction.html"
        - "https://dlmf.nist.gov/8.17"
@@ -5836,7 +5836,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-       - "<math><mrow><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='incomplete-elliptic-integral-of-the-first-kind($a1)'><mi>F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5848,7 +5848,7 @@ concepts:
       property: function
       area: "elliptic functions"
       comments:
-       - "<math><mrow><mi>E</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='incomplete-elliptic-integral-of-the-second-kind($a1)'><mi>E</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticIntegral.html"
        - "https://en.wikipedia.org/wiki/Elliptic_integral"
@@ -5860,7 +5860,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='incomplete-gamma-function($a1)'><mi>Γ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/IncompleteGammaFunction.html"
        - "https://en.wikipedia.org/wiki/Incomplete_gamma_function"
@@ -5910,9 +5910,9 @@ concepts:
       property: fenced
       area: "group theory"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow><mo>|</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>|</mo></mrow></math>"
+       - "<math><mrow intent='index-of-subgroup($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='index-of-subgroup($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='index-of-subgroup($a1,$a2)'><mo>|</mo><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_subgroup"
     
@@ -5922,7 +5922,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-       - "<math><mrow><mi>ind</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='index-of-lie-algebra($a1)'><mi>ind</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Index_of_a_Lie_algebra"
     
@@ -5996,7 +5996,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi>Inn</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='inner-automorphism-group($a1)'><mi>Inn</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerAutomorphism.html"
        - "https://en.wikipedia.org/wiki/Inner_automorphism"
@@ -6022,7 +6022,7 @@ concepts:
       property: infix, fenced
       area: "linear algebra"
       notation: "mo ⋅"
-      notationa: "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+      notationa: "<math><mrow intent='inner-product($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -6057,8 +6057,8 @@ concepts:
       property: msup
       area: "topology"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>o</mo></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mo>∘</mo></msup></math>"
+       - "<math><msup intent='interior($a1)'><mi arg='a1'>X</mi><mo>o</mo></msup></math>"
+       - "<math><msup intent='interior($a1)'><mi arg='a1'>X</mi><mo>∘</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Interior.html"
        - "https://en.wikipedia.org/wiki/Interior_(topology)"
@@ -6129,7 +6129,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>Ti</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='inverse-tangent-integral($a1)'><mi>Ti</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polylogarithm"
     
@@ -6161,7 +6161,7 @@ concepts:
       property: msup
       area: "geometry"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mn>-1</mn></msup></math>"
+       - "<math><msup intent='isogonal-conjugate($a1)'><mi arg='a1'>X</mi><mn>-1</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/IsogonalConjugate.html"
        - "https://en.wikipedia.org/wiki/Isogonal_conjugate"
@@ -6209,7 +6209,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>j</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='j-invariant($a1)'><mi>j</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/j-Invariant.html"
        - "https://ncatlab.org/nlab/show/j-invariant"
@@ -6220,7 +6220,7 @@ concepts:
       property: function
       area: "operator theory"
       comments:
-       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jacobi-matrix($a1)'><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiMatrix.html"
        - "https://en.wikipedia.org/wiki/Jacobi_operator"
@@ -6248,7 +6248,7 @@ concepts:
       property: mixfix$1 $2
       area: "number theory"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='jacobi-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiSymbol.html"
        - "https://en.wikipedia.org/wiki/Jacobi_symbol"
@@ -6261,7 +6261,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow><mi>ϑ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jacobi-theta-function($a1)'><mi>ϑ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobiThetaFunctions.html"
        - "https://en.wikipedia.org/wiki/Jacobi_theta_functions_(notational_variations)"
@@ -6319,7 +6319,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>J</mi></math>"
+       - "<math><mi intent='jacobsthal-number'>J</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsthalNumber.html"
        - "https://en.wikipedia.org/wiki/Jacobsthal_number"
@@ -6330,10 +6330,10 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><msub><mi>J</mi><mn>1</mn></msub></math>"
-       - "<math><msub><mi>J</mi><mn>2</mn></msub></math>"
-       - "<math><msub><mi>J</mi><mn>3</mn></msub></math>"
-       - "<math><msub><mi>J</mi><mn>4</mn></msub></math>"
+       - "<math><msub intent='janko-group'><mi>J</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='janko-group'><mi>J</mi><mn>2</mn></msub></math>"
+       - "<math><msub intent='janko-group'><mi>J</mi><mn>3</mn></msub></math>"
+       - "<math><msub intent='janko-group'><mi>J</mi><mn>4</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/JankoGroups.html"
        - "https://en.wikipedia.org/wiki/Janko_group"
@@ -6367,7 +6367,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-       - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jone-polynomial($a1)'><mi>V</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JonesPolynomial.html"
        - "https://en.wikipedia.org/wiki/Jones_polynomial"
@@ -6391,7 +6391,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='jordan-measure($a1)'><mi>m</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JordanMeasure.html"
        - "https://en.wikipedia.org/wiki/Jordan_measure"
@@ -6403,7 +6403,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><msub><mi>J</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='jordan-totient-function($a1)'><mi>J</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Jordan%27s_totient_function"
     
@@ -6413,7 +6413,7 @@ concepts:
       property: function
       area: "complex dynamics"
       comments:
-       - "<math><mrow><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='julia-set($a1)'><mi>J</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JuliaSet.html"
        - "https://en.wikipedia.org/wiki/Julia_set"
@@ -6438,7 +6438,7 @@ concepts:
       property: fenced
       area: "knot theory"
       comments:
-       - "<math><mrow><mo>⟨</mo><mi arg='a1'>x</mi><mo>⟩</mo></mrow></math>"
+       - "<math><mrow intent='kauffman-bracket($a1)'><mo>⟨</mo><mi arg='a1'>x</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bracket_polynomial"
       alias:
@@ -6467,7 +6467,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>ker</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kernel($a1)'><mi>ker</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Kernel.html"
        - "https://en.wikipedia.org/wiki/Kernel_(algebra)"
@@ -6488,7 +6488,7 @@ concepts:
       property: constant
       area: "continued fractions"
       comments:
-       - "<math><mi>K</mi></math>"
+       - "<math><mi intent='khinchin-constant'>K</mi></math>"
       notationa: "msub K 0"
       urls: 
        - "https://mathworld.wolfram.com/KhinchinsConstant.html"
@@ -6500,7 +6500,7 @@ concepts:
       property: function
       area: "lie algebra"
       comments:
-       - "<math><mrow><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='killing-form($a1)'><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KillingForm.html"
        - "https://en.wikipedia.org/wiki/Killing_form"
@@ -6531,7 +6531,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mi>V</mi></math>"
+       - "<math><mi intent='klein-four-group'>V</mi></math>"
       notationa: "msub K 4"
       urls: 
        - "https://mathworld.wolfram.com/KleinFour-Group.html"
@@ -6566,7 +6566,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='knodel-number($a1)'><mi>K</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KnoedelNumbers.html"
        - "https://en.wikipedia.org/wiki/Kn%C3%B6del_number"
@@ -6577,7 +6577,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-       - "<math><mrow><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kodaira-dimension($a1)'><mi>κ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Kodaira_dimension"
        - "https://www.encyclopediaofmath.org/index.php/Kodaira_dimension"
@@ -6588,7 +6588,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-       - "<math><mrow><mi>K</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kolmogorov-complexity($a1)'><mi>K</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KolmogorovComplexity.html"
        - "https://en.wikipedia.org/wiki/Kolmogorov_complexity"
@@ -6599,7 +6599,7 @@ concepts:
       property: constant
       area: "topology"
       comments:
-       - "<math><msub><mi>T</mi><mn>0</mn></msub></math>"
+       - "<math><msub intent='kolmogorov-space'><mi>T</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions"
     
@@ -6609,7 +6609,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='kontsevich-integral($a1)'><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KontsevichIntegral.html"
        - "https://en.wikipedia.org/wiki/Kontsevich_invariant"
@@ -6622,7 +6622,7 @@ concepts:
       property: function
       area: "orthogonal polynomials"
       comments:
-       - "<math><msub><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='krawtchouk-polynomial($a1)'><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrawtchoukPolynomial.html"
        - "https://en.wikipedia.org/wiki/Kravchuk_polynomials"
@@ -6635,7 +6635,7 @@ concepts:
       property: fenced
       area: "modal logic"
       comments:
-       - "<math><mrow><mo>⟨</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>⟩</mo></mrow></math>"
+       - "<math><mrow intent='kripke-frame($a1,$a2)'><mo>⟨</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Kripke+frame"
     
@@ -6657,7 +6657,7 @@ concepts:
       property: infix
       area: "matrix theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='kronecker-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerProduct.html"
        - "https://en.wikipedia.org/wiki/Khatri-Rao_product"
@@ -6671,7 +6671,7 @@ concepts:
       property: fenced, fenced stacked
       area: "number theory"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='kronecker-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>|</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
       notationa: "( mfrac $1 $2 )"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerSymbol.html"
@@ -6686,7 +6686,7 @@ concepts:
       property: function
       area: "commutative algebra"
       comments:
-       - "<math><mrow><mi>dim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='krull-dimension($a1)'><mi>dim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KrullDimension.html"
        - "https://en.wikipedia.org/wiki/Krull_dimension"
@@ -6736,7 +6736,7 @@ concepts:
       property: symbol
       area: "mathematical optimization"
       comments:
-       - "<math><mi>λ</mi></math>"
+       - "<math><mi intent='lagrange-multiplier'>λ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeMultiplier.html"
        - "https://en.wikipedia.org/wiki/Lagrange_multiplier"
@@ -6751,11 +6751,11 @@ concepts:
       property: symbol
       area: "celestial mechanics"
       comments:
-       - "<math><msub><mi>L</mi><mn>1</mn></msub></math>"
-       - "<math><msub><mi>L</mi><mn>2</mn></msub></math>"
-       - "<math><msub><mi>L</mi><mn>3</mn></msub></math>"
-       - "<math><msub><mi>L</mi><mn>4</mn></msub></math>"
-       - "<math><msub><mi>L</mi><mn>5</mn></msub></math>"
+       - "<math><msub intent='lagrange-point'><mi>L</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='lagrange-point'><mi>L</mi><mn>2</mn></msub></math>"
+       - "<math><msub intent='lagrange-point'><mi>L</mi><mn>3</mn></msub></math>"
+       - "<math><msub intent='lagrange-point'><mi>L</mi><mn>4</mn></msub></math>"
+       - "<math><msub intent='lagrange-point'><mi>L</mi><mn>5</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lagrange_point"
       alias:
@@ -6769,7 +6769,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='laguerre-polynomial($a1)'><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaguerrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Laguerre_polynomials"
@@ -6784,9 +6784,9 @@ concepts:
       property: constant
       area: "complex analysis"
       comments:
-       - "<math><mi>A</mi></math>"
-       - "<math><mi>B</mi></math>"
-       - "<math><mi>L</mi></math>"
+       - "<math><mi intent='landau-constant'>A</mi></math>"
+       - "<math><mi intent='landau-constant'>B</mi></math>"
+       - "<math><mi intent='landau-constant'>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LandauConstant.html"
        - "https://en.wikipedia.org/wiki/Landau%27s_constants"
@@ -6810,7 +6810,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-       - "<math><mrow><mi>ℒ⁡</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='laplace-transform($a1)'><mi>ℒ⁡</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplaceTransform.html"
        - "https://en.wikipedia.org/wiki/Laplace_transform"
@@ -6823,7 +6823,7 @@ concepts:
       property: symbol
       area: "graph theory"
       comments:
-       - "<math><mi>L</mi></math>"
+       - "<math><mi intent='laplacian-matrix'>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LaplacianMatrix.html"
        - "https://en.wikipedia.org/wiki/Laplacian_matrix"
@@ -6858,7 +6858,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>lpf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='least-prime-factor($a1)'><mi>lpf</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeastPrimeFactor.html"
     
@@ -6868,7 +6868,7 @@ concepts:
       property: indexed constant
       area: "fourier series"
       comments:
-       - "<math><msub><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lebesgue-constant($a1)'><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LebesgueConstants.html"
        - "https://en.wikipedia.org/wiki/Lebesgue_constant_(interpolation)"
@@ -6891,7 +6891,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><msub><mo>Λ</mo><mn>24</mn></msub></math>"
+       - "<math><msub intent='leech-lattice'><mo>Λ</mo><mn>24</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LeechLattice.html"
        - "https://en.wikipedia.org/wiki/Leech_lattice"
@@ -6903,7 +6903,7 @@ concepts:
       property: infix
       area: "category theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊣</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='left-adjoint($a1,$a2)'><mi arg='a1'>X</mi><mo>⊣</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjoint_functors"
     
@@ -6913,7 +6913,7 @@ concepts:
       property: infix
       area: "algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>;</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='left-composition($a1,$a2)'><mi arg='a1'>X</mi><mo>;</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Composition_of_relations"
       alias:
@@ -6934,7 +6934,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>χ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='legendre-chi-function($a1)'><mi>χ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Legendre_chi_function"
        - "https://mathworld.wolfram.com/LegendresChi-Function.html"
@@ -6945,7 +6945,7 @@ concepts:
       property: function
       area: "orthogonal polynomials"
       comments:
-       - "<math><msub><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='legendre-polynomial($a1)'><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Legendre_polynomials"
@@ -6974,7 +6974,7 @@ concepts:
       property: "indexed function"
       area: "means"
       comments:
-       - "<math><msub><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lehmer-mean($a1)'><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerMean.html"
        - "https://en.wikipedia.org/wiki/Lehmer_mean"
@@ -6985,7 +6985,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><msub><mi>U</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lehmer-number($a1)'><mi>U</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LehmerNumber.html"
        - "https://mathworld.wolfram.com/LehmersNumber.html"
@@ -6997,7 +6997,7 @@ concepts:
       property: function
       area: "scales of measurement"
       comments:
-       - "<math><msub><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='level($a1)'><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Level_(logarithmic_quantity)"
        - "https://en.wikipedia.org/wiki/Categorical_variable"
@@ -7023,7 +7023,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='levy-prokhorov-metric($a1)'><mi>π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/L%C3%A9vy%E2%80%93Prokhorov_metric"
        - "https://encyclopediaofmath.org/wiki/L%C3%A9vy-Prokhorov_metric"
@@ -7046,7 +7046,7 @@ concepts:
       property: infix
       area: "discrete mathematics"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>&lt;</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='lexicographic-order($a1,$a2)'><mi arg='a1'>X</mi><mo>&lt;</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lexicographic_order"
        - "https://mathworld.wolfram.com/LexicographicOrder.html"
@@ -7060,7 +7060,7 @@ concepts:
       property: "indexed operator"
       area: "lie algebra"
       comments:
-       - "<math><msub><mi>ℒ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lie-derivative($a1)'><mi>ℒ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LieDerivative.html"
        - "https://en.wikipedia.org/wiki/Lie_derivative"
@@ -7072,7 +7072,7 @@ concepts:
       property: fenced
       area: "lie algebra"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='lie-superbracket($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Lie_superalgebra"
       alias:
@@ -7084,7 +7084,7 @@ concepts:
       property: infix
       area: "physics"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⇈</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='like-charge($a1,$a2)'><mi arg='a1'>X</mi><mo>⇈</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4719"
     
@@ -7094,7 +7094,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='line-graph($a1)'><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LineGraph.html"
        - "https://en.wikipedia.org/wiki/Line_graph"
@@ -7121,7 +7121,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='linear-span($a1)'><mi>span</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LinearSpan.html"
        - "https://en.wikipedia.org/wiki/Linear_span"
@@ -7135,7 +7135,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>Lk</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='link($a1)'><mi>Lk</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Link.html"
     
@@ -7157,7 +7157,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mi>L</mi></math>"
+       - "<math><mi intent='liouville-constant'>L</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvillesConstant.html"
       alias:
@@ -7169,7 +7169,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='liouville-function($a1)'><mi>λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LiouvilleFunction.html"
        - "https://en.wikipedia.org/wiki/Liouville_function"
@@ -7194,7 +7194,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>li</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='logarithmic-integral($a1)'><mi>li</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LogarithmicIntegral.html"
        - "https://dlmf.nist.gov/6.2#i"
@@ -7217,7 +7217,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>logit</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='logit($a1)'><mi>logit</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Logit"
     
@@ -7251,7 +7251,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>Ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='loop-space($a1)'><mi>Ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LoopSpace.html"
        - "https://en.wikipedia.org/wiki/Loop_space"
@@ -7308,7 +7308,7 @@ concepts:
       property: "indexed symbol"
       area: "integer sequences"
       comments:
-       - "<math><msub><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lucas-number($a1)'><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LucasNumber.html"
        - "https://en.wikipedia.org/wiki/Lucas_number"
@@ -7320,8 +7320,8 @@ concepts:
       property: "indexed function"
       area: "integer sequences"
       comments:
-       - "<math><msub><mi>U</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>V</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lucas-sequence($a1)'><mi>U</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='lucas-sequence($a1)'><mi>V</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LucasSequence.html"
        - "https://en.wikipedia.org/wiki/Lucas_sequence"
@@ -7332,7 +7332,7 @@ concepts:
       property: function
       area: "stability theory"
       comments:
-       - "<math><mrow><mi>V</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='lyapunov-candidate-function($a1)'><mi>V</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LyapunovFunction.html"
        - "https://en.wikipedia.org/wiki/Lyapunov_function"
@@ -7356,7 +7356,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mahler-measure($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MahlerMeasure.html"
        - "https://en.wikipedia.org/wiki/Mahler_measure"
@@ -7368,7 +7368,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mangoldt-function($a1)'><mi>Λ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MangoldtFunction.html"
        - "https://dlmf.nist.gov/27.2#E14"
@@ -7382,7 +7382,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-       - "<math><mrow><mi>MCG</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mapping-class-group($a1)'><mi>MCG</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_class_group"
        - "https://ncatlab.org/nlab/show/mapping+class+group"
@@ -7393,7 +7393,7 @@ concepts:
       property: "indexed symbol"
       area: "homotopy theory"
       comments:
-       - "<math><msub><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mapping-cone($a1)'><mi>C</mi><mi arg='a1'>x</mi></msub></math>"
       notationa: "mrow C $1"
       urls: 
        - "https://en.wikipedia.org/wiki/Mapping_cone_(topology)"
@@ -7408,9 +7408,9 @@ concepts:
       property: "indexed function"
       area: "graph theory"
       comments:
-       - "<math><msub><mi>m</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='matching-polynomial($a1)'><mi>m</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='matching-polynomial($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='matching-polynomial($a1)'><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Matching_polynomial"
     
@@ -7420,8 +7420,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>ce</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>se</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mathieu-function-of-first-kind($a1)'><mi>ce</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mathieu-function-of-first-kind($a1)'><mi>se</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7445,8 +7445,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>fe</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>ge</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mathieu-function-of-second-kind($a1)'><mi>fe</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mathieu-function-of-second-kind($a1)'><mi>ge</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MathieuFunction.html"
        - "https://en.wikipedia.org/wiki/Mathieu_function"
@@ -7492,7 +7492,7 @@ concepts:
       property: mtable, fenced
       area: "algebra"
       notation: "mtable"
-      notationb: "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+      notationb: "<math><mrow intent='matrix($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       notationa: "mrow ( $1"
       urls: 
        - "https://mathworld.wolfram.com/Matrix.html"
@@ -7511,7 +7511,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='matrix-ring($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Matrix_ring"
        - "https://www.encyclopediaofmath.org/index.php/Matrix_ring"
@@ -7522,7 +7522,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='maximum-degree($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MaximumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7534,7 +7534,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mean-curvature($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MeanCurvature.html"
        - "https://en.wikipedia.org/wiki/Mean_curvature"
@@ -7546,7 +7546,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>MSE</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mean-squared-error($a1)'><mi>MSE</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Mean_squared_error"
     
@@ -7556,7 +7556,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='meixner-pollaczek-polynomial($a1)'><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meixner-PollaczekPolynomial.html"
        - "https://en.wikipedia.org/wiki/Meixner%E2%80%93Pollaczek_polynomials"
@@ -7568,7 +7568,7 @@ concepts:
       property: operator
       area: "integral transforms"
       comments:
-       - "<math><mrow><mi>ℳ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mellin-transform($a1)'><mi>ℳ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MellinTransform.html"
        - "https://en.wikipedia.org/wiki/Mellin_transform"
@@ -7581,7 +7581,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='meridian-radius-of-curvature($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Meridian_arc"
        - "https://en.wikipedia.org/wiki/Meridian_arc"
@@ -7592,7 +7592,7 @@ concepts:
       property: function
       area: "geodesy"
       comments:
-       - "<math><mrow><mi>m</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='meridian-distance($a1)'><mi>m</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Meridian.html"
     
@@ -7602,7 +7602,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mersenne-number($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MersenneNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Mersenne_number"
@@ -7613,7 +7613,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mersenne-prime($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MersennePrime.html"
        - "https://en.wikipedia.org/wiki/Mersenne_number"
@@ -7625,7 +7625,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='merten-function($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MertensFunction.html"
        - "https://en.wikipedia.org/wiki/Mertens_function"
@@ -7656,7 +7656,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>A</mi></math>"
+       - "<math><mi intent='mills-constant'>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsConstant.html"
        - "https://en.wikipedia.org/wiki/Mills%27_constant"
@@ -7681,7 +7681,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='minimum-degree($a1)'><mi>δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinimumDegree.html"
        - "https://en.wikipedia.org/wiki/Degree_(graph_theory)"
@@ -7693,7 +7693,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>-</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='minkowski-difference($a1,$a2)'><mi arg='a1'>X</mi><mo>-</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
       alias:
@@ -7705,7 +7705,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>+</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='minkowski-sum($a1,$a2)'><mi arg='a1'>X</mi><mo>+</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MinkowskiSum.html"
        - "https://en.wikipedia.org/wiki/Minkowski_addition"
@@ -7718,7 +7718,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='mittag-leffler-function($a1)'><mi>E</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Mittag-LefflerFunction.html"
        - "https://en.wikipedia.org/wiki/Mittag-Leffler_function"
@@ -7731,7 +7731,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mobius-function($a1)'><mi>μ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MoebiusFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%9C(n)"
@@ -7745,7 +7745,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-bessel-function-of-first-kind($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/10#PT3"
        - "https://dlmf.nist.gov/10.25#E2"
@@ -7757,7 +7757,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-bessel-function-of-second-kind($a1)'><mi>K</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/10#PT3"
        - "https://dlmf.nist.gov/10.25#E2"
@@ -7769,11 +7769,11 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>Ce</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Se</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Me</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Fe</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Ge</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-mathieu-function($a1)'><mi>Ce</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-mathieu-function($a1)'><mi>Se</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-mathieu-function($a1)'><mi>Me</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-mathieu-function($a1)'><mi>Fe</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-mathieu-function($a1)'><mi>Ge</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/28#PT4"
        - "https://dlmf.nist.gov/28.20#E3"
@@ -7807,7 +7807,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><msub><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='modified-struve-function($a1)'><mi>L</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModifiedStruveFunction.html"
        - "https://dlmf.nist.gov/11.2#E2"
@@ -7819,7 +7819,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='modular-discriminant($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ModularDiscriminant.html"
        - "https://en.wikipedia.org/wiki/Modular_form#The_modular_discriminant"
@@ -7845,7 +7845,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>μ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='moebius-function($a1)'><mi>μ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Moebius_function"
        - "https://en.wikipedia.org/wiki/M%C3%B6bius_function"
@@ -7869,7 +7869,7 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-       - "<math><mi>M</mi></math>"
+       - "<math><mi intent='moment'>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Moment.html"
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -7883,7 +7883,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>I</mi></math>"
+       - "<math><mi intent='moment-of-inertia'>I</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MomentofInertia.html"
        - "https://en.wikipedia.org/wiki/Moment_of_inertia"
@@ -7899,8 +7899,8 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-       - "<math><mi>p</mi></math>"
-       - "<math><mi>mip</mi></math>"
+       - "<math><mi intent='momentum'>p</mi></math>"
+       - "<math><mi intent='momentum'>mip</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Momentum"
        - "https://ncatlab.org/nlab/show/momentum"
@@ -7914,7 +7914,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mi>M</mi></math>"
+       - "<math><mi intent='monster-group'>M</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/MonsterGroup.html"
        - "https://en.wikipedia.org/wiki/Monster_group"
@@ -7928,7 +7928,7 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
+       - "<math><msup intent='moore-penrose-inverse($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse"
       alias:
@@ -7952,7 +7952,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorial analysis"
       comments:
-       - "<math><msub><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='motzkin-number($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
        - "<math><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
@@ -7979,7 +7979,7 @@ concepts:
       property: msup, mixfix
       area: "abstract algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mn>-1</mn></msup></math>"
+       - "<math><msup intent='multiplicative-inverse($a1)'><mi arg='a1'>X</mi><mn>-1</mn></msup></math>"
       notationa: "mrow 1 / $1"
       urls: 
        - "https://mathworld.wolfram.com/Inverse.html"
@@ -7997,8 +7997,8 @@ concepts:
       property: "indexed function"
       area: "modular arithmetic"
       comments:
-       - "<math><msub><mi>O</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>ord</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='multiplicative-order($a1)'><mi>O</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='multiplicative-order($a1)'><mi>ord</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/MultiplicativeOrder.html"
        - "https://en.wikipedia.org/wiki/Multiplicative_order"
@@ -8040,7 +8040,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msub><mi>𝒩</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='multivariate-gaussian-distribution($a1)'><mi>𝒩</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Multivariate_normal_distribution"
       alias:
@@ -8069,7 +8069,7 @@ concepts:
       property: function
       area: "information theory"
       comments:
-       - "<math><mrow><mi>I</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='mutual-information($a1)'><mi>I</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MutualInformation.html"
        - "https://en.wikipedia.org/wiki/Mutual_information"
@@ -8106,7 +8106,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>NB</mi></math>"
+       - "<math><mi intent='negative-binomial-distribution'>NB</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/NegativeBinomialDistribution.html"
        - "https://en.wikipedia.org/wiki/Negative_binomial_distribution"
@@ -8118,7 +8118,7 @@ concepts:
       property: "indexed symbol"
       area: "probability theory"
       comments:
-       - "<math><mrow><mi>NHG</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='negative-hypergeometric-distribution($a1)'><mi>NHG</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution"
        - "https://www.encyclopediaofmath.org/index.php/Negative_hypergeometric_distribution"
@@ -8141,7 +8141,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='neighbourhood-filter($a1)'><mi>𝒩</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Neighbourhood_system"
       alias:
@@ -8154,7 +8154,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>NS</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='neron-severi-group($a1)'><mi>NS</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Neron-SeveriGroup.html"
        - "https://encyclopediaofmath.org/wiki/N%C3%A9ron-Severi_group"
@@ -8177,7 +8177,7 @@ concepts:
       property: function
       area: "category theory"
       comments:
-       - "<math><mrow><mi>N</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='nerve($a1)'><mi>N</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nerve.html"
        - "https://en.wikipedia.org/wiki/Nerve_(category_theory)"
@@ -8189,7 +8189,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>q</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='nome($a1)'><mi>q</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nome.html"
        - "https://en.wikipedia.org/wiki/Nome_(mathematics)"
@@ -8213,7 +8213,7 @@ concepts:
       property: infix
       area: "logic"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>↓</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='nor($a1,$a2)'><mi arg='a1'>X</mi><mo>↓</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Nor.html"
        - "https://mathworld.wolfram.com/NOR.html"
@@ -8226,7 +8226,7 @@ concepts:
       property: fenced
       area: "linear algebra"
       comments:
-       - "<math><mrow><mo>‖</mo><mi arg='a1'>x</mi><mo>‖</mo></mrow></math>"
+       - "<math><mrow intent='norm($a1)'><mo>‖</mo><mi arg='a1'>x</mi><mo>‖</mo></mrow></math>"
       notationa: "mrow | $1"
       urls: 
        - "https://mathworld.wolfram.com/Norm.html"
@@ -8241,7 +8241,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><msub><mi>N</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='normalizer($a1)'><mi>N</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Normalizer.html"
        - "https://en.wikipedia.org/wiki/Centralizer_and_normalizer"
@@ -8253,7 +8253,7 @@ concepts:
       property: infix
       area: "number theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∤</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='not-divisible-by($a1,$a2)'><mi arg='a1'>X</mi><mo>∤</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divisor"
     
@@ -8276,7 +8276,7 @@ concepts:
       property: fenced
       area: "SI units"
       comments:
-       - "<math><mrow><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='numerical-part($a1)'><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values"
     
@@ -8286,7 +8286,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-       - "<math><mrow><mi>Obj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='object($a1)'><mi>Obj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Object.html"
        - "https://en.wikipedia.org/wiki/Lattice-based_access_control"
@@ -8311,8 +8311,8 @@ concepts:
       property: symbol
       area: "compositional algebra"
       comments:
-       - "<math><mi>𝕆</mi></math>"
-       - "<math><mi>O</mi></math>"
+       - "<math><mi intent='octonions'>𝕆</mi></math>"
+       - "<math><mi intent='octonions'>O</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octonion.html"
        - "https://en.wikipedia.org/wiki/Octonion"
@@ -8327,7 +8327,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>OR</mi></math>"
+       - "<math><mi intent='odds-ratio'>OR</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Odds_ratio"
     
@@ -8337,7 +8337,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-       - "<math><mrow><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='onsager-machlup-function($a1)'><mi>L</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Onsager%E2%80%93Machlup_function"
        - "https://www.encyclopediaofmath.org/index.php/Onsager-Machlup_function"
@@ -8361,8 +8361,8 @@ concepts:
       property: fenced
       area: "algebra"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow><mo>]</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>[</mo></mrow></math>"
+       - "<math><mrow intent='open-interval($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='open-interval($a1,$a2)'><mo>]</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>[</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OpenInterval.html"
        - "https://dlmf.nist.gov/front/introduction#Sx4.p1.t1.r28"
@@ -8382,7 +8382,7 @@ concepts:
       property: msup
       area: "category theory,, group theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mi>op</mi></msup></math>"
+       - "<math><msup intent='opposite($a1)'><mi arg='a1'>X</mi><mi>op</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Opposite_category"
        - "https://ncatlab.org/nlab/show/opposite+category"
@@ -8397,7 +8397,7 @@ concepts:
       property: infix
       area: "physics"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⇅</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='opposite-charge($a1,$a2)'><mi arg='a1'>X</mi><mo>⇅</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4657"
     
@@ -8407,7 +8407,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='or-product($a1,$a2)'><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
       alias:
@@ -8421,7 +8421,7 @@ concepts:
       area: "group theory"
       comments:
        - "<math><mi>ord</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
+       - "<math><mrow intent='order-of-group($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
     
@@ -8431,7 +8431,7 @@ concepts:
       property: msup
       area: "lattice theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>⊥</mo></msup></math>"
+       - "<math><msup intent='orthocomplement($a1)'><mi arg='a1'>X</mi><mo>⊥</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complemented_lattice"
     
@@ -8441,7 +8441,7 @@ concepts:
       property: infix
       area: "geometry,, algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊥</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='orthogonal($a1,$a2)'><mi arg='a1'>X</mi><mo>⊥</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Orthogonal.html"
        - "https://en.1wikipedia.org/wiki/Orthogonal_functions"
@@ -8458,7 +8458,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>O</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='orthogonal-group($a1)'><mi>O</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OrthogonalGroup.html"
        - "https://en.wikipedia.org/wiki/Orthogonal_group"
@@ -8472,7 +8472,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi>Out</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='outer-automorphism-group($a1)'><mi>Out</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterAutomorphismGroup.html"
        - "https://en.wikipedia.org/wiki/Outer_automorphism_group"
@@ -8496,7 +8496,7 @@ concepts:
       property: infix
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='outer-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/OuterProduct.html"
        - "https://en.wikipedia.org/wiki/Outer_product"
@@ -8533,7 +8533,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='padovan-sequence($a1)'><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PadovanSequence.html"
        - "https://en.wikipedia.org/wiki/Padovan_sequence"
@@ -8556,7 +8556,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∥</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='parallel($a1,$a2)'><mi arg='a1'>X</mi><mo>∥</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Parallel.html"
        - "https://en.wikipedia.org/wiki/Parallel_(geometry)"
@@ -8594,7 +8594,7 @@ concepts:
       property: infix
       area: "number theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊢</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='partition($a1,$a2)'><mi arg='a1'>X</mi><mo>⊢</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Partition.html"
        - "https://mathworld.wolfram.com/FrequencyRepresentation.html"
@@ -8616,7 +8616,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>p</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='partition-function($a1)'><mi>p</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partition_(number_theory)"
     
@@ -8626,7 +8626,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><msub><mi>σ</mi><mi>G</mi></msub></math>"
+       - "<math><msub intent='pauli-matrix($a1)'><mi>σ</mi><mi>G</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PauliMatrices.html"
        - "https://mathworld.wolfram.com/PauliMatrix.html"
@@ -8639,7 +8639,7 @@ concepts:
       property: "indexed symbol"
       area: "fluid dynamics"
       comments:
-       - "<math><msub><mi>Pe</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='peclet-number($a1)'><mi>Pe</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/P%C3%A9clet_number"
        - "https://www.encyclopediaofmath.org/index.php/Peclet_number"
@@ -8651,7 +8651,7 @@ concepts:
       property: infix
       area: "logic"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>↓</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='peirce-arrow($a1,$a2)'><mi arg='a1'>X</mi><mo>↓</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Peirce_arrow"
     
@@ -8661,7 +8661,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><msub><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='pell-number($a1)'><mi>P</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PellNumber.html"
        - "https://en.wikipedia.org/wiki/Pell_number"
@@ -8672,7 +8672,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><msub><mi>Q</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='pell-luca-number($a1)'><mi>Q</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Pell-LucasNumber.html"
        - "https://en.wikipedia.org/wiki/Pell_number"
@@ -8693,7 +8693,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>perm</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='permanent($a1)'><mi>perm</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Permanent.html"
        - "https://en.wikipedia.org/wiki/Permanent"
@@ -8720,7 +8720,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⟂</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='perpendicular($a1,$a2)'><mi arg='a1'>X</mi><mo>⟂</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Perpendicular"
        - "https://www.encyclopediaofmath.org/index.php/Perpendicular"
@@ -8731,7 +8731,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='perrin-sequence($a1)'><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PerrinNumber.html"
        - "https://en.wikipedia.org/wiki/Perrin_number"
@@ -8757,7 +8757,7 @@ concepts:
       property: symbol
       area: "chemistry"
       comments:
-       - "<math><mi>pH</mi></math>"
+       - "<math><mi intent='ph'>pH</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/PH"
       alias:
@@ -8784,7 +8784,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>φ</mi></math>"
+       - "<math><mi intent='phi-coefficient'>φ</mi></math>"
       notationa: "msub r φ"
       urls: 
        - "https://en.wikipedia.org/wiki/Phi_coefficient"
@@ -8797,7 +8797,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Pic</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='picard-group($a1)'><mi>Pic</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PicardGroup.html"
        - "https://en.wikipedia.org/wiki/Picard_group"
@@ -8810,8 +8810,8 @@ concepts:
       property: constant
       area: "physics"
       comments:
-       - "<math><mi>h</mi></math>"
-       - "<math><mi>ℎ</mi></math>"
+       - "<math><mi intent='planck-constant'>h</mi></math>"
+       - "<math><mi intent='planck-constant'>ℎ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Planck_constant"
        - "https://ncatlab.org/nlab/show/Planck's+constant"
@@ -8823,8 +8823,8 @@ concepts:
       property: constant
       area: "geometry"
       comments:
-       - "<math><mi>P</mi></math>"
-       - "<math><mi>p</mi></math>"
+       - "<math><mi intent='plastic-constant'>P</mi></math>"
+       - "<math><mi intent='plastic-constant'>p</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PlasticConstant.html"
        - "https://en.wikipedia.org/wiki/Plastic_number"
@@ -8889,7 +8889,7 @@ concepts:
       property: fenced
       area: "classical mechanics"
       comments:
-       - "<math><mrow><mo>{</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='poisson-bracket($a1,$a2)'><mo>{</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PoissonBracket.html"
        - "https://en.wikipedia.org/wiki/Poisson_bracket"
@@ -8901,7 +8901,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>Pois</mi></math>"
+       - "<math><mi intent='poisson-distribution'>Pois</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PoissonDistribution.html"
        - "https://en.wikipedia.org/wiki/Poisson_distribution"
@@ -8914,7 +8914,7 @@ concepts:
       property: msup
       area: "functional analysis"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>°</mo></msup></math>"
+       - "<math><msup intent='polar-set($a1)'><mi arg='a1'>X</mi><mo>°</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -8937,7 +8937,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ψ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='polygamma-function($a1)'><mi>ψ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PolygammaFunction.html"
        - "https://en.wikipedia.org/wiki/Polygamma_function"
@@ -8961,7 +8961,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>Li</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='polylogarithm($a1)'><mi>Li</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Polylogarithm.html"
        - "https://en.wikipedia.org/wiki/Polylogarithm"
@@ -8985,7 +8985,7 @@ concepts:
       property: "indexed symbol"
       area: "differential topology"
       comments:
-       - "<math><msub><mi>p</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='pontryagin-class($a1)'><mi>p</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PontryaginClass.html"
        - "https://en.wikipedia.org/wiki/Pontryagin_class"
@@ -8998,7 +8998,7 @@ concepts:
       property: msup, msub
       area: "elementary mathematics"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
+       - "<math><msup intent='positive-part($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
       notationa: "msub $1 +"
       urls: 
        - "https://mathworld.wolfram.com/PositiveElement.html"
@@ -9048,7 +9048,7 @@ concepts:
       property: constant
       area: "topology"
       comments:
-       - "<math><msub><mi>R</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='preregular-space'><mi>R</mi><mn>1</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions)s"
     
@@ -9058,8 +9058,8 @@ concepts:
       property: symbol
       area: "economics"
       comments:
-       - "<math><mi>PV</mi></math>"
-       - "<math><mi>v</mi></math>"
+       - "<math><mi intent='present-value'>PV</mi></math>"
+       - "<math><mi intent='present-value'>v</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PresentValue.html"
        - "https://en.wikipedia.org/wiki/Present_value"
@@ -9070,8 +9070,8 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi>P</mi></math>"
-       - "<math><mi>ρ</mi></math>"
+       - "<math><mi intent='prime-constant'>P</mi></math>"
+       - "<math><mi intent='prime-constant'>ρ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeConstant.html"
        - "https://en.wikipedia.org/wiki/Prime_constant"
@@ -9084,7 +9084,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='prime-counting-function($a1)'><mi>π</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeCountingFunction.html"
     
@@ -9094,7 +9094,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><mrow><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='prime-difference-function($a1)'><mi>d</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeDifferenceFunction.html"
     
@@ -9127,7 +9127,7 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow><mi>Log</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='principal-value($a1)'><mi>Log</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Complex_logarithm#Principal_value"
     
@@ -9137,7 +9137,7 @@ concepts:
       property: "indexed function"
       area: "probability theory"
       comments:
-       - "<math><mrow><mi>plim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='probability-limit($a1)'><mi>plim</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Convergence_of_random_variables#Convergence_in_probability"
       alias:
@@ -9170,7 +9170,7 @@ concepts:
       property: function
       area: "projective geometry"
       comments:
-       - "<math><mrow><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='projective-line($a1)'><mi>P</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Projective_line"
        - "https://ncatlab.org/nlab/show/projective+line"
@@ -9181,7 +9181,7 @@ concepts:
       property: symbol
       area: "projective geometry"
       comments:
-       - "<math><mi>ℙ</mi></math>"
+       - "<math><mi intent='projective-space'>ℙ</mi></math>"
       notationa: "mi ℝ⁢ ℙ"
       urls: 
        - "https://mathworld.wolfram.com/ProjectiveSpace.html"
@@ -9198,7 +9198,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>&lt;</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='proper-subgroup($a1,$a2)'><mi arg='a1'>X</mi><mo>&lt;</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Subgroup"
     
@@ -9208,8 +9208,8 @@ concepts:
       property: infix
       area: "arithmetic"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∝</mo><mi arg='a2'>Y</mi></mrow></math>"
-       - "<math><mrow><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='proportional($a1,$a2)'><mi arg='a1'>X</mi><mo>∝</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='proportional($a1,$a2)'><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Proportional.html"
        - "https://en.wikipedia.org/wiki/Proportionality_(mathematics)"
@@ -9223,7 +9223,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><mi>τ</mi></math>"
+       - "<math><mi intent='prouhet-thue-morse-constant'>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Prouhet%E2%80%93Thue%E2%80%93Morse_constant"
     
@@ -9256,7 +9256,7 @@ concepts:
       property: fenced
       area: "lie algebra"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='pseudo-inner-product($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://youtu.be/mJ8ZDdA10GY?t=870"
     
@@ -9266,7 +9266,7 @@ concepts:
       property: symbol
       area: "differential geometry"
       comments:
-       - "<math><msup><mi>φ</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='pullback'><mi>φ</mi><mo>*</mo></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Pullback_(differential_geometry)"
     
@@ -9276,7 +9276,7 @@ concepts:
       property: infix
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='pushforward($a1,$a2)'><mi arg='a1'>X</mi><mo>*</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://youtu.be/mJ8ZDdA10GY?t=2555"
        - "https://en.wikipedia.org/wiki/Pushforward_(differential)"
@@ -9370,7 +9370,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='quotient-group($a1,$a2)'><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/QuotientGroup.html"
        - "https://ncatlab.org/nlab/show/quotient+group"
@@ -9382,7 +9382,7 @@ concepts:
       property: infix
       area: "topology"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='quotient-space($a1,$a2)'><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/QuotientSpace.html"
        - "https://en.wikipedia.org/wiki/Quotient_space_(topology)"
@@ -9398,7 +9398,7 @@ concepts:
       property: symbol
       area: "complexity theory"
       comments:
-       - "<math><mi>R</mi></math>"
+       - "<math><mi intent='r-complexity-class'>R</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/R.html"
        - "https://en.wikipedia.org/wiki/R_(complexity)"
@@ -9410,7 +9410,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>R</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='racah-polynomial($a1)'><mi>R</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RacahPolynomial.html"
        - "https://en.wikipedia.org/wiki/Racah_polynomials"
@@ -9435,7 +9435,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>rad</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='radical($a1)'><mi>rad</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Radical.html"
        - "https://en.wikipedia.org/wiki/Radical_of_a_Lie_algebra"
@@ -9451,8 +9451,8 @@ concepts:
       area: "geometry"
       comments:
        - "<math><mi arg='a1'>x</mi></math>"
-       - "<math><mi>r</mi></math>"
-       - "<math><mi>s</mi></math>"
+       - "<math><mi intent='radius-vector'>r</mi></math>"
+       - "<math><mi intent='radius-vector'>s</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RadiusVector.html"
        - "https://en.wikipedia.org/wiki/Position_(vector)"
@@ -9468,7 +9468,7 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><msub><mi>c</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='ramanujan-sum($a1)'><mi>c</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansSum.html"
        - "https://dlmf.nist.gov/27.10#E4"
@@ -9480,7 +9480,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='ramanujan-tau-function($a1)'><mi>τ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamanujansTauFunction.html"
        - "https://en.wikipedia.org/wiki/Ramanujan_tau_function"
@@ -9492,7 +9492,7 @@ concepts:
       property: constant
       area: "special functions"
       comments:
-       - "<math><mi>μ</mi></math>"
+       - "<math><mi intent='ramanujan-soldner-constant'>μ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ramanujan-SoldnerConstant.html"
        - "https://en.wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant"
@@ -9506,7 +9506,7 @@ concepts:
       property: msub
       area: "algebraic number theory"
       comments:
-       - "<math><msub><mi>e</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='ramification-index($a1)'><mi>e</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamificationIndex.html"
        - "https://en.wikipedia.org/wiki/Ramification_(mathematics)#In_algebraic_number_theory"
@@ -9517,7 +9517,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='ramsey-number($a1)'><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RamseyNumber.html"
        - "https://www.encyclopediaofmath.org/index.php/Ramsey_number"
@@ -9581,7 +9581,7 @@ concepts:
       property: msup
       area: "functional analysis"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mi>r</mi></msup></math>"
+       - "<math><msup intent='real-polar($a1)'><mi arg='a1'>X</mi><mi>r</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Polar_set"
        - "https://en.wikipedia.org/wiki/Polar_set_(potential_theory)"
@@ -9593,7 +9593,7 @@ concepts:
       property: function
       area: "convex analysis"
       comments:
-       - "<math><mrow><mi>recc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='recession-cone($a1)'><mi>recc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Recession_cone"
     
@@ -9603,8 +9603,8 @@ concepts:
       property: msup
       area: "algebra"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
-       - "<math><msup><mi arg='a1'>X</mi><mi>R</mi></msup></math>"
+       - "<math><msup intent='reciprocal-polynomial($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='reciprocal-polynomial($a1)'><mi arg='a1'>X</mi><mi>R</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/ReciprocalPolynomial.html"
        - "https://en.wikipedia.org/wiki/Reciprocal_polynomial"
@@ -9617,7 +9617,7 @@ concepts:
       property: function
       area: "euclidean geometry"
       comments:
-       - "<math><mrow><mi>r</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='rectification($a1)'><mi>r</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rectification.html"
        - "https://en.wikipedia.org/wiki/Rectification_(geometry)"
@@ -9629,7 +9629,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>Σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='reduced-suspension($a1)'><mi>Σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
     
@@ -9639,7 +9639,7 @@ concepts:
       property: "indexed function"
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='relative-homology($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Relative_homology"
        - "https://ncatlab.org/nlab/show/relative+homology"
@@ -9651,7 +9651,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='repunit($a1)'><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Repunit.html"
        - "https://en.wikipedia.org/wiki/Repunit"
@@ -9687,7 +9687,7 @@ concepts:
       property: function
       area: "set theory"
       comments:
-       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='resolvent-set($a1)'><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Resolvent_set"
        - "https://www.encyclopediaofmath.org/index.php/Resolvent_set"
@@ -9752,7 +9752,7 @@ concepts:
       property: infix
       area: "logic"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>→</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='rewrite-rule($a1,$a2)'><mi arg='a1'>X</mi><mo>→</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Semi-Thue_system"
       alias:
@@ -9764,7 +9764,7 @@ concepts:
       property: symbol
       area: "fluid dynamics"
       comments:
-       - "<math><mi>Re</mi></math>"
+       - "<math><mi intent='reynolds-number'>Re</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Reynolds_number"
     
@@ -9774,9 +9774,9 @@ concepts:
       property: symbol
       area: "riemannian geometry"
       comments:
-       - "<math><mi>S</mi></math>"
-       - "<math><mi>R</mi></math>"
-       - "<math><mi>Sc</mi></math>"
+       - "<math><mi intent='ricci-scalar'>S</mi></math>"
+       - "<math><mi intent='ricci-scalar'>R</mi></math>"
+       - "<math><mi intent='ricci-scalar'>Sc</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciScalar.html"
        - "https://en.wikipedia.org/wiki/Scalar_curvature"
@@ -9789,7 +9789,7 @@ concepts:
       property: "indexed symbol"
       area: "riemannian geometry"
       comments:
-       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='ricci-tensor($a1)'><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RicciTensor.html"
        - "https://www.encyclopediaofmath.org/index.php/Ricci_tensor"
@@ -9817,7 +9817,7 @@ concepts:
       comments:
        - "<math><mover><mi>ℂ</mi><mo>^</mo></mover></math>"
        - "<math><mover><mi>ℂ</mi><mo>¯</mo></mover></math>"
-       - "<math><msub><mi>ℂ</mi><mo>∞</mo></msub></math>"
+       - "<math><msub intent='riemann-sphere($a1)'><mi>ℂ</mi><mo>∞</mo></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannSphere.html"
        - "https://en.wikipedia.org/wiki/Riemann_sphere"
@@ -9833,7 +9833,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>θ⁡</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='riemann-theta-function($a1)'><mi>θ⁡</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannThetaFunction.html"
        - "https://dlmf.nist.gov/21.2#i"
@@ -9845,7 +9845,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='riemann-zeta-function($a1)'><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannZetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%96(x)"
@@ -9861,7 +9861,7 @@ concepts:
       property: "indexed function"
       area: "riemannian geometry"
       comments:
-       - "<math><mrow><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='riemann-christoffel-tensor($a1)'><mi>R</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Riemann-ChristoffelTensor.html"
        - "https://en.wikipedia.org/wiki/Riemann_curvature_tensor"
@@ -9906,7 +9906,7 @@ concepts:
       property: operator
       area: "calculus"
       comments:
-       - "<math><msub><mo>∂</mo><mo>+</mo></msub></math>"
+       - "<math><msub intent='right-derivative($a1)'><mo>∂</mo><mo>+</mo></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
     
@@ -9916,7 +9916,7 @@ concepts:
       property: infix
       area: "formal languages"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>\\</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='right-quotient($a1,$a2)'><mi arg='a1'>X</mi><mo>\\</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Quotient_of_a_formal_language"
     
@@ -9954,14 +9954,14 @@ concepts:
       area: "number theory"
       comments:
        - "<math><mi mathvariant='normal'>i</mi></math>"
-       - "<math><mi>ii</mi></math>"
-       - "<math><mi>iii</mi></math>"
-       - "<math><mi>iv</mi></math>"
-       - "<math><mi>v</mi></math>"
-       - "<math><mi>vi</mi></math>"
-       - "<math><mi>vii</mi></math>"
-       - "<math><mi>viii</mi></math>"
-       - "<math><mi>ix</mi></math>"
+       - "<math><mi intent='roman-numeral'>ii</mi></math>"
+       - "<math><mi intent='roman-numeral'>iii</mi></math>"
+       - "<math><mi intent='roman-numeral'>iv</mi></math>"
+       - "<math><mi intent='roman-numeral'>v</mi></math>"
+       - "<math><mi intent='roman-numeral'>vi</mi></math>"
+       - "<math><mi intent='roman-numeral'>vii</mi></math>"
+       - "<math><mi intent='roman-numeral'>viii</mi></math>"
+       - "<math><mi intent='roman-numeral'>ix</mi></math>"
        - "<math><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RomanNumerals.html"
@@ -9988,7 +9988,7 @@ concepts:
       property: symbol
       area: "complex numbers"
       comments:
-       - "<math><mi>ω</mi></math>"
+       - "<math><mi intent='root-of-unity'>ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RootofUnity.html"
        - "https://en.wikipedia.org/wiki/Root_of_unity"
@@ -10012,7 +10012,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='rooted-product-of-graphs($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Rooted_product_of_graphs"
     
@@ -10022,7 +10022,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>Ru</mi></math>"
+       - "<math><mi intent='ruark-number'>Ru</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Euler_number_(physics)"
     
@@ -10032,7 +10032,7 @@ concepts:
       property: constant
       area: "set theory"
       comments:
-       - "<math><mi>S</mi></math>"
+       - "<math><mi intent='s-set-theory'>S</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/S_(set_theory)"
     
@@ -10051,9 +10051,9 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>S</mi></math>"
-       - "<math><mi>Ω</mi></math>"
-       - "<math><mi>U</mi></math>"
+       - "<math><mi intent='sample-space'>S</mi></math>"
+       - "<math><mi intent='sample-space'>Ω</mi></math>"
+       - "<math><mi intent='sample-space'>U</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SampleSpace.html"
        - "https://en.wikipedia.org/wiki/Sample_space"
@@ -10110,7 +10110,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-       - "<math><msub><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='schroder-number($a1)'><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchroederNumber.html"
        - "https://en.wikipedia.org/wiki/Schr%C3%B6der_number"
@@ -10122,7 +10122,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='schur-multiplier($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchurMultiplier.html"
        - "https://en.wikipedia.org/wiki/Schur_multiplier"
@@ -10136,8 +10136,8 @@ concepts:
       property: symbol
       area: "topology"
       comments:
-       - "<math><mi>𝒮</mi></math>"
-       - "<math><mi>S</mi></math>"
+       - "<math><mi intent='schwartz-space'>𝒮</mi></math>"
+       - "<math><mi intent='schwartz-space'>S</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SchwartzSpace.html"
        - "https://en.wikipedia.org/wiki/Schwartz_space"
@@ -10149,7 +10149,7 @@ concepts:
       property: fenced, mixfix
       area: "complex analysis"
       comments:
-       - "<math><mrow><mo>{</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='schwarzian-derivative($a1,$a2)'><mo>{</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>}</mo></mrow></math>"
       notationa: "mrow ( S $1 ) ($2"
       urls: 
        - "https://mathworld.wolfram.com/SchwarzianDerivative.html"
@@ -10186,7 +10186,7 @@ concepts:
       property: symbol
       area: "abstract algebra"
       comments:
-       - "<math><mi>𝕊</mi></math>"
+       - "<math><mi intent='sedenion'>𝕊</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sedenion"
        - "https://ncatlab.org/nlab/show/sedenion"
@@ -10230,7 +10230,7 @@ concepts:
       property: symbol
       area: "information theory"
       comments:
-       - "<math><mi>H</mi></math>"
+       - "<math><mi intent='shannon-entropy'>H</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShannonEntropy.html"
        - "https://en.wikipedia.org/wiki/Entropy_(information_theory)"
@@ -10259,7 +10259,7 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-       - "<math><mrow><mi>Sh</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='shimura-variety($a1)'><mi>Sh</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Shimura_variety"
        - "https://ncatlab.org/nlab/show/Shimura+variety"
@@ -10282,7 +10282,7 @@ concepts:
       property: symbol
       area: "mathematical finance"
       comments:
-       - "<math><msub><mi>r</mi><mi>t</mi></msub></math>"
+       - "<math><msub intent='short-rate'><mi>r</mi><mi>t</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Short_rate"
        - "https://en.wikipedia.org/wiki/Short-rate_model"
@@ -10295,7 +10295,7 @@ concepts:
       property: symbol
       area: "combinatorics"
       comments:
-       - "<math><mi>A</mi></math>"
+       - "<math><mi intent='sidon-sequence'>A</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SidonSequence.html"
        - "https://en.wikipedia.org/wiki/Sidon_sequence"
@@ -10308,7 +10308,7 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow><mi>sgn</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sign-function($a1)'><mi>sgn</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Sign_function"
       alias:
@@ -10320,7 +10320,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mrow><mi>sign</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='signature-of-permutation($a1)'><mi>sign</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/signature+of+a+permutation"
       alias:
@@ -10332,7 +10332,7 @@ concepts:
       property: constant
       area: "number theory"
       comments:
-       - "<math><msub><mi>δ</mi><mi>S</mi></msub></math>"
+       - "<math><msub intent='silver-ratio'><mi>δ</mi><mi>S</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SilverRatio.html"
        - "https://en.wikipedia.org/wiki/Silver_ratio"
@@ -10344,7 +10344,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='similar($a1,$a2)'><mi arg='a1'>X</mi><mo>~</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Similar.html"
        - "https://en.wikipedia.org/wiki/Matrix_similarity"
@@ -10381,7 +10381,7 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow><mi>Si</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sine-integral($a1)'><mi>Si</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SineIntegral.html"
        - "https://dlmf.nist.gov/6.2#ii"
@@ -10394,7 +10394,7 @@ concepts:
       property: symbol
       area: "statistics"
       comments:
-       - "<math><mi>α</mi></math>"
+       - "<math><mi intent='size-of-test'>α</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Size_(statistics)"
     
@@ -10404,7 +10404,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>Sk</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='skewes-number($a1)'><mi>Sk</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SkewesNumber.html"
        - "https://en.wikipedia.org/wiki/Skewes%27_number"
@@ -10415,7 +10415,7 @@ concepts:
       property: prefix
       area: "complexity"
       comments:
-       - "<math><mrow><mi>o</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='small-o($a1)'><mi>o</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
        - "https://mathworld.wolfram.com/o.html"
@@ -10426,7 +10426,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='smith-number($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SmithNumber.html"
        - "https://en.wikipedia.org/wiki/Smith_number"
@@ -10449,7 +10449,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>soc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='socle($a1)'><mi>soc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Socle.html"
        - "https://en.wikipedia.org/wiki/Socle_(mathematics)"
@@ -10462,7 +10462,7 @@ concepts:
       property: symbol
       area: "complexity theory"
       comments:
-       - "<math><mi>Õ</mi></math>"
+       - "<math><mi intent='soft-o'>Õ</mi></math>"
       urls: 
       alias:
        - Extensions_to_the_Bachmann–Landau_notations
@@ -10473,7 +10473,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mi>Ω</mi></math>"
+       - "<math><mi intent='solid-angle'>Ω</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SolidAngle.html"
        - "https://en.wikipedia.org/wiki/Solid_angle"
@@ -10485,7 +10485,7 @@ concepts:
       property: unit
       area: "imperial units"
       comments:
-       - "<math><mrow><mi>span</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='span($a1)'><mi>span</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(unit)"
     
@@ -10495,7 +10495,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-       - "<math><msub><mi>SL</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='special-linear-group($a1)'><mi>SL</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialLinearGroup.html"
        - "https://en.wikipedia.org/wiki/Special_linear_group"
@@ -10508,7 +10508,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-       - "<math><mrow><mi>SO</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='special-orthogonal-group($a1)'><mi>SO</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialOrthogonalGroup.html"
        - "https://ncatlab.org/nlab/show/special+orthogonal+group"
@@ -10519,7 +10519,7 @@ concepts:
       property: function
       area: "lie groups"
       comments:
-       - "<math><mrow><mi>SU</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='special-unitary-group($a1)'><mi>SU</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpecialUnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Special_unitary_group"
@@ -10531,7 +10531,7 @@ concepts:
       property: function
       area: "spectral theory"
       comments:
-       - "<math><mrow><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='spectral-radius($a1)'><mi>ρ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpectralRadius.html"
        - "https://en.wikipedia.org/wiki/Spectral_radius"
@@ -10543,7 +10543,7 @@ concepts:
       property: function
       area: "functional analysis"
       comments:
-       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='spectrum($a1)'><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_(functional_analysis)"
     
@@ -10553,7 +10553,7 @@ concepts:
       property: symbol
       area: "category theory"
       comments:
-       - "<math><mi>Sp</mi></math>"
+       - "<math><mi intent='spectrum-category'>Sp</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Spectrum"
     
@@ -10563,7 +10563,7 @@ concepts:
       property: msub
       area: "linear algebra"
       comments:
-       - "<math><msub><mi>σ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='spectrum-of-matrix($a1)'><mi>σ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_matrix"
     
@@ -10582,7 +10582,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Spec</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='spectrum-of-ring($a1)'><mi>Spec</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spectrum_of_a_ring"
     
@@ -10615,7 +10615,7 @@ concepts:
       property: symbol
       area: "quantum mechanics"
       comments:
-       - "<math><mi>S</mi></math>"
+       - "<math><mi intent='spin-angular-momentum'>S</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -10625,7 +10625,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mi>Spin</mi></math>"
+       - "<math><mi intent='spin-group'>Spin</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/SpinGroup.html"
        - "https://en.wikipedia.org/wiki/Spin_group"
@@ -10638,7 +10638,7 @@ concepts:
       property: symbol
       area: "quantum mechanics"
       comments:
-       - "<math><mi>s</mi></math>"
+       - "<math><mi intent='spin-quantum-number'>s</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Spin_(physics)"
     
@@ -10659,8 +10659,8 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msub><mi>S</mi><mn>1</mn></msub></math>"
-       - "<math><msub><mi>S</mi><mn>2</mn></msub></math>"
+       - "<math><msub intent='stable-distribution'><mi>S</mi><mn>1</mn></msub></math>"
+       - "<math><msub intent='stable-distribution'><mi>S</mi><mn>2</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/StableDistribution.html"
        - "https://en.wikipedia.org/wiki/Stable_distribution"
@@ -10681,7 +10681,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><mi>σ</mi></math>"
+       - "<math><mi intent='standard-deviation'>σ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/StandardDeviation.html"
        - "https://en.wikipedia.org/wiki/Standard_deviation"
@@ -10719,7 +10719,7 @@ concepts:
       property: msub
       area: "commutative algebra"
       comments:
-       - "<math><msub><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='stanley-reisner-ideal($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
        - "https://www.encyclopediaofmath.org/index.php/Stanley-Reisner_ring"
@@ -10743,7 +10743,7 @@ concepts:
       property: function
       area: "formal languages"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='star-height($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_height"
     
@@ -10753,7 +10753,7 @@ concepts:
       property: function
       area: "k-theory"
       comments:
-       - "<math><mrow><mi>St</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='steinberg-group($a1)'><mi>St</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Group_of_Lie_type"
        - "https://en.wikipedia.org/wiki/Steinberg_group_(K-theory)"
@@ -10776,7 +10776,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='stiefel-whitney-class($a1)'><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stiefel-WhitneyClass.html"
        - "https://en.wikipedia.org/wiki/Stiefel%E2%80%93Whitney_class"
@@ -10790,7 +10790,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='stieltjes-wigert-polynomial($a1)'><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Stieltjes-WigertPolynomial.html"
        - "https://en.wikipedia.org/wiki/Stieltjes%E2%80%93Wigert_polynomials"
@@ -10802,7 +10802,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='stirling-number-of-first-kind($a1)'><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind"
@@ -10814,7 +10814,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='stirling-number-of-second-kind($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StirlingNumberoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_second_kind"
@@ -10826,7 +10826,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='strength-of-a-graph($a1)'><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Strength_of_a_graph"
       alias:
@@ -10848,7 +10848,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊠</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='strong-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⊠</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/w/index.php?title=Graph_product"
       alias:
@@ -10861,7 +10861,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='struve-function($a1)'><mi>H</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/StruveFunction.html"
        - "https://en.wikipedia.org/wiki/Struve_function"
@@ -10875,7 +10875,7 @@ concepts:
       property: function
       area: "field theory"
       comments:
-       - "<math><mrow><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='stufe($a1)'><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stufe_(algebra)"
     
@@ -10898,7 +10898,7 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≤</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='subgroup($a1,$a2)'><mi arg='a1'>X</mi><mo>≤</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Subgroup.html"
        - "https://en.wikipedia.org/wiki/Subgroup"
@@ -10911,7 +10911,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≻</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='succeeds($a1,$a2)'><mi arg='a1'>X</mi><mo>≻</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Succeeds.html"
        - "https://en.wikipedia.org/wiki/Ordered_set_operators"
@@ -10922,7 +10922,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≽</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='succeeds-or-equals($a1,$a2)'><mi arg='a1'>X</mi><mo>≽</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Ordered_set_operators"
     
@@ -10932,7 +10932,7 @@ concepts:
       property: "function, msup"
       area: "number theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
+       - "<math><msup intent='successor($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
        - "<math><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
        - "<math><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
@@ -10958,7 +10958,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>+</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='sumset($a1,$a2)'><mi arg='a1'>X</mi><mo>+</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Sumset.html"
        - "https://en.wikipedia.org/wiki/Sumset"
@@ -10982,7 +10982,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mrow><mi>supp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='support($a1)'><mi>supp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Support.html"
        - "https://en.wikipedia.org/wiki/Support_(mathematics)"
@@ -11053,7 +11053,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='suspension($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Suspension.html"
        - "https://en.wikipedia.org/wiki/Suspension_(topology)"
@@ -11093,9 +11093,9 @@ concepts:
       property: "msub, function, postfix"
       area: "group theory"
       comments:
-       - "<math><msub><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>𝔖</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><msub><mi>Σ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='symmetric-group($a1)'><mi>S</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='symmetric-group($a1)'><mi>𝔖</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='symmetric-group($a1)'><mi>Σ</mi><mi arg='a1'>x</mi></msub></math>"
       notationd: "mrow Σ ( $1 )"
       notationc: "mrow Sym ( $1 )"
       notationb: "mrow $1 !"
@@ -11111,7 +11111,7 @@ concepts:
       property: constant
       area: "topology"
       comments:
-       - "<math><msub><mi>R</mi><mn>0</mn></msub></math>"
+       - "<math><msub intent='symmetric-space'><mi>R</mi><mn>0</mn></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Separation_axiom#Main_definitions)s"
     
@@ -11121,7 +11121,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Sp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='symplectic-group($a1)'><mi>Sp</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymplecticGroup.html"
        - "https://en.wikipedia.org/wiki/Symplectic_group"
@@ -11135,7 +11135,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><msub><mi>ϕ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='szego-polynomial($a1)'><mi>ϕ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Szeg%C5%91_polynomial"
        - "https://www.encyclopediaofmath.org/index.php/Szego_polynomial"
@@ -11147,7 +11147,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='tangent-bundle($a1)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentBundle.html"
        - "https://en.wikipedia.org/wiki/Tangent_bundle"
@@ -11160,7 +11160,7 @@ concepts:
       property: "indexed function"
       area: "topology"
       comments:
-       - "<math><msub><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='tangent-space($a1)'><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TangentSpace.html"
        - "https://en.wikipedia.org/wiki/Tangent_space"
@@ -11172,7 +11172,7 @@ concepts:
       property: symbol
       area: "analytic geometry"
       comments:
-       - "<math><msub><mi>T</mi><mi>n</mi></msub></math>"
+       - "<math><msub intent='tate-algebra'><mi>T</mi><mi>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tate_algebra"
        - "https://ncatlab.org/nlab/show/Tate+algebra"
@@ -11184,7 +11184,7 @@ concepts:
       property: "indexed function"
       area: "group theory"
       comments:
-       - "<math><msub><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='tate-module($a1)'><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tate_module"
        - "https://ncatlab.org/nlab/show/Tate+module"
@@ -11196,7 +11196,7 @@ concepts:
       property: symbol
       area: "particle physics"
       comments:
-       - "<math><mi>τ</mi></math>"
+       - "<math><mi intent='tau-particle'>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tau_(particle)"
     
@@ -11206,7 +11206,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='taxicab-number($a1)'><mi>Ta</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaxicabNumber.html"
        - "https://en.wikipedia.org/wiki/Taxicab_number"
@@ -11217,7 +11217,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>Ta</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='taylor-polynomial($a1)'><mi>Ta</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TaylorPolynomial.html"
        - "https://en.wikipedia.org/wiki/Taylor%27s_theorem"
@@ -11229,7 +11229,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='teichmuller-space($a1)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TeichmuellerSpace.html"
        - "https://en.wikipedia.org/wiki/Teichm%C3%BCller_space"
@@ -11241,7 +11241,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>T</mi></math>"
+       - "<math><mi intent='temperature'>T</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Temperature.html"
        - "https://en.wikipedia.org/wiki/Temperature"
@@ -11264,7 +11264,7 @@ concepts:
       property: infix
       area: "algebra"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='tensor-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⊗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TensorProduct.html"
        - "https://en.wikipedia.org/wiki/Tensor_product"
@@ -11278,7 +11278,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='tensor-product-of-graphs($a1,$a2)'><mi arg='a1'>X</mi><mo>×</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_product_of_graphs"
       alias:
@@ -11303,7 +11303,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><msub><mi>θ</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='theta-function($a1)'><mi>θ</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/ThetaFunction.html"
        - "https://en.wikipedia.org/wiki/Theta_function"
@@ -11318,7 +11318,7 @@ concepts:
       property: function
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='thom-space($a1)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Thom_space"
        - "https://ncatlab.org/nlab/show/Thom+space"
@@ -11330,7 +11330,7 @@ concepts:
       property: symbol
       area: "group theory"
       comments:
-       - "<math><mi>Th</mi></math>"
+       - "<math><mi intent='thompson-group'>Th</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/ThompsonGroup.html"
        - "https://en.wikipedia.org/wiki/Thompson_groups"
@@ -11365,7 +11365,7 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='topological-entropy($a1)'><mi>h</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TopologicalEntropy.html"
        - "https://en.wikipedia.org/wiki/Topological_entropy"
@@ -11388,7 +11388,7 @@ concepts:
       property: symbol
       area: "mechanics"
       comments:
-       - "<math><mi>τ</mi></math>"
+       - "<math><mi intent='torque'>τ</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torque"
     
@@ -11398,7 +11398,7 @@ concepts:
       property: symbol
       area: "differential geometry"
       comments:
-       - "<math><mi>τ</mi></math>"
+       - "<math><mi intent='torsion'>τ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Torsion.html"
        - "https://en.wikipedia.org/wiki/Torsion_of_a_curve"
@@ -11411,7 +11411,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='torsion-submodule($a1)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_(algebra)"
     
@@ -11421,7 +11421,7 @@ concepts:
       property: msub
       area: "group theory"
       comments:
-       - "<math><msub><mi>G</mi><mi>T</mi></msub></math>"
+       - "<math><msub intent='torsion-subgroup($a1)'><mi>G</mi><mi>T</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_subgroup"
        - "https://ncatlab.org/nlab/show/torsion+subgroup"
@@ -11432,7 +11432,7 @@ concepts:
       property: function
       area: "differential geometry"
       comments:
-       - "<math><mrow><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='torsion-tensor($a1)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_tensor"
     
@@ -11455,7 +11455,7 @@ concepts:
       property: fenced
       area: "measure theory"
       comments:
-       - "<math><mrow><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
+       - "<math><mrow intent='total-variation($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TotalVariation.html"
        - "https://en.wikipedia.org/wiki/Total_variation"
@@ -11467,7 +11467,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>tr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='trace($a1)'><mi>tr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trace_(linear_algebra)"
     
@@ -11477,7 +11477,7 @@ concepts:
       property: msup
       area: "set theory"
       comments:
-       - "<math><msup><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
+       - "<math><msup intent='transitive-closure($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/TransitiveClosure.html"
        - "https://en.wikipedia.org/wiki/Transitive_closure"
@@ -11517,7 +11517,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='triangular-number($a1)'><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TriangularNumber.html"
        - "https://en.wikipedia.org/wiki/Triangular_number"
@@ -11540,7 +11540,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>TM</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='trimean($a1)'><mi>TM</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trimean"
       alias:
@@ -11552,7 +11552,7 @@ concepts:
       property: infix
       area: "chemistry"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≡</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='triple-bond($a1,$a2)'><mi arg='a1'>X</mi><mo>≡</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Triple_bond"
     
@@ -11585,7 +11585,7 @@ concepts:
       property: function
       area: "numerical analysis"
       comments:
-       - "<math><mrow><mi>trunc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='truncation($a1)'><mi>trunc</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Truncation.html"
        - "https://en.wikipedia.org/wiki/Truncation"
@@ -11596,7 +11596,7 @@ concepts:
       property: msub
       area: "complex analysis"
       comments:
-       - "<math><msub><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='tube-domain($a1)'><mi>T</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tube_domain"
        - "https://www.encyclopediaofmath.org/index.php/Tube_domain"
@@ -11660,9 +11660,9 @@ concepts:
       property: symbol
       area: "topology"
       comments:
-       - "<math><msub><mi>T</mi><mn>3</mn></msub></math>"
-       - "<math><msub><mi>T</mi><mn>π</mn></msub></math>"
-       - "<math><msub><mi>T</mi><mn>3½</mn></msub></math>"
+       - "<math><msub intent='tychonoff-space'><mi>T</mi><mn>3</mn></msub></math>"
+       - "<math><msub intent='tychonoff-space'><mi>T</mi><mn>π</mn></msub></math>"
+       - "<math><msub intent='tychonoff-space'><mi>T</mi><mn>3½</mn></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/TychonoffSpace.html"
        - "https://en.wikipedia.org/wiki/Tychonoff_space"
@@ -11684,7 +11684,7 @@ concepts:
       property: "indexed symbol"
       area: "integer sequences"
       comments:
-       - "<math><msub><mi>U</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='ulam-number($a1)'><mi>U</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/UlamNumber.html"
        - "https://en.wikipedia.org/wiki/Ulam_number"
@@ -11695,7 +11695,7 @@ concepts:
       property: mixfix
       area: "abstract algebra"
       comments:
-       - "<math><mrow><mo>∏</mo><mi arg='a1'>x</mi><mo>/</mo><mi arg='a2'>y</mi></mrow></math>"
+       - "<math><mrow intent='ultrapower($a1,$a2)'><mo>∏</mo><mi arg='a1'>x</mi><mo>/</mo><mi arg='a2'>y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ultrapower.html"
        - "https://en.wikipedia.org/wiki/Ultraproduct"
@@ -11730,7 +11730,7 @@ concepts:
       property: fenced
       area: "SI units"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='unit-part($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values"
        - "https://physics.stackexchange.com/questions/77690/square-bracket-notation-for-dimensions-and-units-usage-and-conventions"
@@ -11752,7 +11752,7 @@ concepts:
       property: "indexed symbol"
       area: "group theory"
       comments:
-       - "<math><msub><mi>U</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='unitary-group($a1)'><mi>U</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/UnitaryGroup.html"
        - "https://en.wikipedia.org/wiki/Unitary_group"
@@ -11765,7 +11765,7 @@ concepts:
       property: constant
       area: "physics"
       comments:
-       - "<math><mi>R</mi></math>"
+       - "<math><mi intent='universal-gas-constant'>R</mi></math>"
       notationa: "mover R -"
       urls: 
        - "https://en.wikipedia.org/wiki/Gas_constant"
@@ -11780,7 +11780,7 @@ concepts:
       property: constant
       area: "geometry"
       comments:
-       - "<math><mi>P</mi></math>"
+       - "<math><mi intent='universal-parabolic-constant'>P</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/UniversalParabolicConstant.html"
        - "https://en.wikipedia.org/wiki/Universal_parabolic_constant"
@@ -11791,9 +11791,9 @@ concepts:
       property: symbol
       area: "set theory"
       comments:
-       - "<math><mi>V</mi></math>"
-       - "<math><mi>U</mi></math>"
-       - "<math><mi>ξ</mi></math>"
+       - "<math><mi intent='universal-set'>V</mi></math>"
+       - "<math><mi intent='universal-set'>U</mi></math>"
+       - "<math><mi intent='universal-set'>ξ</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/UniversalSet.html"
        - "https://en.wikipedia.org/wiki/Universal_set"
@@ -11818,7 +11818,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>≈</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='unnatural-isomorphism($a1,$a2)'><mi arg='a1'>X</mi><mo>≈</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Isomorphism#Relation_with_equality"
     
@@ -11874,7 +11874,7 @@ concepts:
       property: symbol
       area: "complex analysis"
       comments:
-       - "<math><mi>ℍ</mi></math>"
+       - "<math><mi intent='upper-half-plane'>ℍ</mi></math>"
       notationa: "msup ℍ +"
       urls: 
        - "https://mathworld.wolfram.com/UpperHalf-Plane.html"
@@ -11896,7 +11896,7 @@ concepts:
       property: function
       area: "statistics"
       comments:
-       - "<math><mrow><mi>Var</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='variance($a1)'><mi>Var</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Variance"
       alias:
@@ -11908,7 +11908,7 @@ concepts:
       property: "indexed symbol"
       area: "category theory"
       comments:
-       - "<math><msub><mi>Vect</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='vect($a1)'><mi>Vect</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/Vect"
     
@@ -11930,7 +11930,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>proj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='vector-projection($a1)'><mi>proj</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vector_projection"
       alias:
@@ -11943,7 +11943,7 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow><mi>vec</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='vectorization($a1)'><mi>vec</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Vectorization_(mathematics)"
        - "https://en.wikipedia.org/wiki/Vectorization_(parallel_computing)"
@@ -11978,7 +11978,7 @@ concepts:
       property: infix
       area: "category theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='vertical-composition($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/vertical+composition"
        - "https://proofwiki.org/wiki/Definition: Vertical_Composition_of_Natural_Transformations"
@@ -11998,7 +11998,7 @@ concepts:
       property: symbol
       area: "physics"
       comments:
-       - "<math><mi>V</mi></math>"
+       - "<math><mi intent='volume'>V</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Volume.html"
        - "https://en.wikipedia.org/wiki/Volume_(compression)"
@@ -12014,7 +12014,7 @@ concepts:
       property: symbol
       area: "measure theory"
       comments:
-       - "<math><mi>d</mi><mi>V</mi></math>"
+       - "<math><mi intent='volume-element'>d</mi><mi>V</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/VolumeElement.html"
        - "https://en.wikipedia.org/wiki/Volume_element"
@@ -12025,7 +12025,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='walsh-function($a1)'><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WalshFunction.html"
        - "https://en.wikipedia.org/wiki/Walsh_function"
@@ -12087,7 +12087,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>℘</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='weierstrass-elliptic-function($a1)'><mi>℘</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassEllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Weierstrass%27s_elliptic_functions"
@@ -12101,7 +12101,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='weierstrass-sigma-function($a1)'><mi>σ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassSigmaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -12114,7 +12114,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='weierstrass-zeta-function($a1)'><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeierstrassZetaFunction.html"
        - "https://dlmf.nist.gov/23.1"
@@ -12127,7 +12127,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>wt</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='weight($a1)'><mi>wt</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Weight_(strings)"
        - "https://ncatlab.org/nlab/show/weight"
@@ -12149,7 +12149,7 @@ concepts:
       property: fenced
       area: "special functions"
       comments:
-       - "<math><mrow><mo>⟨</mo><mi arg='a1'>x</mi><mo>⟩</mo></mrow></math>"
+       - "<math><mrow intent='weighted-mean($a1)'><mo>⟨</mo><mi arg='a1'>x</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeightedMean.html"
        - "https://en.wikipedia.org/wiki/Weighted_arithmetic_mean"
@@ -12163,7 +12163,7 @@ concepts:
       property: "indexed symbol"
       area: "graph theory"
       comments:
-       - "<math><msub><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='wheel-graph($a1)'><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WheelGraph.html"
        - "https://en.wikipedia.org/wiki/Wheel_graph"
@@ -12174,7 +12174,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow><mi>Wh</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='whitehead-group($a1)'><mi>Wh</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadGroup.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -12186,7 +12186,7 @@ concepts:
       property: fenced
       area: "lie algebra"
       comments:
-       - "<math><mrow><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='whitehead-bracket($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Whitehead_product"
        - "https://ncatlab.org/nlab/show/Whitehead+product"
@@ -12198,7 +12198,7 @@ concepts:
       property: function
       area: "geometric topology"
       comments:
-       - "<math><mrow><mi>τ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='whitehead-torsion($a1)'><mi>τ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhiteheadTorsion.html"
        - "https://en.wikipedia.org/wiki/Whitehead_torsion"
@@ -12233,7 +12233,7 @@ concepts:
       property: "indexed symbol"
       area: "martingale theory"
       comments:
-       - "<math><msub><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='wiener-process($a1)'><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerProcess.html"
        - "https://en.wikipedia.org/wiki/Wiener_process"
@@ -12257,7 +12257,7 @@ concepts:
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><msub><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
+       - "<math><msub intent='wilson-polynomial($a1)'><mi>W</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonPolynomial.html"
        - "https://en.wikipedia.org/wiki/Wilson_polynomials"
@@ -12270,7 +12270,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wilson-quotient($a1)'><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WilsonQuotient.html"
        - "https://en.wikipedia.org/wiki/Wilson_quotient"
@@ -12281,8 +12281,8 @@ concepts:
       property: "function, symbol"
       area: "algebraic topology"
       comments:
-       - "<math><mrow><mi>𝒩</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='winding-number($a1)'><mi>𝒩</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='winding-number($a1)'><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Winding_number"
        - "https://dlmf.nist.gov/1.9#E32"
@@ -12296,7 +12296,7 @@ concepts:
       property: function
       area: "fourier analysis"
       comments:
-       - "<math><mrow><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='window-function($a1)'><mi>w</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WindowFunction.html"
        - "https://en.wikipedia.org/wiki/Window_function"
@@ -12308,7 +12308,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msub><mi>W</mi><mi>p</mi></msub></math>"
+       - "<math><msub intent='wishart-distribution'><mi>W</mi><mi>p</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WishartDistribution.html"
        - "https://en.wikipedia.org/wiki/Wishart_distribution"
@@ -12320,7 +12320,7 @@ concepts:
       property: "indexed function"
       area: "ring theory"
       comments:
-       - "<math><msub><mi>W</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='witt-polynomials($a1)'><mi>W</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
@@ -12342,7 +12342,7 @@ concepts:
       property: "indexed symbol"
       area: "number theory"
       comments:
-       - "<math><msub><mi>W</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><msub intent='woodall-number($a1)'><mi>W</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/WoodallNumber.html"
        - "https://en.wikipedia.org/wiki/Woodall_number"
@@ -12354,7 +12354,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ϕ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wright-function($a1)'><mi>ϕ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WrightFunction.html"
     
@@ -12364,7 +12364,7 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow><mi>ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wright-omega-function($a1)'><mi>ω</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Wright_Omega_function"
       alias:
@@ -12376,7 +12376,7 @@ concepts:
       property: function
       area: "knot theory"
       comments:
-       - "<math><mrow><mi>Wr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='writhe($a1)'><mi>Wr</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Writhe.html"
        - "https://en.wikipedia.org/wiki/Writhe"
@@ -12402,7 +12402,7 @@ concepts:
       property: function
       area: "gauge theory"
       comments:
-       - "<math><mrow><mi>ℒ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='yang-mill-functional($a1)'><mi>ℒ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Yang-MillsFunctional.html"
        - "https://www.encyclopediaofmath.org/index.php/Yang-Mills_functional"
@@ -12414,7 +12414,7 @@ concepts:
       property: symbol
       area: "linear algebra"
       comments:
-       - "<math><mi>Z</mi></math>"
+       - "<math><mi intent='z-matrix'>Z</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Z-matrix_(mathematics)"
     
@@ -12433,7 +12433,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mrow><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='z-transform($a1)'><mi>Z</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/z-Transform.html"
        - "https://mathworld.wolfram.com/Z-Transform.html"
@@ -12521,7 +12521,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='zeta-function($a1)'><mi>ζ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZetaFunction.html"
        - "https://en.wikipedia.org/wiki/List_of_zeta_functions"
@@ -12534,7 +12534,7 @@ concepts:
       property: infix
       area: "graph theory"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='zig-zag-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
-    
+ 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10995,7 +10995,7 @@ concepts:
       property: msub
       area: "sheaf theory"
       comments:
-       - "<math><msub intent='stalk($a1,$a2)'><mi arg='a1'>ℱ</mi><mi arg='a2'>x</mi></msub></mrow></math>"
+       - "<math><msub intent='stalk($a1,$a2)'><mi arg='a1'>ℱ</mi><mi arg='a2'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Stalk_(sheaf)"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6079,9 +6079,8 @@ concepts:
       property: indexed
       area: "limits"
       comments:
-       - "<math><mrow intent='infimum-limit($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mi lim inf"
-      notationa: "munder lim ¯"
+       - "<math><mrow intent='infimum-limit($a1)'><mi>lim inf</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='infimum-limit($a1)'><munder><mi>lim</mi><mo>_</mo></munder><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InfimumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
@@ -6160,9 +6159,8 @@ concepts:
       property: infix, fenced
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='inner-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mo ⋅"
-      notationa: "<math><mrow intent='inner-product($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='inner-product($a1,$a2)'><mo>(</mo><mi arg='a1'>x</mi><mo>⋅</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='inner-product($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/InnerProduct.html"
        - "https://en.wikipedia.org/wiki/Dot_product"
@@ -6340,8 +6338,7 @@ concepts:
       property: msub
       area: "group theory"
       comments:
-       - "<math><mrow intent='isotropy-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub $1 $2"
+       - "<math><msub intent='isotropy-group($a1,$a2)'><mi arg='a1'>G</mi><mi arg='a2'>x</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/IsotropyGroup.html"
        - "https://www.encyclopediaofmath.org/index.php/Isotropy_group"
@@ -10294,8 +10291,7 @@ concepts:
       property: msub
       area: "means"
       comments:
-       - "<math><mrow intent='root-mean-square($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub $1 RMS"
+       - "<math><msub intent='root-mean-square($a1)'><mi arg='a1'>G</mi><mi>RMS</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Root-Mean-Square.html"
       alias:
@@ -11011,8 +11007,7 @@ concepts:
       property: "indexed symbol"
       area: "multilinear algebra"
       comments:
-       - "<math><mrow intent='standard-flattening($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub 𝒜 ($1"
+       - "<math><msub intent='standard-flattening($a1)'><mi>𝐀</mi><mrow><mo>[</mo><mi arg='a1'>m</mi><mo>]</mo></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Matricization"
       alias:
@@ -11339,9 +11334,8 @@ concepts:
       property: indexed
       area: "limits"
       comments:
-       - "<math><mrow intent='supremum-limit($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mi lim sup"
-      notationa: "mover lim ¯"
+       - "<math><mrow intent='supremum-limit($a1)'><mi>lim sup</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='supremum-limit($a1)'><mover><mi>lim</mi><mo>¯</mo></mover><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SupremumLimit.html"
        - "https://en.wikipedia.org/wiki/Limit_superior_and_limit_inferior"
@@ -12433,8 +12427,7 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow intent='weber-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub E ν"
+       - "<math><mrow intent='weber-function($a1)'><msub><mi>𝐄</mi><mi arg='a1'>ν</mi></msub><mrow><mo>(</mo><mi arg='a2'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeberFunctions.html"
        - "https://dlmf.nist.gov/11.10#E2"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -688,7 +688,7 @@ concepts:
       property: postfix
       area: "calendar units"
       comments:
-       - "<math><mrow intent='bc($a1)'><mn ad='a1'>2024</mn><mo>&#x2009;</mo><mi>BC</mi></mrow></math>"      
+       - "<math><mrow intent='bc($a1)'><mn arg='a1'>2024</mn><mo>&#x2009;</mo><mi>BC</mi></mrow></math>"      
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -3046,7 +3046,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-       - "<math><mrow intent='direct-limit($a1)'><munder><mi>lim</mi><mo>→</mo></munder><mi ad='a1'>A</mi></mrow></math>"
+       - "<math><mrow intent='direct-limit($a1)'><munder><mi>lim</mi><mo>→</mo></munder><mi arg='a1'>A</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectLimit.html"
        - "https://en.wikipedia.org/wiki/Direct_limit"
@@ -3089,9 +3089,9 @@ concepts:
       property: "function, mixfix"
       area: "differential calculus"
       comments:
-       - "<math><msup intent='directional-derivative($a1)'><mi>∇</mi><mi>v</mi></msup><mi ad='a1'>f</mi></math>"
-       - "<math><msup intent='directional-derivative($a1)'><mi>D</mi><mi>v</mi></msup><mi ad='a1'>f</mi></math>"
-       - "<math><mrow intent='directional-derivative($a1)'><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi ad='a1'>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>∇</mi><mi>v</mi></msup><mi arg='a1'>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>D</mi><mi>v</mi></msup><mi arg='a1'>f</mi></math>"
+       - "<math><mrow intent='directional-derivative($a1)'><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi arg='a1'>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectionalDerivative.html"
        - "https://en.wikipedia.org/wiki/Directional_derivative"
@@ -3252,8 +3252,8 @@ concepts:
       property: "function, mixfix"
       area: "vector calculus"
       comments:
-       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi ad='a1'>f</mi></mrow></math>"
-       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi ad='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi arg='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi arg='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3386,7 +3386,7 @@ concepts:
       property: postfix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='double-factorial($a1)'><mn ad='a1'>10</mn><mo>&#x203c;</mo></mrow></math>"
+       - "<math><mrow intent='double-factorial($a1)'><mn arg='a1'>10</mn><mo>&#x203c;</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleFactorial.html"
        - "https://en.wikipedia.org/wiki/Double_factorial"
@@ -3455,8 +3455,8 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup intent='dual-space($a1)'><mi ad='a1'>V</mi><mo>*</mo></msup></math>"
-       - "<math><msup intent='dual-space($a1)'><mi ad='a1'>V</mi><mo>&#x2032;</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi arg='a1'>V</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi arg='a1'>V</mi><mo>&#x2032;</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
@@ -4345,7 +4345,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='fourier-cosine-transform($a1)'><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi ad='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='fourier-cosine-transform($a1)'><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi arg='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierCosineTransform.html"
        - "https://dlmf.nist.gov/1.14#E9"
@@ -4357,7 +4357,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='fourier-sine-transform($a1)'><msub><mi>ℱ</mi><mi>s</mi></msub><mi ad='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='fourier-sine-transform($a1)'><msub><mi>ℱ</mi><mi>s</mi></msub><mi arg='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierSineTransform.html"
        - "https://dlmf.nist.gov/1.14#E10"
@@ -4511,7 +4511,7 @@ concepts:
       property: mixfix
       area: "ring theory"
       comments:
-       - "<math><mrow intent='free-algebra($a1,$a2)'><mi ad='a1'>R</mi><mo>⟨</mo><mi arg='a2'>X</mi><mo>⟩</mo></mrow></math>"
+       - "<math><mrow intent='free-algebra($a1,$a2)'><mi arg='a1'>R</mi><mo>⟨</mo><mi arg='a2'>X</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeAlgebra.html"
        - "https://en.wikipedia.org/wiki/Free_algebra"
@@ -4706,7 +4706,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi><mi ad='a1'>G</mi></mrow></math>"
+       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi><mi arg='a1'>G</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -6117,7 +6117,7 @@ concepts:
       property: mixfix, 
       area: "set theory"
       comments:
-       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi ad='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>↣</mo><mi arg='a3'>Y</mi></mrow></math>"
+       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>↣</mo><mi arg='a3'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -7137,8 +7137,8 @@ concepts:
       property: fenced, fenced stacked
       area: "number theory"
       comments:
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi ad='a2'>p</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi ad='a2'>p</mi></mfrac><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi arg='a2'>p</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi arg='a2'>p</mi></mfrac><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
@@ -8523,7 +8523,7 @@ concepts:
       property: fenced
       area: "euclidean solid geometry"
       comments:
-       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi ad='a1'>±</mi><mo>,</mo><mi ad='a2'>±</mi><mo>,</mo><mi ad='a3'>±</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>±</mi><mo>,</mo><mi arg='a2'>±</mi><mo>,</mo><mi arg='a3'>±</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octant.html"
        - "https://en.wikipedia.org/wiki/Octant_(plane_geometry)"
@@ -8739,7 +8739,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='p-core($a1)'><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi ad='a1'>G</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='p-core($a1)'><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi arg='a1'>G</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Core_(group)"
        - "https://en.wikipedia.org/wiki/P-soluble_group"
@@ -8752,7 +8752,7 @@ concepts:
       property: mixfix
       area: "numerical analysis"
       comments:
-       - "<math><msub intent='pade-approximant($a1,$a2,$a3)'><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi ad='a3'>f</mi></msub></math>"
+       - "<math><msub intent='pade-approximant($a1,$a2,$a3)'><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi arg='a3'>f</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/3.11#SS4.p1"
        - "https://mathworld.wolfram.com/PadeApproximant.html"
@@ -8861,7 +8861,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><msub intent='pauli-matrix($a1)'><mi>σ</mi><mi ad='a1'>G</mi></msub></math>"
+       - "<math><msub intent='pauli-matrix($a1)'><mi>σ</mi><mi arg='a1'>G</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PauliMatrices.html"
        - "https://mathworld.wolfram.com/PauliMatrix.html"
@@ -10189,7 +10189,7 @@ concepts:
       property: operator
       area: "calculus"
       comments:
-       - "<math><msub intent='right-derivative($a1)'><mo>∂</mo><mo>+</mo></msub><mi ad='a1'>f</mi></math>"
+       - "<math><msub intent='right-derivative($a1)'><mo>∂</mo><mo>+</mo></msub><mi arg='a1'>f</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
     
@@ -10261,7 +10261,7 @@ concepts:
       property: mixfix
       area: "category theory"
       comments:
-       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi ad='a3'>Z</mi></mrow></math>"
+       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi arg='a3'>Z</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
@@ -11743,7 +11743,7 @@ concepts:
       property: msub
       area: "group theory"
       comments:
-       - "<math><msub intent='torsion-subgroup($a1)'><mi ad='a1'>G</mi><mi>T</mi></msub></math>"
+       - "<math><msub intent='torsion-subgroup($a1)'><mi arg='a1'>G</mi><mi>T</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_subgroup"
        - "https://ncatlab.org/nlab/show/torsion+subgroup"
@@ -12597,7 +12597,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi ad='a1'>&delta;</mi></msub><mrow><mo>(</mo><mi ad='a2'>t</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi arg='a1'>&delta;</mi></msub><mrow><mo>(</mo><mi arg='a2'>t</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerSausage.html"
        - "https://en.wikipedia.org/wiki/Wiener_sausage"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -5636,11 +5636,12 @@ concepts:
        - "https://dlmf.nist.gov/6.2#E15"
     
     - concept: hyperbolic-space
-      arity: 0
+      arity: 1
       en: hyperbolic space
       property: symbol
       area: "non-euclidean geometry"
-      notation: "msupH$1"
+      comments:
+       - "<math><msup intent='hyperbolic-space($1)'><mi mathvariant='normal'>H</mi><mi arg='a1'>n</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicSpace.html"
        - "https://en.wikipedia.org/wiki/Hyperbolic_space"
@@ -5650,7 +5651,8 @@ concepts:
       en: hyperbolic umbilic canonical integral function of $1
       property: function
       area: "special functions"
-      notation: "mrow Ψ sup (E"
+      comments:
+       - "<math><mrow intent='hyperbolic-umbilic-canonical-integral-function($a1)'><msup><mo>Ψ</mo><mrow><mo>(</mo><mi mathvariant='normal'>E</mi></mrow></msup><mi arg='a1'>z</mi></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/36.2#E11"
        - "https://dlmf.nist.gov/36.3#i"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -66,7 +66,7 @@ concepts:
       property: postfix. prefix
       area: "calendar units"
       comments:
-       - "<math><mrow intent='ad($a1)'><mi>AD</mi><mo>&#x2009;</mo><mn>2024</mn></mrow></math>"
+       - "<math><mrow intent='ad($a1)'><mi>AD</mi><mo>&#x2009;</mo><mn arg='a1'>2024</mn></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -76,7 +76,7 @@ concepts:
       property: prefix
       area: "abstract algebra"
       comments:
-       - "<math><mrow intent='additive-inverse($a1)'><mo>-</mo><mi arg='a1'>n</mi></math>"
+       - "<math><mrow intent='additive-inverse($a1)'><mo>-</mo><mi arg='a1'>n</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Additive_inverse"
       alias:
@@ -346,7 +346,7 @@ concepts:
       property: indexed infix
       area: "group theory"
       comments:
-       - "<math><mi arg='a1'>A</mi><msub><mo>⁎</mo><mi arg='a3'>C</mi></msub><mi arg='a2'>B</mi></math>"
+       - "<math><mrow intent='amalgamated-product($a1,$a2,$a3)'><mi arg='a1'>A</mi><msub><mo>⁎</mo><mi arg='a3'>C</mi></msub><mi arg='a2'>B</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/828828/amalgamated-product"
        - "https://en.wikipedia.org/wiki/Free_product"
@@ -421,7 +421,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></math>"
+       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -493,8 +493,8 @@ concepts:
       property: unit
       area: "SI-mentioned units"
       comments:
-       - "<math><mrow intent='arcminute($a1)'><mi>arcmin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='arcminute($a1)'><mi>amin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcminute($a1)'><mi>arcmin</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='arcminute($a1)'><mi>amin</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "mo ′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -511,8 +511,8 @@ concepts:
       property: unit
       area: "SI-mentioned units"
       comments:
-       - "<math><mrow intent='arcsecond($a1)'><mi>arcsec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='arcsecond($a1)'><mi>asec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcsecond($a1)'><mi>arcsec</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='arcsecond($a1)'><mi>asec</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "mo ′′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -560,8 +560,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>agm</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>AGM</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>agm</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>AGM</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Arithmetic-GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean"
@@ -585,7 +585,7 @@ concepts:
       property: fenced
       area: "algebra"
       comments:
-       - "<math><mrow intent='associator($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
+       - "<math><mrow intent='associator($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Associator.html"
        - "https://en.wikipedia.org/wiki/Associator"
@@ -636,7 +636,7 @@ concepts:
       property: unit
       area: "imperial units"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>bbl</mi></math>"
+       - "<math><mrow intent='barrel($a1)'><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>bbl</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Barrel.html"
        - "https://en.wikipedia.org/wiki/Barrelled_space"
@@ -669,7 +669,7 @@ concepts:
       property: postfix
       area: "calendar units"
       comments:
-       - "<math><mn>2024</mn><mo>&#x2009;</mo><mi>BC</mi></math>"      
+       - "<math><mrow intent='bc($a1)'><mn>2024</mn><mo>&#x2009;</mo><mi>BC</mi></mrow></math>"      
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -804,10 +804,10 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mrow intent='beta-distribution($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='beta-distribution($a1)'><mi>Beta</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='beta-distribution($a1)'><mi>𝓑𝓮</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='beta-distribution($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>Beta</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>𝓑𝓮</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaDistribution.html"
        - "https://en.wikipedia.org/wiki/Beta_distribution"
@@ -818,8 +818,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='beta-function($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='beta-function($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-function($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='beta-function($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%92(x,_y)"
@@ -850,9 +850,9 @@ concepts:
       property: infix
       area: "logic"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⇔</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>≡</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>iff</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='biconditional($a1,$a2)'><mi arg='a1'>X</mi><mo>⇔</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='biconditional($a1,$a2)'><mi arg='a1'>X</mi><mo>≡</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='biconditional($a1,$a2)'><mi arg='a1'>X</mi><mo>iff</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Biconditional.html"
        - "https://ncatlab.org/nlab/show/biconditional"
@@ -866,7 +866,7 @@ concepts:
       property: prefix
       area: "complexity"
       comments:
-       - "<math><mrow><mi>O</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='big-O($a1)'><mi>O</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
@@ -887,7 +887,7 @@ concepts:
       property: mixfix
       area: "set theory"
       comments:
-       - "<math><mrow intent='bijection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>⤖</mo><mi arg='a3'>Y</mi></math>"
+       - "<math><mrow intent='bijection($a1,$a2,$a3)'><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>⤖</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -934,8 +934,8 @@ concepts:
       property: symbol
       area: "computer science"
       comments:
-       - "<math><mn>0</mn></math>"
-       - "<math><mn>1</mn></math>"
+       - "<math><mrow><mn>0</mn></mrow></math>"
+       - "<math><mrow><mn>1</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Bit.html"
        - "https://en.wikipedia.org/wiki/Bit"
@@ -1030,9 +1030,9 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mrow intent='boundary($a1)'><mi>bd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='boundary($a1)'><mi>fr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='boundary($a1)'><mi>∂</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>bd</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>fr</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>∂</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Boundary.html"
        - "https://en.wikipedia.org/wiki/Boundary_(topology)"
@@ -1146,7 +1146,7 @@ concepts:
       area: "set theory"
       notation: "mrow | mo #"
       notationb: "mi card"
-      notationa: "<math><mrow intent='cardinality($a1)'><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+      notationa: "<math><mrow intent='cardinality($a1)'><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cardinality.html"
        - "https://en.wikipedia.org/wiki/Cardinality"
@@ -1251,7 +1251,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mrow intent='cauchy-principal-value($a1)'><mi>p.v.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='cauchy-principal-value($a1)'><mi>p.v.</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CauchyPrincipalValue.html"
        - "https://en.wikipedia.org/wiki/Cauchy_principal_value"
@@ -1297,10 +1297,10 @@ concepts:
       property: fenced, function
       area: "number theory"
       comments:
-       - "<math><mrow intent='ceiling($a1)'><mo>⌈</mo><mi arg='a1'>X</mi><mo>⌉</mo></math>"
-       - "<math><mrow intent='ceiling($a1)'><mo>&#x27e7;</mo><mi arg='a1'>X</mi><mo>&#x27e6;</mo></math>"
-       - "<math><mrow intent='ceiling($a1)'><mo>]</mo><mi arg='a1'>X</mi><mo>[</mo></math>"
-       - "<math><mrow intent='ceiling($a1)'><mi>ceil</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>⌈</mo><mi arg='a1'>X</mi><mo>⌉</mo></mrow></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>&#x27e7;</mo><mi arg='a1'>X</mi><mo>&#x27e6;</mo></mrow></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>]</mo><mi arg='a1'>X</mi><mo>[</mo></mrow></math>"
+       - "<math><mrow intent='ceiling($a1)'><mi>ceil</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -1338,7 +1338,7 @@ concepts:
       property: unit
       area: "imperial units"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>chain</mi></math>"
+       - "<math><mrow intent='chain($a1)'><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>chain</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Chain_(unit)"
     
@@ -1389,7 +1389,7 @@ concepts:
       area: "probability theory"
       comments:
        - "<math><msub intent='characteristic-function($a1)'><mi>𝟏</mi><mi arg='a1'>X</mi></msub></math>"
-       - "<math><mn>1</mn><mrow><mo>{</mo><mi arg='a1'>X</mi><mo>}</mo></mrow></math>"
+       - "<math><mrow intent='characteristic-function($a1)'><mn>1</mn><mrow><mo>{</mo><mi arg='a1'>X</mi><mo>}</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CharacteristicFunction.html"
        - "https://en.wikipedia.org/wiki/Characteristic_function_(probability_theory)"
@@ -1431,9 +1431,9 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>θ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>ϑ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>θ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>ϑ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1447,8 +1447,8 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>ψ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>U</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>ψ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>U</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1558,8 +1558,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='classifying-space($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='classifying-space($a1)'><mi>ℬ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='classifying-space($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='classifying-space($a1)'><mi>ℬ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Classifying_space"
        - "https://ncatlab.org/nlab/show/classifying+space"
@@ -1659,8 +1659,8 @@ concepts:
       property: "function, msup"
       area: "abstract algebra,, topology"
       comments:
-       - "<math><mrow intent='closure($a1)'><mi>cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='closure($a1)'><mi>Cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='closure($a1)'><mi>cl</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='closure($a1)'><mi>Cl</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><msup intent='closure($a1)'><mi arg='a1'>X</mi><mo>−</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
@@ -1712,8 +1712,8 @@ concepts:
       property: "indexed function"
       area: "signal processing, quantum physics"
       comments:
-       - "<math><mrow intent='coherence($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='coherence($a1)'><mi>γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='coherence($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='coherence($a1)'><mi>γ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coherence_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Coherence_(physics)"
@@ -1768,7 +1768,7 @@ concepts:
       property: fenced
       area: "abstract algebra"
       comments:
-       - "<math><mrow intent='commutator($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
+       - "<math><mrow intent='commutator($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Commutator.html"
        - "https://en.wikipedia.org/wiki/Commutator"
@@ -1811,7 +1811,7 @@ concepts:
       property: infix
       area: "order theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⪋</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='comparability($a1,$a2)'><mi arg='a1'>X</mi><mo>⪋</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
       alias:
@@ -1823,7 +1823,7 @@ concepts:
       property: fenced
       area: "order theory"
       comments:
-       - "<math><mrow intent='complement-of-interval($a1,$a2)'><mo>]</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>[</mo></math>"
+       - "<math><mrow intent='complement-of-interval($a1,$a2)'><mo>]</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>[</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Interval_(mathematics)"
     
@@ -1998,7 +1998,7 @@ concepts:
       property: mixfix
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></math>"     
+       - "<math><mrow><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></mrow></math>"     
       urls: 
        - "https://mathworld.wolfram.com/Configuration.html"
        - "https://en.wikipedia.org/wiki/Configuration_(geometry)"
@@ -2148,7 +2148,7 @@ concepts:
       property: constant
       area: "logic"
       comments:
-       - "<math><mrow><mo>⊥</mo></math>"
+       - "<math><mrow><mo>⊥</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2160,7 +2160,7 @@ concepts:
       property: postfix
       area: "computer science"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>↓</mo></math>"
+       - "<math><mrow intent='converge($a1)'><mi arg='a1'>x</mi><mo>↓</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
       alias:
@@ -2345,8 +2345,8 @@ concepts:
       property: infix
       area: "order theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⋖</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>&lt;:</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='covering-relation($a1,$a2)'><mi arg='a1'>X</mi><mo>⋖</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='covering-relation($a1,$a2)'><mi arg='a1'>X</mi><mo>&lt;:</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Partially_ordered_set"
        - "https://en.wikipedia.org/wiki/Covering_relation"
@@ -2372,7 +2372,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></math>"
+       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -2447,8 +2447,8 @@ concepts:
       property: function
       area: "vector calculus"
       comments:
-       - "<math><mrow intent='curl($a1)'><mi>curl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='curl($a1)'><mi>rot</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='curl($a1)'><mi>curl</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='curl($a1)'><mi>rot</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "mrow ∇ × $1"
       urls: 
        - "https://mathworld.wolfram.com/Curl.html"
@@ -2534,7 +2534,7 @@ concepts:
       property: prefix
       area: "partial differential equations"
       comments:
-       - "<math><mrow intent='dalembert-operator($a1)'><mo>☐</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='dalembert-operator($a1)'><mo>☐</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/D%27Alembert_operator"
        - "https://www.encyclopediaofmath.org/index.php/D'Alembert_operator"
@@ -2561,8 +2561,8 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow intent='dawson-function($a1)'><mi>F</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='dawson-function($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='dawson-function($a1)'><mi>F</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='dawson-function($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationb: "mi sub D -"
       notationa: "mi sub D +"
       urls: 
@@ -2579,7 +2579,7 @@ concepts:
       property: postfix
       area: "physics"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>↓</mo></math>"
+       - "<math><mrow intent='decrease($a1)'><mi arg='a1'>x</mi><mo>↓</mo></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4705"
     
@@ -2622,8 +2622,8 @@ concepts:
       property: function
       area: "logic"
       comments:
-       - "<math><mrow intent='deductive-closure($a1)'><mi>Ded</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='deductive-closure($a1)'><mi>Th</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='deductive-closure($a1)'><mi>Ded</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='deductive-closure($a1)'><mi>Th</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Deductive_closure"
     
@@ -2633,11 +2633,11 @@ concepts:
       property: infix
       area: "general"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>≜</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>≝</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>:=</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mover><mo>=</mo><mi>def</mi></mover><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='defined-as($a1,$a2)'><mi arg='a1'>X</mi><mo>≜</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='defined-as($a1,$a2)'><mi arg='a1'>X</mi><mo>≝</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='defined-as($a1,$a2)'><mi arg='a1'>X</mi><mo>:=</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='defined-as($a1,$a2)'><mi arg='a1'>X</mi><mover><mo>=</mo><mi>def</mi></mover><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='defined-as($a1,$a2)'><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/522864/what-is-the-symbol-triangleq"
        - "https://drive.google.com/file/d/1z_dcQ6lsOA_0CsH55fwcg4hQF_w22olM/view"
@@ -2651,7 +2651,7 @@ concepts:
       property: prefix, postfix
       area: "physics, geometry"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>°</mo></math>"
+       - "<math><mrow intent='degree($a1)'><mi arg='a1'>x</mi><mo>°</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Degree.html"
        - "https://en.wikipedia.org/wiki/Degree_(angle)"
@@ -2723,7 +2723,7 @@ concepts:
       property: prefix
       area: "programming languages"
       comments:
-       - "<math><mrow intent='dereference($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='dereference($a1)'><mo>!</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/pdf/1208.5915.pdf"
     
@@ -2785,8 +2785,8 @@ concepts:
       property: symbol, prefix unit
       area: "geometry"
       comments:
-       - "<math><mrow intent='diameter($a1)'><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='diameter($a1)'><mo>⌀</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='diameter($a1)'><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='diameter($a1)'><mo>⌀</mo><mi arg='a1'>x</mi></mrow></math>"
       notationb: "mi DIA"
       notationa: "mi dia"
       urls: 
@@ -2838,8 +2838,8 @@ concepts:
       property: prefix
       area: "calculus"
       comments:
-       - "<math><mrow intent='differential-operator($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='differential-operator($a1)'><mo>∂</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='differential-operator($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='differential-operator($a1)'><mo>∂</mo><mi arg='a1'>x</mi></mrow></math>"
       notationa: "mfrac d mrow d $1"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialOperator.html"
@@ -2908,7 +2908,7 @@ concepts:
       property: "function, fenced"
       area: "linear algebra, graph theory"
       comments:
-       - "<math><mrow intent='dimension($a1)'><mi>dim</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='dimension($a1)'><mi>dim</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><mrow intent='dimension($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
@@ -3124,9 +3124,9 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mrow intent='discriminant($a1)'><mi>Disc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='discriminant($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='discriminant($a1)'><mi>Δ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>Disc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>Δ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Discriminant.html"
        - "https://en.wikipedia.org/wiki/Discriminant"
@@ -3153,7 +3153,7 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mi arg='a1'>A</mi><msup><mi></mi><mo>*</mo></msup><mi arg='a2'>B</mi></math>"
+       - "<math><mrow intent='disjoint-union($a1,$a2)'><mi arg='a1'>A</mi><msup><mi></mi><mo>*</mo></msup><mi arg='a2'>B</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DisjointUnion.html"
        - "https://en.wikipedia.org/wiki/Disjoint_union"
@@ -3167,7 +3167,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='distance($a1,$a2)'><mo>|</mo><mi arg='a1'>X</mi><mo>&#x2009;</mo><mi arg='a2'>Y</mi><mo>|</mo></math>"
+       - "<math><mrow intent='distance($a1,$a2)'><mo>|</mo><mi arg='a1'>X</mi><mo>&#x2009;</mo><mi arg='a2'>Y</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance"
     
@@ -3177,7 +3177,7 @@ concepts:
       property: postfix
       area: "computer science"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>↑</mo></math>"
+       - "<math><mrow intent='diverge($a1)'><mi arg='a1'>x</mi><mo>↑</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
       alias:
@@ -3189,8 +3189,8 @@ concepts:
       property: "function, mixfix"
       area: "vector calculus"
       comments:
-       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi>f</mi></math>"
-       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi>f</mi></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi>f</mi></mrow></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3218,9 +3218,9 @@ concepts:
       property: infix
       area: "number theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>|</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a2'>Y</mi><mo>⋮</mo><mi arg='a1'>X</mi></math>"
-       - "<math><mi arg='a2'>Y</mi><mo>/</mo><mi arg='a1'>X</mi></math>"
+       - "<math><mrow intent='divisible-by($a1,$a2)'><mi arg='a1'>X</mi><mo>|</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='divisible-by($a1,$a2)'><mi arg='a2'>Y</mi><mo>⋮</mo><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='divisible-by($a1,$a2)'><mi arg='a2'>Y</mi><mo>/</mo><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://youtu.be/9dyK_op-Ocw?t=251"
        - "https://en.wikipedia.org/wiki/Divisor"
@@ -3311,7 +3311,7 @@ concepts:
       property: infix
       area: "category theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⇉</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='double-category($a1,$a2)'><mi arg='a1'>X</mi><mo>⇉</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/double+category"
     
@@ -3321,7 +3321,7 @@ concepts:
       property: postfix
       area: "combinatorics"
       comments:
-       - "<math><mn>10</mn><mo>&#x203c;</mo></math>"
+       - "<math><mrow intent='double-factorial($a1)'><mn>10</mn><mo>&#x203c;</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleFactorial.html"
        - "https://en.wikipedia.org/wiki/Double_factorial"
@@ -3492,9 +3492,9 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Elliptic_function"
@@ -3602,7 +3602,7 @@ concepts:
       property: fenced
       area: "set theory"
       comments:
-       - "<math><mrow intent='equivalence-class($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
+       - "<math><mrow intent='equivalence-class($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EquivalenceClass.html"
        - "https://en.wikipedia.org/wiki/Equivalence_class"
@@ -3654,9 +3654,9 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='error-function($a1)'><mi>erf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='error-function($a1)'><mi>erfc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='error-function($a1)'><mi>w</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>erf</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>erfc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>w</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ErrorFunction.html"
        - "https://en.wikipedia.org/wiki/Error_function"
@@ -3669,9 +3669,9 @@ concepts:
       property: infix
       area: "abstract algebra"
       comments:
-       - "<math><mi arg='a1'>X</mi><msub><mo>⊆</mo><mi>e</mi></msub><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊴</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊂</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='essential-extension($a1,$a2)'><mi arg='a1'>X</mi><msub><mo>⊆</mo><mi>e</mi></msub><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='essential-extension($a1,$a2)'><mi arg='a1'>X</mi><mo>⊴</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='essential-extension($a1,$a2)'><mi arg='a1'>X</mi><mo>⊂</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -3684,7 +3684,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow intent='essential-infimum($a1)'><mi>ess inf</mi><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='essential-infimum($a1)'><mi>ess inf</mi><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/essentialsupremum.html"
        - "https://en.wikipedia.org/wiki/essential_supremum_and_essential_infimum"
@@ -3696,7 +3696,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mrow intent='essential-supremum($a1)'><mi>ess sup</mi><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='essential-supremum($a1)'><mi>ess sup</mi><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EssentialSupremum.html"
        - "https://en.wikipedia.org/wiki/Essential_supremum_and_essential_infimum"
@@ -3844,8 +3844,8 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow intent='euler-totient-function($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='euler-totient-function($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='euler-totient-function($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='euler-totient-function($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerTotientFunction.html"
        - "https://en.wikipedia.org/wiki/Euler%27s_totient_function"
@@ -3882,11 +3882,11 @@ concepts:
       property: infix
       area: "logic"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⊻</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>↮</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>≢</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mi>XOR</mi><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='exclusive-or($a1,$a2)'><mi arg='a1'>X</mi><mo>⊻</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='exclusive-or($a1,$a2)'><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='exclusive-or($a1,$a2)'><mi arg='a1'>X</mi><mo>↮</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='exclusive-or($a1,$a2)'><mi arg='a1'>X</mi><mo>≢</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='exclusive-or($a1,$a2)'><mi arg='a1'>X</mi><mi>XOR</mi><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExclusiveDisjunction.html"
        - "https://ncatlab.org/nlab/show/exclusive+disjunction"
@@ -3902,7 +3902,7 @@ concepts:
       property: fenced
       area: "quantum physics"
       comments:
-       - "<math><mrow intent='expectation-value($a1)'><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
+       - "<math><mrow intent='expectation-value($a1)'><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExpectationValue.html"
        - "https://en.wikipedia.org/wiki/Expectation_value_(quantum_mechanics)"
@@ -3914,8 +3914,8 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mrow intent='expected-value($a1)'><mi>E</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='expected-value($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='expected-value($a1)'><mi>E</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='expected-value($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><msub intent='expected-value($a1)'><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
@@ -3932,7 +3932,7 @@ concepts:
       property: postfix
       area: "number theory"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>$</mo></math>"
+       - "<math><mrow intent='exponential-factorial($a1)'><mi arg='a1'>x</mi><mo>$</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExponentialFactorial.html"
        - "https://en.wikipedia.org/wiki/Exponential_factorial"
@@ -3959,7 +3959,7 @@ concepts:
       property: "function, msup"
       area: "topology"
       comments:
-       - "<math><mrow intent='exterior($a1)'><mi>ext</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='exterior($a1)'><mi>ext</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><msup intent='exterior($a1)'><mi arg='a1'>X</mi><mi>e</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
@@ -4230,10 +4230,10 @@ concepts:
       property: fenced, function
       area: "number theory"
       comments:
-       - "<math><mrow intent='floor($a1)'><mo>⌊</mo><mi arg='a1'>X</mi><mo>⌋</mo></math>"
-       - "<math><mrow intent='floor($a1)'><mo>&#x27e6;</mo><mi arg='a1'>X</mi><mo>&#x27e7;</mo></math>"
-       - "<math><mrow intent='floor($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
-       - "<math><mrow intent='floor($a1)'><mi>floor</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='floor($a1)'><mo>⌊</mo><mi arg='a1'>X</mi><mo>⌋</mo></mrow></math>"
+       - "<math><mrow intent='floor($a1)'><mo>&#x27e6;</mo><mi arg='a1'>X</mi><mo>&#x27e7;</mo></mrow></math>"
+       - "<math><mrow intent='floor($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='floor($a1)'><mi>floor</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://youtu.be/RxNs4SwP6lk"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -4350,9 +4350,9 @@ concepts:
       property: "function, fenced"
       area: "arithmetic"
       comments:
-       - "<math><mrow intent='fractional-part($a1)'><mi>frac</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='fractional-part($a1)'><mo>&#x27e6;</mo><mi arg='a1'>x</mi><mo>&#x27e7;</mo></math>"
-       - "<math><mrow intent='fractional-part($a1)'><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mi>frac</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mo>&#x27e6;</mo><mi arg='a1'>x</mi><mo>&#x27e7;</mo></mrow></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FractionalPart.html"
        - "https://en.wikipedia.org/wiki/Fractional_part"
@@ -4377,8 +4377,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='frattini-subgroup($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='frattini-subgroup($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='frattini-subgroup($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='frattini-subgroup($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrattiniSubgroup.html"
        - "https://en.wikipedia.org/wiki/Frattini_subgroup"
@@ -4428,7 +4428,7 @@ concepts:
       property: mixfix
       area: "ring theory"
       comments:
-       - "<math><mrow intent='free-algebra($a1,$a2)'><mi>R</mi><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
+       - "<math><mrow intent='free-algebra($a1,$a2)'><mi>R</mi><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeAlgebra.html"
        - "https://en.wikipedia.org/wiki/Free_algebra"
@@ -4477,9 +4477,9 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow intent='fresnel-integral($a1)'><mi>ℱ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='fresnel-integral($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='fresnel-integral($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>ℱ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FresnelIntegrals.html"
        - "https://en.wikipedia.org/wiki/Fresnel_integral"
@@ -4508,7 +4508,7 @@ concepts:
       property: fenced
       area: "differntial geometry"
       comments:
-       - "<math><mrow intent='frolicher-nijenhuis-bracket($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
+       - "<math><mrow intent='frolicher-nijenhuis-bracket($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fr%C3%B6licher%E2%80%93Nijenhuis_bracket"
        - "https://encyclopediaofmath.org/wiki/Fr%C3%B6licher-Nijenhuis_bracket"
@@ -4532,7 +4532,7 @@ concepts:
       area: "category theory"
       comments:
        - "<math><msup intent='functor-category($a1,$a2)'><mi arg='a1'>f</mi><mi arg='a1'>g</mi></msup></math>"
-       - "<math><mrow intent='functor-category($a1,$a2)'><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></math>"
+       - "<math><mrow intent='functor-category($a1,$a2)'><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -4617,7 +4617,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi></math>"
+       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -4730,7 +4730,7 @@ concepts:
       property: fenced
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='gelfand-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='gelfand-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Rigged_Hilbert_space#Formal_definition_(Gelfand_triple)"
     
@@ -4773,8 +4773,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='general-linear-group($a1)'><mi>GL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='general-linear-group($a1)'><mi>Aut</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='general-linear-group($a1)'><mi>GL</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='general-linear-group($a1)'><mi>Aut</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeneralLinearGroup.html"
        - "https://en.wikipedia.org/wiki/General_linear_group"
@@ -4894,7 +4894,7 @@ concepts:
       property: infix
       area: "geometric algebra"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>&#x2062;</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='geometric-product($a1,$a2)'><mi arg='a1'>X</mi><mo>&#x2062;</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Geometric_algebra"
     
@@ -4975,8 +4975,8 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mrow intent='gram-determinant($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='gram-determinant($a1)'><mi>Γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gram-determinant($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='gram-determinant($a1)'><mi>Γ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramDeterminant.html"
        - "https://www.encyclopediaofmath.org/index.php/Gram_determinant"
@@ -5055,7 +5055,7 @@ concepts:
       comments:
        - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
        - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>×</mo></msup></math>"
-       - "<math><mrow intent='group-of-units($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='group-of-units($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5091,8 +5091,8 @@ concepts:
       property: infix
       area: "algebra"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊙</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='hadamard-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='hadamard-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⊙</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HadamardProduct.html"
        - "https://en.wikipedia.org/wiki/Hadamard_product_(matrices)"
@@ -5120,7 +5120,7 @@ concepts:
       property: operator
       area: "quantum mechanics"
       comments:
-       - "<math><mrow intent='hamiltonian($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hamiltonian($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationc: "mover H ˇ"
       notationb: "mover H ^"
       notationa: "mrow < H >"
@@ -5278,8 +5278,8 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mrow intent='height-function($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='height-function($a1)'><mi>h</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='height-function($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='height-function($a1)'><mi>h</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_of_a_polynomial"
     
@@ -5325,8 +5325,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='hermite-polynomial($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='hermite-polynomial($a1)'><mi>He</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hermite-polynomial($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='hermite-polynomial($a1)'><mi>He</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HermitePolynomial.html"
        - "https://en.wikipedia.org/wiki/Hermite_polynomials"
@@ -5389,8 +5389,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='heun-function($a1)'><mi>Hf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='heun-function($a1)'><mi>H⁢ℓ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='heun-function($a1)'><mi>Hf</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='heun-function($a1)'><mi>H⁢ℓ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.1"
@@ -5415,7 +5415,7 @@ concepts:
       property: unit
       area: "arithmetic"
       comments:
-       - "<math><mrow intent='hexadecimal($a1)'><mi>hex</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hexadecimal($a1)'><mi>hex</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationb: "msub $1 hex"
       notationa: "msub $1 16"
       urls: 
@@ -5461,7 +5461,7 @@ concepts:
       property: prefix
       area: "differential geometry"
       comments:
-       - "<math><mrow intent='hodge-star-operator($a1)'><mo>⋆</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='hodge-star-operator($a1)'><mo>⋆</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hodge_dual"
        - "https://ncatlab.org/nlab/show/Hodge+star+operator"
@@ -5538,7 +5538,7 @@ concepts:
       property: unit
       area: "imperial unit"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>hp</mi></math>"
+       - "<math><mrow intent='horsepower-mechanical($a1)'><mi arg='a1'>x</mi><mo>&#x2009;</mo><mi>hp</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Horsepower"
       alias:
@@ -5550,12 +5550,12 @@ concepts:
       property: unit
       area: "metric unit"
       comments:
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>PS</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>cv</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>hk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>pk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>ks</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='horsepower-metric($a1)'><mi>ch</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>PS</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>cv</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>hk</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>pk</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>ks</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>ch</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Metric_horsepower"
       alias:
@@ -5593,8 +5593,8 @@ concepts:
       property: infix
       area: "chemistry"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>•</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='hydrated-compound($a1,$a2)'><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='hydrated-compound($a1,$a2)'><mi arg='a1'>X</mi><mo>•</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hydrate"
        - "https://en.wikipedia.org/wiki/Cobalt(II)_chloride"
@@ -5659,7 +5659,7 @@ concepts:
       property: "function, fenced"
       area: "multilinear algebra"
       comments:
-       - "<math><mrow intent='hyperdeterminant($a1)'><mi>det</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hyperdeterminant($a1)'><mi>det</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><mrow intent='hyperdeterminant($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
@@ -5702,7 +5702,7 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mrow intent='identity-function($a1)'><mi>id</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='identity-function($a1)'><mi>id</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><msub intent='identity-function($a1)'><mi>id</mi><mi arg='a1'>x</mi></msub></math>"
        - "<math><msub intent='identity-function($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
@@ -5776,7 +5776,7 @@ concepts:
       property: infix
       area: "projective geometry"
       comments:
-       - "<math><mi arg='a1'>X</mi><mi>I</mi><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='incidence-relation($a1,$a2)'><mi arg='a1'>X</mi><mi>I</mi><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Incidence_(geometry)"
        - "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"
@@ -5788,7 +5788,7 @@ concepts:
       property: fenced
       area: "incidence geometry"
       comments:
-       - "<math><mrow intent='incidence-structure($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>P</mi><mo>,</mo><mi arg='a2'>L</mi><mo>,</mo><mi arg='a3'>I</mi><mo>)</mo></math>"
+       - "<math><mrow intent='incidence-structure($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>P</mi><mo>,</mo><mi arg='a2'>L</mi><mo>,</mo><mi arg='a3'>I</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Incidence_structure"
     
@@ -5876,7 +5876,7 @@ concepts:
       property: postfix
       area: "physics"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>↑</mo></math>"
+       - "<math><mrow intent='increase($a1)'><mi arg='a1'>x</mi><mo>↑</mo></mrow></math>"
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4606"
     
@@ -5886,7 +5886,7 @@ concepts:
       property: infix
       area: "calculus"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>↗</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow><mi arg='a1'>X</mi><mo>↗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"
@@ -5897,8 +5897,8 @@ concepts:
       property: infix
       area: "probability theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⟂</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⫫</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='independent($a1,$a2)'><mi arg='a1'>X</mi><mo>⟂</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='independent($a1,$a2)'><mi arg='a1'>X</mi><mo>⫫</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Independence_(probability_theory)"
        - "https://en.wikipedia.org/wiki/Independence_(mathematical_logic)"
@@ -5932,8 +5932,8 @@ concepts:
       property: "function, largeop"
       area: "order theory"
       comments:
-       - "<math><mrow intent='infimum($a1)'><mi>inf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='infimum($a1)'><mo>⋀</mo><mi arg='a1'>X</mi></math>"
+       - "<math><mrow intent='infimum($a1)'><mi>inf</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='infimum($a1)'><mo>⋀</mo><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
        - "https://en.wikipedia.org/wiki/Infimum_and_supremum"
@@ -5976,7 +5976,7 @@ concepts:
       property: prefix
       area: "formal languages"
       comments:
-       - "<math><mrow intent='infinitely-many-concurrently-active-copies($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='infinitely-many-concurrently-active-copies($a1)'><mo>!</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/pdf/0903.3513.pdf"
     
@@ -5986,7 +5986,7 @@ concepts:
       property: mixfix, 
       area: "set theory"
       comments:
-       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>↣</mo><mi arg='a3'>Y</mi></math>"
+       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>↣</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -6045,7 +6045,7 @@ concepts:
       property: "function, fenced"
       area: "number theory"
       comments:
-       - "<math><mrow intent='integer-part($a1)'><mi>int</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='integer-part($a1)'><mi>int</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "[ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/IntegerPart.html"
@@ -6082,7 +6082,7 @@ concepts:
       property: infix
       area: "algebraic geometry"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='intersection-number($a1,$a2)'><mi arg='a1'>X</mi><mo>⋅</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Intersection_number"
     
@@ -6172,8 +6172,8 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mover><mo>↦</mo><mo>∼</mo></mover><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>≅</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='isomorphism($a1,$a2)'><mi arg='a1'>X</mi><mover><mo>↦</mo><mo>∼</mo></mover><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='isomorphism($a1,$a2)'><mi arg='a1'>X</mi><mo>≅</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Isomorphism.html"
        - "https://en.wikipedia.org/wiki/Isomorphism"
@@ -6284,12 +6284,12 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sd</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cd</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/22.2"
        - "https://dlmf.nist.gov/22.2#E5"
@@ -6305,8 +6305,8 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-       - "<math><mrow intent='jacobson-radical($a1)'><mi>J</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='jacobson-radical($a1)'><mi>rad</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobson-radical($a1)'><mi>J</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='jacobson-radical($a1)'><mi>rad</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsonRadical.html"
        - "https://en.wikipedia.org/wiki/Jacobson_radical"
@@ -6425,7 +6425,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mn>6174</mn></math>"
+       - "<math><mrow><mn>6174</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KaprekarConstant.html"
        - "https://en.wikipedia.org/wiki/6174_(number)"
@@ -6543,8 +6543,8 @@ concepts:
       property: function
       area: "analytic number theory"
       comments:
-       - "<math><mrow intent='kloosterman-sum($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='kloosterman-sum($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='kloosterman-sum($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='kloosterman-sum($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KloostermansSum.html"
        - "https://en.wikipedia.org/wiki/Kloosterman_sum"
@@ -6707,7 +6707,7 @@ concepts:
       property: function
       area: "mathematical statistics"
       comments:
-       - "<math><mrow intent='kullback-leibler-distance($a1)'><mi>KL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='kullback-leibler-distance($a1)'><mi>KL</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "msub D KL"
       urls: 
        - "http://users.monash.edu/~lloyd/tildeMML/KL/"
@@ -6798,7 +6798,7 @@ concepts:
       area: "differential operators"
       notation: "msup ∇ 2"
       notationb: "mrow ∇ · ∇"
-      notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+      notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Laplace_operator"
        - "https://ncatlab.org/nlab/show/Laplace+operator"
@@ -6959,8 +6959,8 @@ concepts:
       property: fenced, fenced stacked
       area: "number theory"
       comments:
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></math>"
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi>p</mi></mfrac><mo>)</mo></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi>p</mi></mfrac><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
@@ -7145,9 +7145,9 @@ concepts:
       property: unit
       area: "units"
       comments:
-       - "<math><mrow intent='gunter-link($a1)'><mi>l.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='gunter-link($a1)'><mi>li.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='gunter-link($a1)'><mi>lnk.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>l.</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>li.</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>lnk.</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Link_(unit)"
     
@@ -7263,7 +7263,7 @@ concepts:
       property: prefix
       area: "order theory"
       comments:
-       - "<math><mrow intent='lower-closure-poset($a1)'><mo>↓</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='lower-closure-poset($a1)'><mo>↓</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     
@@ -7295,7 +7295,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='lower-shadow($a1)'><mi>𝜕</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='lower-shadow($a1)'><mi>𝜕</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "msub 𝜕 -"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
@@ -7668,8 +7668,8 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mrow intent='mills-ratio($a1)'><mi>m</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='mills-ratio($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='mills-ratio($a1)'><mi>m</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='mills-ratio($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsRatio.html"
        - "https://en.wikipedia.org/wiki/Mills_ratio"
@@ -7953,7 +7953,7 @@ concepts:
       area: "combinatorial analysis"
       comments:
        - "<math><msub intent='motzkin-number($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><mrow intent='motzkin-number($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='motzkin-number($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
        - "https://en.wikipedia.org/wiki/Motzkin_number"
@@ -8200,7 +8200,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='non-oriented-angle($a1)'><mo>∠</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='non-oriented-angle($a1)'><mo>∠</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Orientation_(vector_space)"
        - "https://en.wikipedia.org/wiki/Euclidean_space#Angle"
@@ -8298,7 +8298,7 @@ concepts:
       property: fenced
       area: "euclidean solid geometry"
       comments:
-       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></math>"
+       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octant.html"
        - "https://en.wikipedia.org/wiki/Octant_(plane_geometry)"
@@ -8420,7 +8420,7 @@ concepts:
       property: "function, fenced"
       area: "group theory"
       comments:
-       - "<math><mrow intent='order-of-group($a1)'><mi>ord</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='order-of-group($a1)'><mi>ord</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
        - "<math><mrow intent='order-of-group($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
@@ -8544,7 +8544,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='paraboloidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='paraboloidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ParaboloidalCoordinates.html"
        - "https://en.wikipedia.org/wiki/Paraboloidal_coordinates"
@@ -8742,8 +8742,8 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-       - "<math><mrow intent='pfaffian($a1)'><mi>Pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='pfaffian($a1)'><mi>pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='pfaffian($a1)'><mi>Pf</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='pfaffian($a1)'><mi>pf</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Pfaffian.html"
        - "https://en.wikipedia.org/wiki/Pfaffian"
@@ -8770,8 +8770,8 @@ concepts:
       property: function
       area: "physics"
       comments:
-       - "<math><mrow intent='phase($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='phase($a1)'><mi>ph</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='phase($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='phase($a1)'><mi>ph</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Phase.html"
        - "https://en.wikipedia.org/wiki/Phase_(waves)"
@@ -9011,7 +9011,7 @@ concepts:
       property: prefix
       area: "predicative mathematics"
       comments:
-       - "<math><mrow intent='positivitiy-predicate($a1)'><mo>◊</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='positivitiy-predicate($a1)'><mo>◊</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/positive+element"
     
@@ -9032,10 +9032,10 @@ concepts:
       property: "function, msup"
       area: "set theory"
       comments:
-       - "<math><mrow intent='power-set($a1)'><mi>P</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>𝒫</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>ℙ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='power-set($a1)'><mi>℘</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>P</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>𝒫</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>ℙ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>℘</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "msup 2 $1"
       urls: 
        - "https://mathworld.wolfram.com/PowerSet.html"
@@ -9104,8 +9104,8 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><mrow intent='prime-gap($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='prime-gap($a1)'><mi>g</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='prime-gap($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='prime-gap($a1)'><mi>g</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeGaps.html"
        - "https://en.wikipedia.org/wiki/Prime_gap"
@@ -9116,7 +9116,7 @@ concepts:
       property: postfix
       area: "number theory"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>#</mo></math>"
+       - "<math><mrow intent='primorial($a1)'><mi arg='a1'>x</mi><mo>#</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Primorial.html"
        - "https://en.wikipedia.org/wiki/Primorial"
@@ -9302,7 +9302,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='pythagorean-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='pythagorean-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PythagoreanTriple.html"
        - "https://en.wikipedia.org/wiki/Pythagorean_triple"
@@ -9322,8 +9322,8 @@ concepts:
       property: symbol
       area: "mathematical symbols"
       comments:
-       - "<math><mrow><mo>□</mo></math>"
-       - "<math><mrow><mo>∎</mo></math>"
+       - "<math><mrow><mo>□</mo></mrow></math>"
+       - "<math><mrow><mo>∎</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -9356,7 +9356,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='quadrilateral($a1)'><mo>◻</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='quadrilateral($a1)'><mo>◻</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Quadrangle.html"
        - "https://en.wikipedia.org/wiki/Quadrilateral"
@@ -9422,8 +9422,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Mc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Ms</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Mc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Ms</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/28.20#iv"
        - "https://dlmf.nist.gov/28.20#E15"
@@ -9450,7 +9450,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mi arg='a1'>x</mi></math>"
+       - "<math><mrow><mi arg='a1'>x</mi></mrow></math>"
        - "<math><mi intent='radius-vector'>r</mi></math>"
        - "<math><mi intent='radius-vector'>s</mi></math>"
       urls: 
@@ -9528,9 +9528,9 @@ concepts:
       property: function
       area: "graph theory, linear algebra, "
       comments:
-       - "<math><mrow intent='rank($a1)'><mi>r</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='rank($a1)'><mi>rank</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='rank($a1)'><mi>rk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>r</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>rank</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>rk</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rank.html"
        - "https://en.wikipedia.org/wiki/Rank_(graph_theory)"
@@ -9556,9 +9556,9 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='real-part($a1)'><mi>ℜ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='real-part($a1)'><mi>Re</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='real-part($a1)'><mi>ℛℯ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>ℜ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>Re</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>ℛℯ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RealPart.html"
        - "https://dlmf.nist.gov/1.9#E2"
@@ -9663,8 +9663,8 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mrow intent='residue($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='residue($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='residue($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='residue($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Residue.html"
        - "https://en.wikipedia.org/wiki/Residue_(complex_analysis)"
@@ -9736,8 +9736,8 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mrow intent='resultant($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='resultant($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='resultant($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='resultant($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Resultant.html"
        - "https://en.wikipedia.org/wiki/Resultant"
@@ -9892,10 +9892,10 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='right-angle($a1)'><mo>∟</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mrow intent='right-angle($a1)'><mo>⊾</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mrow intent='right-angle($a1)'><mo>⦜</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mrow intent='right-angle($a1)'><mo>⦝</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>∟</mo><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⊾</mo><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⦜</mo><mi arg='a1'>x</mi></mrow></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⦝</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RightAngle.html"
        - "https://en.wikipedia.org/wiki/Right_angle"
@@ -9962,7 +9962,7 @@ concepts:
        - "<math><mi intent='roman-numeral'>vii</mi></math>"
        - "<math><mi intent='roman-numeral'>viii</mi></math>"
        - "<math><mi intent='roman-numeral'>ix</mi></math>"
-       - "<math><mi arg='a1'>x</mi></math>"
+       - "<math><mrow><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RomanNumerals.html"
        - "https://en.wikipedia.org/wiki/Roman_numerals"
@@ -9974,7 +9974,7 @@ concepts:
       property: mixfix
       area: "category theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi></math>"
+       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
@@ -10079,8 +10079,8 @@ concepts:
       property: mixfix, fenced
       area: "vector algebra"
       comments:
-       - "<math><mi arg='a1'>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi arg='a2'>B</mi><mo>&middot;</mo><mi arg='a3'>C</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>,</mo><mi arg='a3'>C</mi><mo>]</mo></math>"
+       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mi arg='a1'>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi arg='a2'>B</mi><mo>&middot;</mo><mi arg='a3'>C</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>,</mo><mi arg='a3'>C</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ScalarTripleProduct.html"
        - "https://en.wikipedia.org/wiki/Triple_product"
@@ -10173,8 +10173,8 @@ concepts:
       property: function
       area: "riemannian geometry"
       comments:
-       - "<math><mrow intent='sectional-curvature($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='sectional-curvature($a1)'><mi>κ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sectional-curvature($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='sectional-curvature($a1)'><mi>κ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SectionalCurvature.html"
        - "https://en.wikipedia.org/wiki/Sectional_curvature"
@@ -10220,7 +10220,7 @@ concepts:
       property: prefix
       area: "commutative algebra"
       comments:
-       - "<math><mrow intent='set-of-invertible-maps($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='set-of-invertible-maps($a1)'><mo>!</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/abs/2009.015866"
     
@@ -10271,7 +10271,7 @@ concepts:
       property: mixfix
       area: "group theory"
       comments:
-       - "<math><mn>0</mn><mo>&rightarrow;</mo><mi arg='a1'>X</mi><mo>&rightarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi><mo>&rightarrow;</mo><mn>0</mn></math>"
+       - "<math><mrow intent='short-exact-sequence($a1,$a2,$a3)'><mn>0</mn><mo>&rightarrow;</mo><mi arg='a1'>X</mi><mo>&rightarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi><mo>&rightarrow;</mo><mn>0</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShortExactSequence.html"
        - "https://en.wikipedia.org/wiki/Exact_sequence"
@@ -10368,8 +10368,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='sinc-function($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='sinc-function($a1)'><mi>sinc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sinc-function($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='sinc-function($a1)'><mi>sinc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SincFunction.html"
        - "https://en.wikipedia.org/wiki/Sinc_function"
@@ -10604,7 +10604,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='spherical-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='spherical-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SphericalCoordinates.html"
        - "https://www.encyclopediaofmath.org/index.php/Spherical_coordinates"
@@ -10648,7 +10648,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></math>"
+       - "<math><mrow><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Square.html"
        - "https://en.wikipedia.org/wiki/Square"
@@ -10885,7 +10885,7 @@ concepts:
       property: prefix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='subfactorial($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='subfactorial($a1)'><mo>!</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derangement"
       alias:
@@ -10933,8 +10933,8 @@ concepts:
       area: "number theory"
       comments:
        - "<math><msup intent='successor($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
-       - "<math><mrow intent='successor($a1)'><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow intent='successor($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='successor($a1)'><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='successor($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Proclus"
        - "https://en.wikipedia.org/wiki/Successor_cardinal"
@@ -10947,8 +10947,8 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>|</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='such-that($a1,$a2)'><mi arg='a1'>X</mi><mo>|</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='such-that($a1,$a2)'><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Set_(mathematics)#Set-builder_notation"
     
@@ -10969,8 +10969,8 @@ concepts:
       property: infix
       area: "abstract algebra"
       comments:
-       - "<math><mi arg='a1'>X</mi><msub><mo>⊆</mo><mi>s</mi></msub><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>≪</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='superfluous-submodule($a1,$a2)'><mi arg='a1'>X</mi><msub><mo>⊆</mo><mi>s</mi></msub><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='superfluous-submodule($a1,$a2)'><mi arg='a1'>X</mi><mo>≪</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Essential_extension"
       alias:
@@ -10999,8 +10999,8 @@ concepts:
       property: "function, largeop"
       area: "order theory, lattice theory"
       comments:
-       - "<math><mrow intent='supremum($a1)'><mi>sup</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='supremum($a1)'><mo>⋁</mo><mi arg='a1'>X</mi></math>"
+       - "<math><mrow intent='supremum($a1)'><mi>sup</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='supremum($a1)'><mo>⋁</mo><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
       alias:
@@ -11042,7 +11042,7 @@ concepts:
       property: mixfix, infix
       area: "set theory"
       comments:
-       - "<math><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>&#x21a0;</mo><mi arg='a3'>Y</mi></math>"
+       - "<math><mrow intent='surjection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>&#x21a0;</mo><mi arg='a3'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
        - "https://en.wikipedia.org/wiki/Surjective_function"
@@ -11066,8 +11066,8 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mrow intent='symmetric-algebra($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='symmetric-algebra($a1)'><mi>Sym</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='symmetric-algebra($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='symmetric-algebra($a1)'><mi>Sym</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Symmetric_algebra"
        - "https://ncatlab.org/nlab/show/symmetric+algebra"
@@ -11079,9 +11079,9 @@ concepts:
       property: infix
       area: "set theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>△</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊖</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='symmetric-difference($a1,$a2)'><mi arg='a1'>X</mi><mo>△</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='symmetric-difference($a1,$a2)'><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='symmetric-difference($a1,$a2)'><mi arg='a1'>X</mi><mo>⊖</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SymmetricDifference.html"
        - "https://en.wikipedia.org/wiki/Symmetric_difference"
@@ -11253,7 +11253,7 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-       - "<math><mrow intent='tensor-algebra($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='tensor-algebra($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       notationa: "msup T •"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_algebra"
@@ -11291,7 +11291,7 @@ concepts:
       property: prefix
       area: "logic"
       comments:
-       - "<math><mrow intent='therefore-sign($a1)'><mo>∴</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='therefore-sign($a1)'><mo>∴</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Therefore_sign"
        - "https://en.wikipedia.org/wiki/.%C2%B7."
@@ -11342,7 +11342,7 @@ concepts:
       property: infix
       area: "arithmetic"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='to($a1,$a2)'><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/One-to-One.html"
     
@@ -11352,8 +11352,8 @@ concepts:
       property: function
       area: "characteristic classes"
       comments:
-       - "<math><mrow intent='todd-class($a1)'><mi>td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='todd-class($a1)'><mi>Td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='todd-class($a1)'><mi>td</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='todd-class($a1)'><mi>Td</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Todd_class"
        - "https://ncatlab.org/nlab/show/Todd+class"
@@ -11489,7 +11489,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mrow intent='triangle($a1,$a2,$a3)'><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi></mrow></math>"
+       - "<math><mrow intent='triangle($a1,$a2,$a3)'><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Triangle.html"
        - "https://en.wikipedia.org/wiki/Triangle"
@@ -11502,8 +11502,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='triangle-function($a1)'><mi>Λ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='triangle-function($a1)'><mi>tri</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='triangle-function($a1)'><mi>Λ</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='triangle-function($a1)'><mi>tri</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TriangleFunction.html"
        - "https://en.wikipedia.org/wiki/Triangular_function"
@@ -11530,7 +11530,7 @@ concepts:
       property: infix
       area: "geometry"
       comments:
-       - "<math><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>:</mo><mi arg='a3'>z</mi></math>"
+       - "<math><mrow intent='trilinear-coordinates($a1,$a2,$a3)'><mi arg='a1'>x</mi><mo>:</mo><mi arg='a2'>y</mi><mo>:</mo><mi arg='a3'>z</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Trilinear_coordinates"
     
@@ -11562,7 +11562,7 @@ concepts:
       property: fenced
       area: "algebra"
       comments:
-       - "<math><mrow intent='triple-scalar-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
+       - "<math><mrow intent='triple-scalar-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TripleScalarProduct.html"
       alias:
@@ -11621,7 +11621,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mrow intent='turan-number($a1,$a2,$a3)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='turan-number($a1,$a2,$a3)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tur%C3%A1n_number"
        - "https://www.encyclopediaofmath.org/index.php/Turan_number"
@@ -11633,10 +11633,10 @@ concepts:
       property: unit
       area: "geometry"
       comments:
-       - "<math><mrow intent='turn($a1)'><mi>cyc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='turn($a1)'><mi>rev</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='turn($a1)'><mi>tr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mrow intent='turn($a1)'><mi>pla</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>cyc</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>rev</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>tr</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>pla</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Turn_(geometry)"
       alias:
@@ -11650,7 +11650,7 @@ concepts:
       property: infix
       area: "topology"
       comments:
-       - "<math><mi arg='a1'>X</mi><msub><mo>⊗</mo><mi>τ</mi></msub><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='twisted-tensor-product($a1,$a2)'><mi arg='a1'>X</mi><msub><mo>⊗</mo><mi>τ</mi></msub><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/twisted+tensor+product"
     
@@ -11674,7 +11674,7 @@ concepts:
       property: infix
       area: "type theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='typing-judgement($a1,$a2)'><mi arg='a1'>X</mi><mo>:</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/judgment"
     
@@ -11828,9 +11828,9 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>≀</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>Wr</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><msub><mo>Wr</mo><mi>&#x03a9;</mi></msub><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='unrestricted-wreath-product($a1,$a2)'><mi arg='a1'>X</mi><mo>≀</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='unrestricted-wreath-product($a1,$a2)'><mi arg='a1'>X</mi><mo>Wr</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='unrestricted-wreath-product($a1,$a2)'><mi arg='a1'>X</mi><msub><mo>Wr</mo><mi>&#x03a9;</mi></msub><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -11843,7 +11843,7 @@ concepts:
       property: prefix
       area: "order theory"
       comments:
-       - "<math><mrow intent='upper-closure-poset($a1)'><mo>↑</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='upper-closure-poset($a1)'><mo>↑</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     
@@ -11918,8 +11918,8 @@ concepts:
       property: infix
       area: "machine learning"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>◦</mo><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='vector-concatenation($a1,$a2)'><mi arg='a1'>X</mi><mo>◦</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='vector-concatenation($a1,$a2)'><mi arg='a1'>X</mi><mo>⊕</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://arxiv.org/pdf/1903.00172v1.pdf"
        - "https://arxiv.org/abs/1901.10879"
@@ -11955,7 +11955,7 @@ concepts:
       property: function
       area: "quaternions"
       comments:
-       - "<math><mrow intent='versor($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='versor($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Versor_(physics)"
        - "https://en.wikipedia.org/wiki/Versor"
@@ -12050,7 +12050,7 @@ concepts:
       property: infix
       area: "domain theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mo>≪</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='way-below($a1,$a2)'><mi arg='a1'>X</mi><mo>≪</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "http://mizar.org/fm/1997-6/pdf6-1/waybel_3.pdf"
        - "https://en.wikipedia.org/wiki/Domain_theory"
@@ -12064,8 +12064,8 @@ concepts:
       property: infix
       area: "analysis"
       comments:
-       - "<math><mi arg='a1'>X</mi><mover><mo>→</mo><mi>w</mi></mover><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><mo>⇀</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='weak-convergence($a1,$a2)'><mi arg='a1'>X</mi><mover><mo>→</mo><mi>w</mi></mover><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='weak-convergence($a1,$a2)'><mi arg='a1'>X</mi><mo>⇀</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WeakConvergence.html"
        - "https://en.wikipedia.org/wiki/Weak_convergence_(Hilbert_space)"
@@ -12331,7 +12331,7 @@ concepts:
       property: fenced
       area: "ring theory"
       comments:
-       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
@@ -12457,7 +12457,7 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroIdeal.html"
        - "https://ncatlab.org/nlab/show/zero+ideal"
@@ -12488,7 +12488,7 @@ concepts:
       property: symbol
       area: "algebra"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_object_(algebra)"
        - "https://ncatlab.org/nlab/show/zero+object"
@@ -12499,8 +12499,8 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
-       - "<math><mn>0</mn></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></mrow></math>"
+       - "<math><mrow><mn>0</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroRing.html"
        - "https://en.wikipedia.org/wiki/Zero_ring"
@@ -12511,7 +12511,7 @@ concepts:
       property: constant
       area: "linear algebra"
       comments:
-       - "<math><mn>0</mn></math>"
+       - "<math><mrow><mn>0</mn></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroVector.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -887,7 +887,7 @@ concepts:
       property: mixfix
       area: "set theory"
       comments:
-       - "<math><mrow intent='bijection($a1,$a2,$a3)'><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>⤖</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='bijection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>⤖</mo><mi arg='a3'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -10197,8 +10197,7 @@ concepts:
       property: mixfix
       area: "ring theory"
       comments:
-       - "<math><mrow intent='ring-of-formal-power-series($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow $1 [[ $2 ]]"
+       - "<math><mrow intent='ring-of-formal-power-series($a1,$a2)'><mi arg='a1'>R</mi><mrow><mo>⟦</mo><mi arg='a2'>x</mi><mo>⟧</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Formal_power_series#The_ring_of_formal_power_series"
     
@@ -10350,7 +10349,7 @@ concepts:
       urls: 
        - "https://mathworld.wolfram.com/SampleVariance.html"
        - "https://www.encyclopediaofmath.org/index.php/Sample_variance"
-       - "https://en.wikipedia.org/wiki/Variance#Sample_variance"
+       - "https://en.wikipedia.org/wiki/Variance#Sample_variance	"
     
     - concept: scalar-triple-product
       arity: 3
@@ -10377,13 +10376,12 @@ concepts:
        - "https://dlmf.nist.gov/21.2#E1"
     
     - concept: schlaefli-symbol
-      arity: 1
-      en: schlaefli symbol of $1
+      arity: "*"	
+      en: schlaefli symbol of $1, ...
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='schlaefli-symbol($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow { $1 , ..., $n }"
+       - "<math><mrow intent='schlaefli-symbol($a1,$a2,$a3)'><mo>{</mo><mi arg='a1'>p</mi><mo>,</mo><mi arg='a2'>r</mi><mo>,</mo><mi arg='a3'>r</mi><mo>}</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Schl%C3%A4fli_symbol"
     
@@ -10446,8 +10444,7 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mrow intent='second-carmichael-function($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup λ '"
+       - "<math><mrow intent='second-carmichael-function($a1)'><msup><mi>λ</mi><mo>′</mo></msup><mrow><mo>(</mo><mi arg='a1'>n</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CarmichaelFunction.html"
        - "https://en.wikipedia.org/wiki/Carmichael_function"
@@ -10531,8 +10528,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='shift-operator($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup T t"
+       - "<math><mrow intent='shift-operator($a1)'><msup><mi>T</mi><mo>t</mo></msup><mrow><mo>(</mo><mi arg='a1'>f</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ShiftOperator.html"
        - "https://en.wikipedia.org/wiki/Shift_operator"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -675,8 +675,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='baumslag-solitar-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow BS ( $1, $2 )"
+       - "<math><mrow intent='baumslag-solitar-group($a1,$a2)'><mi>BS</mi><mrow><mo>(</mo><mi arg='a1'>m</mi><mo>,</mo><mi arg='a2'>n</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Baumslag%E2%80%93Solitar_group"
        - "https://www.encyclopediaofmath.org/index.php/Baumslag-Solitar_group"
@@ -942,13 +941,12 @@ concepts:
        - combination
     
     - concept: binomial-distribution
-      arity: 1
-      en: binomial distribution of $1
+      arity: 2
+      en: binomial distribution $1 $2
       property: function
       area: "probability theory"
       comments:
-       - "<math><mrow intent='binomial-distribution($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow B(n,p"
+       - "<math><mrow intent='binomial-distribution($a1,$a2)'><mi>B</mi><mrow><mo>(</mo><mi arg='a1'>n</mi><mo>,</mo><mi arg='a2'>p</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BinomialDistribution.html"
        - "https://en.wikipedia.org/wiki/Binomial_distribution"
@@ -1816,6 +1814,8 @@ concepts:
       area: "abstract algebra"
       comments:
        - "<math><msup intent='commutator-subgroup($a1)'><mi arg='a1'>X</mi><mo>'</mo></msup></math>"
+       - "<math><msup intent='commutator-subgroup($a1)'><mi arg='a1'>X</mi><mrow><mo>(</mo><mn>1</mn><mo>)</mo></mrow></msup></math>"
+       - "<math><mrow intent='commutator-subgroup($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>,</mo><mi>X</mi><mo>]</mo></mrow></math>"
       notationb: "msup $1 (1)"
       notationa: "mrow [ $1, $1 ]"
       urls: 
@@ -2511,9 +2511,8 @@ concepts:
       property: fenced
       area: "differential topology"
       comments:
-       - "<math><mrow intent='current($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow [[ $1 ]]"
-      notationa: "<math><mrow intent='current($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='current($a1)'><mo>[</mo><mi arg='a1'>M</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='current($a1)'><mo>⟦</mo><mi arg='a1'>M</mi><mo>⟧</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Current.html"
        - "https://en.wikipedia.org/wiki/Current_(mathematics)"
@@ -8181,8 +8180,8 @@ concepts:
       property: msup, mixfix
       area: "abstract algebra"
       comments:
-       - "<math><msup intent='multiplicative-inverse($a1)'><mi arg='a1'>X</mi><mn>-1</mn></msup></math>"
-      notationa: "mrow 1 / $1"
+       - "<math><msup intent='multiplicative-inverse($a1)'><mi arg='a1'>x</mi><mn>-1</mn></msup></math>"
+       - "<math><mrow intent='multiplicative-inverse($a1)'><mn>1</mn><mo>/</mo><mi arg='a1'>x</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Inverse.html"
        - "https://en.wikipedia.org/wiki/Inverse_function"
@@ -11674,13 +11673,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Topological_entropy"
     
     - concept: toroidal-coordinate
-      arity: 1
-      en: toroidal coordinate of $1
+      arity: 3
+      en: toroidal coordinates $1 $2 $3
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='toroidal-coordinate($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow ( σ , τ , ϕ"
+       - "<math><mrow intent='toroidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>σ</mi><mo>,</mo><mi arg='a2'>τ</mi><mo>,</mo><mi arg='a3'>ϕ"</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ToroidalCoordinates.html"
        - "https://en.wikipedia.org/wiki/Toroidal_coordinates"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -66,7 +66,7 @@ concepts:
       property: postfix. prefix
       area: "calendar units"
       comments:
-       - "<math><mi>AD</mi><mo>&#x2009;</mo><mn>2024</mn></math>"
+       - "<math><mrow intent='ad($a1)'><mi>AD</mi><mo>&#x2009;</mo><mn>2024</mn></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -76,7 +76,7 @@ concepts:
       property: prefix
       area: "abstract algebra"
       comments:
-       - "<math><mo>-</mo><mi arg='a1'>n</mi></math>"
+       - "<math><mrow intent='additive-inverse($a1)'><mo>-</mo><mi arg='a1'>n</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Additive_inverse"
       alias:
@@ -208,8 +208,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>Ai</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Bi</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='airy-function($a1)'><mi>Ai</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='airy-function($a1)'><mi>Bi</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AiryFunctions.html"
        - "https://en.wikipedia.org/wiki/Airy_function"
@@ -225,8 +225,8 @@ concepts:
       property: function
       area: "algebraic geometry"
       comments:
-       - "<math><mi>A</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Alb</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='albanese-variety($a1)'><mi>A</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='albanese-variety($a1)'><mi>Alb</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AlbaneseVariety.html"
        - "https://en.wikipedia.org/wiki/Albanese_variety"
@@ -292,8 +292,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mi>A</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Alt</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='alternating-group($a1)'><mi>A</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
+       - "<math><mrow intent='alternating-group($a1)'><mi>Alt</mi><mrow><mi arg='a1'>X</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AlternatingGroup.html"
        - "https://en.wikipedia.org/wiki/Alternating_group"
@@ -421,7 +421,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></math>"
+       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/AnharmonicRatio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -493,8 +493,8 @@ concepts:
       property: unit
       area: "SI-mentioned units"
       comments:
-       - "<math><mi>arcmin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>amin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcminute($a1)'><mi>arcmin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcminute($a1)'><mi>amin</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "mo ′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -511,8 +511,8 @@ concepts:
       property: unit
       area: "SI-mentioned units"
       comments:
-       - "<math><mi>arcsec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>asec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcsecond($a1)'><mi>arcsec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arcsecond($a1)'><mi>asec</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "mo ′′"
       urls: 
        - "https://mathworld.wolfram.com/Arcminute.html"
@@ -560,8 +560,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>agm</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>AGM</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>agm</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='arithmetic-geometric-mean($a1)'><mi>AGM</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Arithmetic-GeometricMean.html"
        - "https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean"
@@ -585,7 +585,7 @@ concepts:
       property: fenced
       area: "algebra"
       comments:
-       - "<math><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
+       - "<math><mrow intent='associator($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Associator.html"
        - "https://en.wikipedia.org/wiki/Associator"
@@ -804,10 +804,10 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Beta</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>𝓑𝓮</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>Beta</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>𝓑𝓮</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-distribution($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaDistribution.html"
        - "https://en.wikipedia.org/wiki/Beta_distribution"
@@ -818,8 +818,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-function($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='beta-function($a1)'><mi>β</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/BetaFunction.html"
        - "https://en.wikipedia.org/wiki/%CE%92(x,_y)"
@@ -866,7 +866,7 @@ concepts:
       property: prefix
       area: "complexity"
       comments:
-       - "<math><mi>O</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow><mi>O</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: ""
       urls: 
        - "https://en.wikipedia.org/wiki/Big_O_notation"
@@ -887,7 +887,7 @@ concepts:
       property: mixfix
       area: "set theory"
       comments:
-       - "<math><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>⤖</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='bijection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>⤖</mo><mi arg='a3'>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -1030,9 +1030,9 @@ concepts:
       property: function
       area: "topology"
       comments:
-       - "<math><mi>bd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>fr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>∂</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>bd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>fr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='boundary($a1)'><mi>∂</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Boundary.html"
        - "https://en.wikipedia.org/wiki/Boundary_(topology)"
@@ -1146,7 +1146,7 @@ concepts:
       area: "set theory"
       notation: "mrow | mo #"
       notationb: "mi card"
-      notationa: "<math><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+      notationa: "<math><mrow intent='cardinality($a1)'><mi>n</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cardinality.html"
        - "https://en.wikipedia.org/wiki/Cardinality"
@@ -1251,7 +1251,7 @@ concepts:
       property: function
       area: "analysis"
       comments:
-       - "<math><mi>p.v.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='cauchy-principal-value($a1)'><mi>p.v.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CauchyPrincipalValue.html"
        - "https://en.wikipedia.org/wiki/Cauchy_principal_value"
@@ -1297,10 +1297,10 @@ concepts:
       property: fenced, function
       area: "number theory"
       comments:
-       - "<math><mo>⌈</mo><mi arg='a1'>X</mi><mo>⌉</mo></math>"
-       - "<math><mo>&#x27e7;</mo><mi arg='a1'>X</mi><mo>&#x27e6;</mo></math>"
-       - "<math><mo>]</mo><mi arg='a1'>X</mi><mo>[</mo></math>"
-       - "<math><mi>ceil</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>⌈</mo><mi arg='a1'>X</mi><mo>⌉</mo></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>&#x27e7;</mo><mi arg='a1'>X</mi><mo>&#x27e6;</mo></math>"
+       - "<math><mrow intent='ceiling($a1)'><mo>]</mo><mi arg='a1'>X</mi><mo>[</mo></math>"
+       - "<math><mrow intent='ceiling($a1)'><mi>ceil</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Floor_and_ceiling_functions"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -1431,9 +1431,9 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mi>θ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ϑ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>θ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>ϑ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-first-kind($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheFirstKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1447,8 +1447,8 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mi>ψ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>U</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>ψ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='chebyshev-polynomial-of-second-kind($a1)'><mi>U</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChebyshevPolynomialoftheSecondKind.html"
        - "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
@@ -1558,8 +1558,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ℬ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='classifying-space($a1)'><mi>B</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='classifying-space($a1)'><mi>ℬ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Classifying_space"
        - "https://ncatlab.org/nlab/show/classifying+space"
@@ -1659,8 +1659,8 @@ concepts:
       property: "function, msup"
       area: "abstract algebra,, topology"
       comments:
-       - "<math><mi>cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='closure($a1)'><mi>cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='closure($a1)'><mi>Cl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><msup intent='closure($a1)'><mi arg='a1'>X</mi><mo>−</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Closure.html"
@@ -1712,8 +1712,8 @@ concepts:
       property: "indexed function"
       area: "signal processing, quantum physics"
       comments:
-       - "<math><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='coherence($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='coherence($a1)'><mi>γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Coherence_(signal_processing)"
        - "https://en.wikipedia.org/wiki/Coherence_(physics)"
@@ -1768,7 +1768,7 @@ concepts:
       property: fenced
       area: "abstract algebra"
       comments:
-       - "<math><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
+       - "<math><mrow intent='commutator($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Commutator.html"
        - "https://en.wikipedia.org/wiki/Commutator"
@@ -1823,7 +1823,7 @@ concepts:
       property: fenced
       area: "order theory"
       comments:
-       - "<math><mo>]</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>[</mo></math>"
+       - "<math><mrow intent='complement-of-interval($a1,$a2)'><mo>]</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>[</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Interval_(mathematics)"
     
@@ -1998,7 +1998,7 @@ concepts:
       property: mixfix
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></math>"     
+       - "<math><mrow><mo>(</mo><msub><mi arg='a1'>a</mi><mi arg='a2'>b</mi></msub><mo>,</mo><msub><mi arg='a3'>c</mi><mi arg='a4'>d</mi></msub><mo>)</mo></math>"     
       urls: 
        - "https://mathworld.wolfram.com/Configuration.html"
        - "https://en.wikipedia.org/wiki/Configuration_(geometry)"
@@ -2148,7 +2148,7 @@ concepts:
       property: constant
       area: "logic"
       comments:
-       - "<math><mo>⊥</mo></math>"
+       - "<math><mrow><mo>⊥</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2372,7 +2372,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></math>"
+       - "<math><mrow><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"
@@ -2447,8 +2447,8 @@ concepts:
       property: function
       area: "vector calculus"
       comments:
-       - "<math><mi>curl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>rot</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='curl($a1)'><mi>curl</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='curl($a1)'><mi>rot</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "mrow ∇ × $1"
       urls: 
        - "https://mathworld.wolfram.com/Curl.html"
@@ -2534,7 +2534,7 @@ concepts:
       property: prefix
       area: "partial differential equations"
       comments:
-       - "<math><mo>☐</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='dalembert-operator($a1)'><mo>☐</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/D%27Alembert_operator"
        - "https://www.encyclopediaofmath.org/index.php/D'Alembert_operator"
@@ -2561,8 +2561,8 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mi>F</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='dawson-function($a1)'><mi>F</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='dawson-function($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationb: "mi sub D -"
       notationa: "mi sub D +"
       urls: 
@@ -2622,8 +2622,8 @@ concepts:
       property: function
       area: "logic"
       comments:
-       - "<math><mi>Ded</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Th</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='deductive-closure($a1)'><mi>Ded</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='deductive-closure($a1)'><mi>Th</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Deductive_closure"
     
@@ -2723,7 +2723,7 @@ concepts:
       property: prefix
       area: "programming languages"
       comments:
-       - "<math><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='dereference($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://arxiv.org/pdf/1208.5915.pdf"
     
@@ -2785,8 +2785,8 @@ concepts:
       property: symbol, prefix unit
       area: "geometry"
       comments:
-       - "<math><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mo>⌀</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='diameter($a1)'><mi>d</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='diameter($a1)'><mo>⌀</mo><mi arg='a1'>x</mi></math>"
       notationb: "mi DIA"
       notationa: "mi dia"
       urls: 
@@ -2838,8 +2838,8 @@ concepts:
       property: prefix
       area: "calculus"
       comments:
-       - "<math><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mo>∂</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='differential-operator($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='differential-operator($a1)'><mo>∂</mo><mi arg='a1'>x</mi></math>"
       notationa: "mfrac d mrow d $1"
       urls: 
        - "https://mathworld.wolfram.com/DifferentialOperator.html"
@@ -2908,7 +2908,7 @@ concepts:
       property: "function, fenced"
       area: "linear algebra, graph theory"
       comments:
-       - "<math><mi>dim</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='dimension($a1)'><mi>dim</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><mrow intent='dimension($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dimension.html"
@@ -3124,9 +3124,9 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mi>Disc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Δ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>Disc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>D</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='discriminant($a1)'><mi>Δ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Discriminant.html"
        - "https://en.wikipedia.org/wiki/Discriminant"
@@ -3167,7 +3167,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>|</mo><mi arg='a1'>X</mi><mo>&#x2009;</mo><mi arg='a2'>Y</mi><mo>|</mo></math>"
+       - "<math><mrow intent='distance($a1,$a2)'><mo>|</mo><mi arg='a1'>X</mi><mo>&#x2009;</mo><mi arg='a2'>Y</mi><mo>|</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Distance"
     
@@ -3189,8 +3189,8 @@ concepts:
       property: "function, mixfix"
       area: "vector calculus"
       comments:
-       - "<math><mi>div</mi><mi>f</mi></math>"
-       - "<math><mi>∇</mi><mo>⋅</mo><mi>f</mi></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi>f</mi></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3492,9 +3492,9 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EllipticFunction.html"
        - "https://en.wikipedia.org/wiki/Elliptic_function"
@@ -3602,7 +3602,7 @@ concepts:
       property: fenced
       area: "set theory"
       comments:
-       - "<math><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
+       - "<math><mrow intent='equivalence-class($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/EquivalenceClass.html"
        - "https://en.wikipedia.org/wiki/Equivalence_class"
@@ -3654,9 +3654,9 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>erf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>erfc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>w</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>erf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>erfc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='error-function($a1)'><mi>w</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ErrorFunction.html"
        - "https://en.wikipedia.org/wiki/Error_function"
@@ -3684,7 +3684,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mi>ess inf</mi><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='essential-infimum($a1)'><mi>ess inf</mi><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/essentialsupremum.html"
        - "https://en.wikipedia.org/wiki/essential_supremum_and_essential_infimum"
@@ -3696,7 +3696,7 @@ concepts:
       property: function
       area: "measure theory"
       comments:
-       - "<math><mi>ess sup</mi><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='essential-supremum($a1)'><mi>ess sup</mi><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/EssentialSupremum.html"
        - "https://en.wikipedia.org/wiki/Essential_supremum_and_essential_infimum"
@@ -3844,8 +3844,8 @@ concepts:
       property: function
       area: "number theory"
       comments:
-       - "<math><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='euler-totient-function($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='euler-totient-function($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/EulerTotientFunction.html"
        - "https://en.wikipedia.org/wiki/Euler%27s_totient_function"
@@ -3902,7 +3902,7 @@ concepts:
       property: fenced
       area: "quantum physics"
       comments:
-       - "<math><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
+       - "<math><mrow intent='expectation-value($a1)'><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ExpectationValue.html"
        - "https://en.wikipedia.org/wiki/Expectation_value_(quantum_mechanics)"
@@ -3914,8 +3914,8 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mi>E</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='expected-value($a1)'><mi>E</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='expected-value($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><msub intent='expected-value($a1)'><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Expected_value#Notations"
@@ -3959,7 +3959,7 @@ concepts:
       property: "function, msup"
       area: "topology"
       comments:
-       - "<math><mi>ext</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='exterior($a1)'><mi>ext</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><msup intent='exterior($a1)'><mi arg='a1'>X</mi><mi>e</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Exterior.html"
@@ -4230,10 +4230,10 @@ concepts:
       property: fenced, function
       area: "number theory"
       comments:
-       - "<math><mo>⌊</mo><mi arg='a1'>X</mi><mo>⌋</mo></math>"
-       - "<math><mo>&#x27e6;</mo><mi arg='a1'>X</mi><mo>&#x27e7;</mo></math>"
-       - "<math><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
-       - "<math><mi>floor</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='floor($a1)'><mo>⌊</mo><mi arg='a1'>X</mi><mo>⌋</mo></math>"
+       - "<math><mrow intent='floor($a1)'><mo>&#x27e6;</mo><mi arg='a1'>X</mi><mo>&#x27e7;</mo></math>"
+       - "<math><mrow intent='floor($a1)'><mo>[</mo><mi arg='a1'>X</mi><mo>]</mo></math>"
+       - "<math><mrow intent='floor($a1)'><mi>floor</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://youtu.be/RxNs4SwP6lk"
        - "https://youtu.be/RxNs4SwP6lk"
@@ -4350,9 +4350,9 @@ concepts:
       property: "function, fenced"
       area: "arithmetic"
       comments:
-       - "<math><mi>frac</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mo>&#x27e6;</mo><mi arg='a1'>x</mi><mo>&#x27e7;</mo></math>"
-       - "<math><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mi>frac</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mo>&#x27e6;</mo><mi arg='a1'>x</mi><mo>&#x27e7;</mo></math>"
+       - "<math><mrow intent='fractional-part($a1)'><mo>{</mo><mi arg='a1'>x</mi><mo>}</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/FractionalPart.html"
        - "https://en.wikipedia.org/wiki/Fractional_part"
@@ -4377,8 +4377,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='frattini-subgroup($a1)'><mi>φ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='frattini-subgroup($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FrattiniSubgroup.html"
        - "https://en.wikipedia.org/wiki/Frattini_subgroup"
@@ -4428,7 +4428,7 @@ concepts:
       property: mixfix
       area: "ring theory"
       comments:
-       - "<math><mi>R</mi><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
+       - "<math><mrow intent='free-algebra($a1,$a2)'><mi>R</mi><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeAlgebra.html"
        - "https://en.wikipedia.org/wiki/Free_algebra"
@@ -4477,9 +4477,9 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mi>ℱ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>ℱ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>C</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='fresnel-integral($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FresnelIntegrals.html"
        - "https://en.wikipedia.org/wiki/Fresnel_integral"
@@ -4508,7 +4508,7 @@ concepts:
       property: fenced
       area: "differntial geometry"
       comments:
-       - "<math><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
+       - "<math><mrow intent='frolicher-nijenhuis-bracket($a1,$a2)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>]</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fr%C3%B6licher%E2%80%93Nijenhuis_bracket"
        - "https://encyclopediaofmath.org/wiki/Fr%C3%B6licher-Nijenhuis_bracket"
@@ -4532,7 +4532,7 @@ concepts:
       area: "category theory"
       comments:
        - "<math><msup intent='functor-category($a1,$a2)'><mi arg='a1'>f</mi><mi arg='a1'>g</mi></msup></math>"
-       - "<math><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></math>"
+       - "<math><mrow intent='functor-category($a1,$a2)'><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -4617,7 +4617,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mi>Gal</mi></math>"
+       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -4730,7 +4730,7 @@ concepts:
       property: fenced
       area: "functional analysis"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='gelfand-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Rigged_Hilbert_space#Formal_definition_(Gelfand_triple)"
     
@@ -4773,8 +4773,8 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mi>GL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Aut</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='general-linear-group($a1)'><mi>GL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='general-linear-group($a1)'><mi>Aut</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GeneralLinearGroup.html"
        - "https://en.wikipedia.org/wiki/General_linear_group"
@@ -4975,8 +4975,8 @@ concepts:
       property: function
       area: "linear algebra"
       comments:
-       - "<math><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gram-determinant($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gram-determinant($a1)'><mi>Γ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GramDeterminant.html"
        - "https://www.encyclopediaofmath.org/index.php/Gram_determinant"
@@ -5055,7 +5055,7 @@ concepts:
       comments:
        - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>*</mo></msup></math>"
        - "<math><msup intent='group-of-units($a1)'><mi arg='a1'>X</mi><mo>×</mo></msup></math>"
-       - "<math><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='group-of-units($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/group+of+units"
        - "https://ncatlab.org/nlab/show/group+of+units"
@@ -5120,7 +5120,7 @@ concepts:
       property: operator
       area: "quantum mechanics"
       comments:
-       - "<math><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hamiltonian($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationc: "mover H ˇ"
       notationb: "mover H ^"
       notationa: "mrow < H >"
@@ -5278,8 +5278,8 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>h</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='height-function($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='height-function($a1)'><mi>h</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Height_of_a_polynomial"
     
@@ -5325,8 +5325,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>He</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hermite-polynomial($a1)'><mi>H</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hermite-polynomial($a1)'><mi>He</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/HermitePolynomial.html"
        - "https://en.wikipedia.org/wiki/Hermite_polynomials"
@@ -5389,8 +5389,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>Hf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>H⁢ℓ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='heun-function($a1)'><mi>Hf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='heun-function($a1)'><mi>H⁢ℓ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Heun_function"
        - "https://dlmf.nist.gov/31.1"
@@ -5415,7 +5415,7 @@ concepts:
       property: unit
       area: "arithmetic"
       comments:
-       - "<math><mi>hex</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hexadecimal($a1)'><mi>hex</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationb: "msub $1 hex"
       notationa: "msub $1 16"
       urls: 
@@ -5461,7 +5461,7 @@ concepts:
       property: prefix
       area: "differential geometry"
       comments:
-       - "<math><mo>⋆</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='hodge-star-operator($a1)'><mo>⋆</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Hodge_dual"
        - "https://ncatlab.org/nlab/show/Hodge+star+operator"
@@ -5550,12 +5550,12 @@ concepts:
       property: unit
       area: "metric unit"
       comments:
-       - "<math><mi>PS</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>cv</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>hk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>pk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ks</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ch</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>PS</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>cv</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>hk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>pk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>ks</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='horsepower-metric($a1)'><mi>ch</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Metric_horsepower"
       alias:
@@ -5659,7 +5659,7 @@ concepts:
       property: "function, fenced"
       area: "multilinear algebra"
       comments:
-       - "<math><mi>det</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='hyperdeterminant($a1)'><mi>det</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><mrow intent='hyperdeterminant($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Hyperdeterminant.html"
@@ -5702,7 +5702,7 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mi>id</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='identity-function($a1)'><mi>id</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><msub intent='identity-function($a1)'><mi>id</mi><mi arg='a1'>x</mi></msub></math>"
        - "<math><msub intent='identity-function($a1)'><mi>I</mi><mi arg='a1'>x</mi></msub></math>"
       urls: 
@@ -5788,7 +5788,7 @@ concepts:
       property: fenced
       area: "incidence geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>P</mi><mo>,</mo><mi arg='a2'>L</mi><mo>,</mo><mi arg='a3'>I</mi><mo>)</mo></math>"
+       - "<math><mrow intent='incidence-structure($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>P</mi><mo>,</mo><mi arg='a2'>L</mi><mo>,</mo><mi arg='a3'>I</mi><mo>)</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Incidence_structure"
     
@@ -5932,8 +5932,8 @@ concepts:
       property: "function, largeop"
       area: "order theory"
       comments:
-       - "<math><mi>inf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mo>⋀</mo><mi arg='a1'>X</mi></math>"
+       - "<math><mrow intent='infimum($a1)'><mi>inf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='infimum($a1)'><mo>⋀</mo><mi arg='a1'>X</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Infimum.html"
        - "https://en.wikipedia.org/wiki/Infimum_and_supremum"
@@ -5976,7 +5976,7 @@ concepts:
       property: prefix
       area: "formal languages"
       comments:
-       - "<math><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='infinitely-many-concurrently-active-copies($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://arxiv.org/pdf/0903.3513.pdf"
     
@@ -5986,7 +5986,7 @@ concepts:
       property: mixfix, 
       area: "set theory"
       comments:
-       - "<math><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>↣</mo><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi arg='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>↣</mo><mi arg='a3'>Y</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -6045,7 +6045,7 @@ concepts:
       property: "function, fenced"
       area: "number theory"
       comments:
-       - "<math><mi>int</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='integer-part($a1)'><mi>int</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "[ $1 ]"
       urls: 
        - "https://mathworld.wolfram.com/IntegerPart.html"
@@ -6284,12 +6284,12 @@ concepts:
       property: function
       area: "special-functions"
       comments:
-       - "<math><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>sd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>cd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>sc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>dn</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>cd</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobian-elliptic-function($a1)'><mi>sc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/22.2"
        - "https://dlmf.nist.gov/22.2#E5"
@@ -6305,8 +6305,8 @@ concepts:
       property: function
       area: "ring theory"
       comments:
-       - "<math><mi>J</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>rad</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobson-radical($a1)'><mi>J</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='jacobson-radical($a1)'><mi>rad</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/JacobsonRadical.html"
        - "https://en.wikipedia.org/wiki/Jacobson_radical"
@@ -6543,8 +6543,8 @@ concepts:
       property: function
       area: "analytic number theory"
       comments:
-       - "<math><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='kloosterman-sum($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='kloosterman-sum($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/KloostermansSum.html"
        - "https://en.wikipedia.org/wiki/Kloosterman_sum"
@@ -6707,7 +6707,7 @@ concepts:
       property: function
       area: "mathematical statistics"
       comments:
-       - "<math><mi>KL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='kullback-leibler-distance($a1)'><mi>KL</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "msub D KL"
       urls: 
        - "http://users.monash.edu/~lloyd/tildeMML/KL/"
@@ -6798,7 +6798,7 @@ concepts:
       area: "differential operators"
       notation: "msup ∇ 2"
       notationb: "mrow ∇ · ∇"
-      notationa: "<math><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+      notationa: "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Laplace_operator"
        - "https://ncatlab.org/nlab/show/Laplace+operator"
@@ -6959,8 +6959,8 @@ concepts:
       property: fenced, fenced stacked
       area: "number theory"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></math>"
-       - "<math><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi>p</mi></mfrac><mo>)</mo></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi>p</mi></mfrac><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
@@ -7145,9 +7145,9 @@ concepts:
       property: unit
       area: "units"
       comments:
-       - "<math><mi>l.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>li.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>lnk.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>l.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>li.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='gunter-link($a1)'><mi>lnk.</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Link_(unit)"
     
@@ -7263,7 +7263,7 @@ concepts:
       property: prefix
       area: "order theory"
       comments:
-       - "<math><mo>↓</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='lower-closure-poset($a1)'><mo>↓</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     
@@ -7295,7 +7295,7 @@ concepts:
       property: function
       area: "combinatorics"
       comments:
-       - "<math><mi>𝜕</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='lower-shadow($a1)'><mi>𝜕</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "msub 𝜕 -"
       urls: 
        - "http://qk206.user.srcf.net/notes/combinatorics.pdf"
@@ -7668,8 +7668,8 @@ concepts:
       property: function
       area: "probability theory"
       comments:
-       - "<math><mi>m</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='mills-ratio($a1)'><mi>m</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='mills-ratio($a1)'><mi>M</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MillsRatio.html"
        - "https://en.wikipedia.org/wiki/Mills_ratio"
@@ -7953,7 +7953,7 @@ concepts:
       area: "combinatorial analysis"
       comments:
        - "<math><msub intent='motzkin-number($a1)'><mi>M</mi><mi arg='a1'>x</mi></msub></math>"
-       - "<math><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='motzkin-number($a1)'><mi>M</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MotzkinNumber.html"
        - "https://en.wikipedia.org/wiki/Motzkin_number"
@@ -8200,7 +8200,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mo>∠</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='non-oriented-angle($a1)'><mo>∠</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Orientation_(vector_space)"
        - "https://en.wikipedia.org/wiki/Euclidean_space#Angle"
@@ -8298,7 +8298,7 @@ concepts:
       property: fenced
       area: "euclidean solid geometry"
       comments:
-       - "<math><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></math>"
+       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octant.html"
        - "https://en.wikipedia.org/wiki/Octant_(plane_geometry)"
@@ -8420,7 +8420,7 @@ concepts:
       property: "function, fenced"
       area: "group theory"
       comments:
-       - "<math><mi>ord</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='order-of-group($a1)'><mi>ord</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
        - "<math><mrow intent='order-of-group($a1)'><mo>|</mo><mi arg='a1'>x</mi><mo>|</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Order_(group_theory))"
@@ -8544,7 +8544,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='paraboloidal-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ParaboloidalCoordinates.html"
        - "https://en.wikipedia.org/wiki/Paraboloidal_coordinates"
@@ -8742,8 +8742,8 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-       - "<math><mi>Pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='pfaffian($a1)'><mi>Pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='pfaffian($a1)'><mi>pf</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Pfaffian.html"
        - "https://en.wikipedia.org/wiki/Pfaffian"
@@ -8770,8 +8770,8 @@ concepts:
       property: function
       area: "physics"
       comments:
-       - "<math><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ph</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='phase($a1)'><mi>ϕ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='phase($a1)'><mi>ph</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Phase.html"
        - "https://en.wikipedia.org/wiki/Phase_(waves)"
@@ -9011,7 +9011,7 @@ concepts:
       property: prefix
       area: "predicative mathematics"
       comments:
-       - "<math><mo>◊</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='positivitiy-predicate($a1)'><mo>◊</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://ncatlab.org/nlab/show/positive+element"
     
@@ -9032,10 +9032,10 @@ concepts:
       property: "function, msup"
       area: "set theory"
       comments:
-       - "<math><mi>P</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>𝒫</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ℙ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>℘</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>P</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>𝒫</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>ℙ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='power-set($a1)'><mi>℘</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "msup 2 $1"
       urls: 
        - "https://mathworld.wolfram.com/PowerSet.html"
@@ -9104,8 +9104,8 @@ concepts:
       property: "indexed function"
       area: "number theory"
       comments:
-       - "<math><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>g</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='prime-gap($a1)'><mi>G</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='prime-gap($a1)'><mi>g</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/PrimeGaps.html"
        - "https://en.wikipedia.org/wiki/Prime_gap"
@@ -9302,7 +9302,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='pythagorean-triple($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/PythagoreanTriple.html"
        - "https://en.wikipedia.org/wiki/Pythagorean_triple"
@@ -9322,8 +9322,8 @@ concepts:
       property: symbol
       area: "mathematical symbols"
       comments:
-       - "<math><mo>□</mo></math>"
-       - "<math><mo>∎</mo></math>"
+       - "<math><mrow><mo>□</mo></math>"
+       - "<math><mrow><mo>∎</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -9356,7 +9356,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mo>◻</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='quadrilateral($a1)'><mo>◻</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Quadrangle.html"
        - "https://en.wikipedia.org/wiki/Quadrilateral"
@@ -9422,8 +9422,8 @@ concepts:
       property: "indexed function"
       area: "special functions"
       comments:
-       - "<math><mi>Mc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Ms</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Mc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='radial-mathieu-function($a1)'><mi>Ms</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://dlmf.nist.gov/28.20#iv"
        - "https://dlmf.nist.gov/28.20#E15"
@@ -9528,9 +9528,9 @@ concepts:
       property: function
       area: "graph theory, linear algebra, "
       comments:
-       - "<math><mi>r</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>rank</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>rk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>r</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>rank</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='rank($a1)'><mi>rk</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Rank.html"
        - "https://en.wikipedia.org/wiki/Rank_(graph_theory)"
@@ -9556,9 +9556,9 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mi>ℜ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Re</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>ℛℯ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>ℜ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>Re</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='real-part($a1)'><mi>ℛℯ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/RealPart.html"
        - "https://dlmf.nist.gov/1.9#E2"
@@ -9663,8 +9663,8 @@ concepts:
       property: function
       area: "complex analysis"
       comments:
-       - "<math><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='residue($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='residue($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Residue.html"
        - "https://en.wikipedia.org/wiki/Residue_(complex_analysis)"
@@ -9709,8 +9709,8 @@ concepts:
       property: infix
       area: "group theory"
       comments:
-       - "<math><mi arg='a1'>X</mi><mi>wr</mi><mi arg='a2'>Y</mi></math>"
-       - "<math><mi arg='a1'>X</mi><msub><mi>wr</mi><mi>&#x03a9;</mi></msub><mi arg='a2'>Y</mi></math>"
+       - "<math><mrow intent='restricted-wreath-product($a1,$a2)'><mi arg='a1'>X</mi><mi>wr</mi><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='restricted-wreath-product($a1,$a2)'><mi arg='a1'>X</mi><msub><mi>wr</mi><mi>&#x03a9;</mi></msub><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WreathProduct.html"
        - "https://en.wikipedia.org/wiki/Wreath_product"
@@ -9736,8 +9736,8 @@ concepts:
       property: function
       area: "polynomials"
       comments:
-       - "<math><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='resultant($a1)'><mi>res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='resultant($a1)'><mi>Res</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Resultant.html"
        - "https://en.wikipedia.org/wiki/Resultant"
@@ -9892,10 +9892,10 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mo>∟</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mo>⊾</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mo>⦜</mo><mi arg='a1'>x</mi></math>"
-       - "<math><mo>⦝</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>∟</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⊾</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⦜</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='right-angle($a1)'><mo>⦝</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/RightAngle.html"
        - "https://en.wikipedia.org/wiki/Right_angle"
@@ -10080,7 +10080,7 @@ concepts:
       area: "vector algebra"
       comments:
        - "<math><mi arg='a1'>A</mi><mo>&middot;</mo><mrow><mo>(</mo><mi arg='a2'>B</mi><mo>&middot;</mo><mi arg='a3'>C</mi><mo>)</mo></mrow></math>"
-       - "<math><mo>[</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>,</mo><mi arg='a3'>C</mi><mo>]</mo></math>"
+       - "<math><mrow intent='scalar-triple-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>,</mo><mi arg='a3'>C</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ScalarTripleProduct.html"
        - "https://en.wikipedia.org/wiki/Triple_product"
@@ -10173,8 +10173,8 @@ concepts:
       property: function
       area: "riemannian geometry"
       comments:
-       - "<math><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>κ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sectional-curvature($a1)'><mi>K</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sectional-curvature($a1)'><mi>κ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SectionalCurvature.html"
        - "https://en.wikipedia.org/wiki/Sectional_curvature"
@@ -10220,7 +10220,7 @@ concepts:
       property: prefix
       area: "commutative algebra"
       comments:
-       - "<math><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='set-of-invertible-maps($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://arxiv.org/abs/2009.015866"
     
@@ -10368,8 +10368,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>sinc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sinc-function($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='sinc-function($a1)'><mi>sinc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/SincFunction.html"
        - "https://en.wikipedia.org/wiki/Sinc_function"
@@ -10604,7 +10604,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
+       - "<math><mrow intent='spherical-coordinate($a1,$a2,$a3)'><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/SphericalCoordinates.html"
        - "https://www.encyclopediaofmath.org/index.php/Spherical_coordinates"
@@ -10648,7 +10648,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></math>"
+       - "<math><mrow><mo>&squ;</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi><mo>&thinsp;</mo><mi arg='a4'>D</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Square.html"
        - "https://en.wikipedia.org/wiki/Square"
@@ -10885,7 +10885,7 @@ concepts:
       property: prefix
       area: "combinatorics"
       comments:
-       - "<math><mo>!</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='subfactorial($a1)'><mo>!</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Derangement"
       alias:
@@ -10933,8 +10933,8 @@ concepts:
       area: "number theory"
       comments:
        - "<math><msup intent='successor($a1)'><mi arg='a1'>X</mi><mo>+</mo></msup></math>"
-       - "<math><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
-       - "<math><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='successor($a1)'><mi>s</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='successor($a1)'><mi>S</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Proclus"
        - "https://en.wikipedia.org/wiki/Successor_cardinal"
@@ -10999,8 +10999,8 @@ concepts:
       property: "function, largeop"
       area: "order theory, lattice theory"
       comments:
-       - "<math><mi>sup</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mo>⋁</mo><mi arg='a1'>X</mi></math>"
+       - "<math><mrow intent='supremum($a1)'><mi>sup</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='supremum($a1)'><mo>⋁</mo><mi arg='a1'>X</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/Supremum.html"
       alias:
@@ -11066,8 +11066,8 @@ concepts:
       property: function
       area: "algebra"
       comments:
-       - "<math><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Sym</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='symmetric-algebra($a1)'><mi>S</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='symmetric-algebra($a1)'><mi>Sym</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Symmetric_algebra"
        - "https://ncatlab.org/nlab/show/symmetric+algebra"
@@ -11253,7 +11253,7 @@ concepts:
       property: function
       area: "multilinear algebra"
       comments:
-       - "<math><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='tensor-algebra($a1)'><mi>T</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       notationa: "msup T •"
       urls: 
        - "https://en.wikipedia.org/wiki/Tensor_algebra"
@@ -11291,7 +11291,7 @@ concepts:
       property: prefix
       area: "logic"
       comments:
-       - "<math><mo>∴</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='therefore-sign($a1)'><mo>∴</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Therefore_sign"
        - "https://en.wikipedia.org/wiki/.%C2%B7."
@@ -11352,8 +11352,8 @@ concepts:
       property: function
       area: "characteristic classes"
       comments:
-       - "<math><mi>td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>Td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='todd-class($a1)'><mi>td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='todd-class($a1)'><mi>Td</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Todd_class"
        - "https://ncatlab.org/nlab/show/Todd+class"
@@ -11489,7 +11489,7 @@ concepts:
       property: prefix
       area: "geometry"
       comments:
-       - "<math><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi></mrow></math>"
+       - "<math><mrow intent='triangle($a1,$a2,$a3)'><mo>△</mo><mrow><mi arg='a1'>A</mi><mo>&thinsp;</mo><mi arg='a2'>B</mi><mo>&thinsp;</mo><mi arg='a3'>C</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Triangle.html"
        - "https://en.wikipedia.org/wiki/Triangle"
@@ -11502,8 +11502,8 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mi>Λ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>tri</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='triangle-function($a1)'><mi>Λ</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='triangle-function($a1)'><mi>tri</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/TriangleFunction.html"
        - "https://en.wikipedia.org/wiki/Triangular_function"
@@ -11562,7 +11562,7 @@ concepts:
       property: fenced
       area: "algebra"
       comments:
-       - "<math><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
+       - "<math><mrow intent='triple-scalar-product($a1,$a2,$a3)'><mo>[</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>]</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/TripleScalarProduct.html"
       alias:
@@ -11621,7 +11621,7 @@ concepts:
       property: function
       area: "graph theory"
       comments:
-       - "<math><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='turan-number($a1,$a2,$a3)'><mi>T</mi><mrow><mo>(</mo><mi arg='a1'>a</mi><mo>,</mo><mi arg='a2'>b</mi><mo>,</mo><mi arg='a3'>c</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tur%C3%A1n_number"
        - "https://www.encyclopediaofmath.org/index.php/Turan_number"
@@ -11633,10 +11633,10 @@ concepts:
       property: unit
       area: "geometry"
       comments:
-       - "<math><mi>cyc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>rev</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>tr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
-       - "<math><mi>pla</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>cyc</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>rev</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>tr</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
+       - "<math><mrow intent='turn($a1)'><mi>pla</mi><mrow><mi arg='a1'>X</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Turn_(geometry)"
       alias:
@@ -11843,7 +11843,7 @@ concepts:
       property: prefix
       area: "order theory"
       comments:
-       - "<math><mo>↑</mo><mi arg='a1'>x</mi></math>"
+       - "<math><mrow intent='upper-closure-poset($a1)'><mo>↑</mo><mi arg='a1'>x</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Upper_set#Upper_closure_and_lower_closure"
     
@@ -11955,7 +11955,7 @@ concepts:
       property: function
       area: "quaternions"
       comments:
-       - "<math><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='versor($a1)'><mi>U</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Versor_(physics)"
        - "https://en.wikipedia.org/wiki/Versor"
@@ -12331,7 +12331,7 @@ concepts:
       property: fenced
       area: "ring theory"
       comments:
-       - "<math><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
@@ -12457,7 +12457,7 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroIdeal.html"
        - "https://ncatlab.org/nlab/show/zero+ideal"
@@ -12488,7 +12488,7 @@ concepts:
       property: symbol
       area: "algebra"
       comments:
-       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_object_(algebra)"
        - "https://ncatlab.org/nlab/show/zero+object"
@@ -12499,7 +12499,7 @@ concepts:
       property: symbol
       area: "ring theory"
       comments:
-       - "<math><mo>{</mo><mn>0</mn><mo>}</mo></math>"
+       - "<math><mrow><mo>{</mo><mn>0</mn><mo>}</mo></math>"
        - "<math><mn>0</mn></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZeroRing.html"
@@ -12537,4 +12537,3 @@ concepts:
        - "<math><mrow intent='zig-zag-product($a1,$a2)'><mi arg='a1'>X</mi><mo>∘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zig-zag_product"
- 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -142,9 +142,8 @@ concepts:
       property: "function/msub"
       area: "lie algebra"
       comments:
-       - "<math><mrow intent='adjoint-action($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mi ad $1"
-      notationa: "msub ad $1"
+       - "<math><mrow intent='adjoint-action($a1)'><mi>ad</mi><mrow><mo>(</mo><mi arg='a1'>f</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><msub intent='adjoint-action($a1)'><mi>ad</mi><mi arg='a1'>f</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Adjoint_representation_of_a_Lie_algebra"
        - "https://en.wikipedia.org/wiki/Adjoint_representation"
@@ -584,13 +583,12 @@ concepts:
        - "https://dlmf.nist.gov/19.8#SS1.p1"
     
     - concept: associated-legendre-polynomial
-      arity: 1
-      en: associated legendre polynomial of $1
+      arity: 2
+      en: associated legendre polynomial of degree $1 and order $m
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='associated-legendre-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msubsup P l m"
+       - "<math><mrow><msubsup intent='associated-legendre-polynomial($a1,m2)'><mi>P</mi><mi arg='a1'>ℓ</mi><mi arg='a2'>m</mi></msubsup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/AssociatedLegendrePolynomial.html"
        - "https://en.wikipedia.org/wiki/Associated_Legendre_polynomials"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2893,6 +2893,8 @@ concepts:
       property: function
       area: "special functions"
       notation: "msub Li 2"
+      comments:
+       - "<math><mrow intent='dilogarithm($a1)'><msub><mi>L</mi><mn>2</mn></msub><mi arg='a1'>z</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dilogarithm.html"
        - "https://en.wikipedia.org/wiki/Spence%27s_function"
@@ -2983,7 +2985,8 @@ concepts:
       en: direct limit of $1
       property: prefix
       area: "category theory"
-      notation: "munder lim →"
+      comments:
+       - "<math><mrow intent='direct-limit($a1)'><munder><mi>lim</mi><mo>→</mo></munder><mi>A</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectLimit.html"
        - "https://en.wikipedia.org/wiki/Direct_limit"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2952,9 +2952,6 @@ concepts:
       property: function
       area: "special functions"
       comments:
-       - "<math><mrow intent='dilogarithm($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub Li 2"
-      comments:
        - "<math><mrow intent='dilogarithm($a1)'><msub><mi>L</mi><mn>2</mn></msub><mi arg='a1'>z</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Dilogarithm.html"
@@ -4083,8 +4080,6 @@ concepts:
       area: "polynomials"
       comments:
        - "<math><mrow intent='faber-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub P m"
-      comments:
        - "<math><msub intent='faber-polynomial($a1)'><mi mathvariant='normal'>P</mi><mi arg='a1'>n</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/FaberPolynomial.html"
@@ -8231,7 +8226,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
+       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness='0pt'><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Multiset.html"
     
@@ -8241,7 +8236,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multiset-coefficient($a1,$a2)'><mo>⦅</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo>⦆</mo></mrow></math>"
+       - "<math><mrow intent='multiset-coefficient($a1,$a2)'><mo>⦅</mo><mfrac linethickness='0pt'><mi arg='a1'>n</mi><mi arg='a2'>n</mi></mfrac><mo>⦆</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Multiset"
       alias:
@@ -9574,7 +9569,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><msub intent='q-binomial-coefficient($a1,$a2,$a3)'><mrow><mo>[</mo><mfrac linethickness="0pt"><mi arg='a1'>n</mi><mi arg='a2'>m</mi></mfrac><mo>]</mo></mrow><mi arg='a3'>q</mi></msub></math>"
+       - "<math><msub intent='q-binomial-coefficient($a1,$a2,$a3)'><mrow><mo>[</mo><mfrac linethickness='0pt'><mi arg='a1'>n</mi><mi arg='a2'>m</mi></mfrac><mo>]</mo></mrow><mi arg='a3'>q</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/q-BinomialCoefficient.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -5622,7 +5622,8 @@ concepts:
       en: hyperbolic plane
       property: symbol
       area: "non-euclidean geometry"
-      notation: "msup ℍ 2"
+      comments:
+       - "<math><msup intent='hyperbolic-plane'><mi>ℍ</mi><mn>2</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/HyperbolicPlane.html"
        - "https://ncatlab.org/nlab/show/hyperbolic+plane"
@@ -5676,10 +5677,11 @@ concepts:
     
     - concept: hypertorus
       arity: 1
-      en: hypertorus of $1
+      en: $1 th hypertorus
       property: "indexed symbol"
       area: "topology"
-      notation: "msupT$1"
+      comments:
+       - "<math><msup intent='ypertorus($a1)'><mi>T</mi><mi arg='a1'>n</mi></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torus#n-dimensional_torus"
       alias:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -6955,7 +6955,7 @@ concepts:
       property: "embellished operator"
       area: "differential operators"
       comments:
-       - "<math><mrow intent='laplace-operator($a1)'><msup>m<mo>∇</mo><mn>2</mn></msup><mi arg='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='laplace-operator($a1)'><msup><mo>∇</mo><mn>2</mn></msup><mi arg='a1'>f</mi></mrow></math>"
        - "<math><mrow intent='laplace-operator($a1)'><mo>∇</mo><mo>·</mo><mo>∇</mo><mi arg='a1'>f</mi></mrow></math>"
        - "<math><mrow intent='laplace-operator($a1)'><mi>Δ</mi><mrow><mo>(</mo><mi arg='a1'>f</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
@@ -8217,7 +8217,7 @@ concepts:
       property: fenced-stacked
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='multichoose($a1,$a2)'><mo mathvariant='bold'>(</mo><mfrac linethickness='0pt'><mi arg='a1'>m</mi><mi arg='a2'>n</mi></mfrac><mo mathvariant='bold'>)</mo></mrow></math>"
+       - "<math><mrow intent='multichoose($a1,$a2)'><mo style='font-weight:bold'>(</mo><mfrac linethickness='0pt'><mi arg='a1'>m</mi><mi arg='a2'>n</mi></mfrac><mo style='font-weight:bold'>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Multiset.html"
     

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12552,6 +12552,7 @@ concepts:
       area: "special functions"
       comments:
        - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi></mrow></mrow></math>"
+       - "<math><mrow><msub intent='whittaker-function($a1,$a2)'><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi>z</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"
@@ -12565,6 +12566,7 @@ concepts:
       area: "special functions"
       comments:
        - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>M</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi></mrow></mrow></math>"
+       - "<math><mrow intent='whittaker-function($a1,$a2,$a3)'><msub><mi>W</mi><mrow><mi arg='a1'>κ</mi><mo>,</mo><mi arg='a2'>μ</mi></mrow></msub><mrow><mo>(</mo><mi arg='a3'>z</mi></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WhittakerFunction.html"
        - "https://en.wikipedia.org/wiki/Whittaker_function"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -2372,7 +2372,7 @@ concepts:
       property: fenced
       area: "geometry"
       comments:
-       - "<math><mrow intent='cross-ratio($a1,$a2,$a3,$a4)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>]</mo></mrow></math>"
+       - "<math><mrow intent='cross-ratio($a1,$a2,$a3,$a4)'><mo>(</mo><mi arg='a1'>A</mi><mo>,</mo><mi arg='a2'>B</mi><mo>;</mo><mi arg='a3'>C</mi><mo>,</mo><mi arg='a4'>D</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Cross-Ratio.html"
        - "https://en.wikipedia.org/wiki/Cross-ratio"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -320,6 +320,8 @@ concepts:
       en: $1 alternative denial $2
       property: infix, prefix
       area: "propositional calculus"
+      comments:
+       - "<math><mrow intent='alternative-denial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo | "
       notationb: "mo ↑"
       notationa: "mrow D $1 $2"
@@ -647,6 +649,8 @@ concepts:
       en: bateman function
       property: function
       area: "special functions"
+      comments:
+       - "<math><mrow intent='bateman-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow msub k $1 ( $2"
       urls: 
        - "https://mathworld.wolfram.com/BatemanFunction.html"
@@ -658,6 +662,8 @@ concepts:
       en: baumslag solitar group
       property: function
       area: "group theory"
+      comments:
+       - "<math><mrow intent='baumslag-solitar-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow BS ( $1, $2 )"
       urls: 
        - "https://en.wikipedia.org/wiki/Baumslag%E2%80%93Solitar_group"
@@ -1114,6 +1120,8 @@ concepts:
       en: calderon toeplitz operator $1 $2
       property: "indexed symbol"
       area: "operator theory"
+      comments:
+       - "<math><mrow intent='calderon-toeplitz-operator($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub T mrow $1, $2"
       urls: 
        - "https://www.encyclopediaofmath.org/index.php/Calderon-Toeplitz_operator"
@@ -1625,6 +1633,8 @@ concepts:
       en: closed ball $1 $2
       property: mixfix
       area: "topology"
+      comments:
+       - "<math><mrow intent='closed-ball($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow msub B $1 /msub [ $2 ]"
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
@@ -1648,6 +1658,8 @@ concepts:
       en: closed neighbourhood
       property: "indexed function, function"
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='closed-neighbourhood($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub N $1 [ $2 ]"
       notationa: "mrow N [ $1 ]"
       urls: 
@@ -1913,6 +1925,8 @@ concepts:
       en: compound interest
       property: msup
       area: "finance"
+      comments:
+       - "<math><mrow intent='compound-interest($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 ($2"
       urls: 
        - "https://mathworld.wolfram.com/CompoundInterest.html"
@@ -1945,6 +1959,8 @@ concepts:
       en: conditional expectation $1 $2
       property: mixfix
       area: "probability theory"
+      comments:
+       - "<math><mrow intent='conditional-expectation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow E ( $1 | $2 )"
       urls: 
        - "https://en.wikipedia.org/wiki/Conditional_expectation"
@@ -1955,6 +1971,8 @@ concepts:
       en: conditional probability $1 $2
       property: mixfix
       area: "probability theory"
+      comments:
+       - "<math><mrow intent='conditional-probability($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow P ( $1 | $2 )"
       urls: 
        - "https://mathworld.wolfram.com/ConditionalProbability.html"
@@ -1986,6 +2004,8 @@ concepts:
       en: contrast function $1 $2
       property: mixfix
       area: "statistics"
+      comments:
+       - "<math><mrow intent='contrast-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "D ( $1 | $2)"
       urls: 
        - "https://en.wikipedia.org/wiki/Divergence_(statistics)"
@@ -2009,6 +2029,8 @@ concepts:
       en: $1 congruence relation $2
       property: infix
       area: "algebra, geometry"
+      comments:
+       - "<math><mrow intent='congruence-relation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ≡"
       notationa: "mo ≅"
       urls: 
@@ -4031,6 +4053,8 @@ concepts:
       en: falling factorial $1 $2
       property: mixfix
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='falling-factorial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 mover $2 ¯"
       notationb: "msup $1 munder $2 ¯"
       notationa: "msub mrow ( $1 ) /mrow $2"
@@ -4446,6 +4470,8 @@ concepts:
       en: free module $1 $2
       property: mixfix, msup
       area: "module theory"
+      comments:
+       - "<math><mrow intent='free-module($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 { $2 }"
       notationa: "msup $1 ($2"
       urls: 
@@ -4726,6 +4752,8 @@ concepts:
       en: gegenbauer polynomial
       property: "indexed function"
       area: "orthogonal polynomials"
+      comments:
+       - "<math><mrow intent='gegenbauer-polynomial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup C $1 ($2"
       urls: 
        - "https://mathworld.wolfram.com/GegenbauerPolynomial.html"
@@ -4913,6 +4941,8 @@ concepts:
       en: germ of $1 at $2
       property: mixfix
       area: "topology"
+      comments:
+       - "<math><mrow intent='germ($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [ # 1 ] _ $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Germ_(mathematics)"
@@ -5049,6 +5079,8 @@ concepts:
       en: group algebra $1 $2
       property: mixfix
       area: "ring theory"
+      comments:
+       - "<math><mrow intent='group-algebra($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1[$2]"
       notationa: "mrow $1$2"
       urls: 
@@ -5075,6 +5107,8 @@ concepts:
       en: group ring $1 $2
       property: mixfix, infix
       area: "ring theory"
+      comments:
+       - "<math><mrow intent='group-ring($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 [ $2 ]"
       notationa: "mrow $1 $2"
       urls: 
@@ -5759,6 +5793,8 @@ concepts:
       en: image $1 $2
       property: mixfix
       area: "set theory"
+      comments:
+       - "<math><mrow intent='image($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "$1 [ $2 ]"
       notationc: "msub $1 *"
       notationb: "<msup><mi>X</mi><mo>→</mo></msup>"
@@ -5825,6 +5861,8 @@ concepts:
       en: $1 incomparability $2
       property: infix
       area: "order theory"
+      comments:
+       - "<math><mrow intent='incomparability($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "menclose notation='updiagonalstrike' munderover = > <"
       urls: 
        - "https://en.wikipedia.org/wiki/Comparability"
@@ -6035,6 +6073,8 @@ concepts:
       en: $1 inner product $2
       property: infix, fenced
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='inner-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ⋅"
       notationa: "<math><mrow intent='inner-product($a1,$a2)'><mo>[</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>]</mo></mrow></math>"
       urls: 
@@ -6049,6 +6089,8 @@ concepts:
       en: instantaneous activity $1 $2
       property: mixfix
       area: "chemistry"
+      comments:
+       - "<math><mrow intent='instantaneous-activity($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow { $1 } /mrow $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Reaction_quotient"
@@ -6105,6 +6147,8 @@ concepts:
       en: inverse image $1 $2
       property: mixfix
       area: "set theory"
+      comments:
+       - "<math><mrow intent='inverse-image($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow msup $1 -1 /msup [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Image_(mathematics)"
@@ -6130,6 +6174,8 @@ concepts:
       en: inverse moment of function $1 $2
       property: "msub, mixfix"
       area: "mathematics"
+      comments:
+       - "<math><mrow intent='inverse-moment-of-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub μ mrow - $1 /mrow"
       notationa: "mrow E [ msup $1 mrow - $2 /mrow ]"
       urls: 
@@ -6164,6 +6210,8 @@ concepts:
       en: ionic charge
       property: msup
       area: "chemistry"
+      comments:
+       - "<math><mrow intent='ionic-charge($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 $2"
       notationa: ""
       urls: 
@@ -6201,6 +6249,8 @@ concepts:
       en: isotropy group
       property: msub
       area: "group theory"
+      comments:
+       - "<math><mrow intent='isotropy-group($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/IsotropyGroup.html"
@@ -6285,6 +6335,8 @@ concepts:
       en: jacobi zeta function
       property: function
       area: "special-functions"
+      comments:
+       - "<math><mrow intent='jacobi-zeta-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow Z⁡ ( $1 |  $2 )"
       urls: 
        - "https://mathworld.wolfram.com/JacobiZetaFunction.html"
@@ -6392,6 +6444,8 @@ concepts:
       en: jordan block
       property: "indexed symbol"
       area: "linear algebra"
+      comments:
+       - "<math><mrow intent='jordan-block($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub J mrow $1, $2"
       urls: 
        - "https://mathworld.wolfram.com/JordanBlock.html"
@@ -6568,6 +6622,8 @@ concepts:
       en: kneser graph
       property: "indexed symbol"
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='kneser-graph($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow K ( $1, $2 )"
       notationa: "msub mi KG /mi $1, $2"
       urls: 
@@ -6658,6 +6714,8 @@ concepts:
       en: kronecker delta
       property: "indexed function"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='kronecker-delta($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub δ mrow $1 $2 mrow"
       urls: 
        - "https://mathworld.wolfram.com/KroneckerDelta.html"
@@ -7047,6 +7105,8 @@ concepts:
       en: $1 lexicographic product $2
       property: infix, mixfix
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='lexicographic-product($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo ∙"
       notationa: "$1 [ $2 ]"
       urls: 
@@ -7194,6 +7254,8 @@ concepts:
       en: localization $1 $2
       property: mixfix
       area: "module theory"
+      comments:
+       - "<math><mrow intent='localization($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 -1 /msup $2"
       urls: 
        - "https://mathworld.wolfram.com/Localization.html"
@@ -7219,6 +7281,8 @@ concepts:
       en: logarithmic moment of function $1 $2
       property: "mixfix"
       area: "mathematics"
+      comments:
+       - "<math><mrow intent='logarithmic-moment-of-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "E [ msup ln $1 /msup ( $2 ) ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -7240,6 +7304,8 @@ concepts:
       en: lommel function
       property: "indexed function"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='lommel-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub S mrow $1,$2 /mrow"
       notationa: "msub s mrow $1, $2 /mrow"
       urls: 
@@ -7844,6 +7910,8 @@ concepts:
       en: $1 modulo $2
       property: infix, mixfix
       area: "modular arithmetic"
+      comments:
+       - "<math><mrow intent='modulo($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo mod"
       notationa: "mrow $1 ( mod $2"
       urls: 
@@ -8034,6 +8102,8 @@ concepts:
       en: multichoose
       property: fenced-stacked
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='multichoose($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( mfrac $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/Multiset.html"
@@ -8043,6 +8113,8 @@ concepts:
       en: multiset coefficient
       property: fenced-stacked
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='multiset-coefficient($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( ( mfrac $1 $2 )"
       urls: 
        - "https://en.wikipedia.org/wiki/Multiset"
@@ -8067,6 +8139,8 @@ concepts:
       en: mutation
       property: msup
       area: "abstract algebra"
+      comments:
+       - "<math><mrow intent='mutation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/Mutation.html"
@@ -8094,6 +8168,8 @@ concepts:
       en: narayana number
       property: function
       area: "combinatorial analysis"
+      comments:
+       - "<math><mrow intent='narayana-number($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow N ($1, $2"
       urls: 
        - "https://mathworld.wolfram.com/NarayanaNumber.html"
@@ -8143,6 +8219,8 @@ concepts:
       en: neighbourhood
       property: "indexed function, function"
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='neighbourhood($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub N $1 ( $2 )"
       notationa: "mrow N ( $1"
       urls: 
@@ -8363,6 +8441,8 @@ concepts:
       en: open ball $1 $2
       property: mixfix
       area: "topology"
+      comments:
+       - "<math><mrow intent='open-ball($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow msub B $1 /msub ( $2"
       urls: 
        - "https://mathworld.wolfram.com/OpenBall.html"
@@ -8387,6 +8467,8 @@ concepts:
       en: open real interval
       property: fenced
       area: "algebra"
+      comments:
+       - "<math><mrow intent='open-real-interval($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ($1 . . $2)"
       urls: 
        - "https://proofwiki.org/wiki/Definition: Real_Interval/Open"
@@ -8582,6 +8664,8 @@ concepts:
       en: parallel morphism
       property: embellished infix
       area: "category theory"
+      comments:
+       - "<math><mrow intent='parallel-morphism($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "<munderover>"
       notationd: "<mrow/>"
       notationc: "<munder><mo>⟶</mo> $1</munder>"
@@ -8871,6 +8955,8 @@ concepts:
       en: plethysm $1 $2
       property: mixfix
       area: "algebra"
+      comments:
+       - "<math><mrow intent='plethysm($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow { $1 } ⊗ { $2 }"
       urls: 
        - "https://mathworld.wolfram.com/Plethysm.html"
@@ -8882,6 +8968,8 @@ concepts:
       en: plucker coordinate
       property: fenced
       area: "geometry"
+      comments:
+       - "<math><mrow intent='plucker-coordinate($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow ( $1 : $2 : ... : $n"
       urls: 
        - "https://mathworld.wolfram.com/PlueckerCoordinates.html"
@@ -8965,6 +9053,8 @@ concepts:
       en: polynomial ring $1 $2
       property: mixfix
       area: "ring theory"
+      comments:
+       - "<math><mrow intent='polynomial-ring($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Polynomial_ring#Definition_(univariate_case)"
@@ -9175,6 +9265,8 @@ concepts:
       en: product measure
       property: function
       area: "measure theory"
+      comments:
+       - "<math><mrow intent='product-measure($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 × $2"
       urls: 
        - "https://mathworld.wolfram.com/ProductMeasure.html"
@@ -9259,6 +9351,8 @@ concepts:
       en: pseudovector $1 $2
       property: mixfix
       area: "vector calculus"
+      comments:
+       - "<math><mrow intent='pseudovector($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow (det $1) ($1 $2"
       urls: 
        - "https://mathworld.wolfram.com/Pseudovector.html"
@@ -9362,6 +9456,8 @@ concepts:
       en: quadratic variation
       property: indexed fenced
       area: "stochastic processes"
+      comments:
+       - "<math><mrow intent='quadratic-variation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow [ $1 ] /mrow $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Quadratic_variation"
@@ -9691,6 +9787,8 @@ concepts:
       en: resolvent
       property: "indexed function"
       area: "galois theory"
+      comments:
+       - "<math><mrow intent='resolvent($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup R $1 ($2"
       urls: 
        - "https://mathworld.wolfram.com/Resolvent.html"
@@ -9713,6 +9811,8 @@ concepts:
       en: restricted quantifier $1 $2
       property: mixfix
       area: "formal logic"
+      comments:
+       - "<math><mrow intent='restricted-quantifier($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub mrow ( Ǝ $1 ) /mrow $2"
       notationa: "msub mrow ( ∀ $1 ) /mrow $2"
       urls: 
@@ -9738,6 +9838,8 @@ concepts:
       en: restriction
       property: indexed postfix
       area: "elementary mathematics"
+      comments:
+       - "<math><mrow intent='restriction($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "$1 mo msub ↾ $2 /mo"
       notationa: "$1 mo msub | $2 /mo"
       urls: 
@@ -9941,6 +10043,8 @@ concepts:
       en: ring of formal power series $1 $2
       property: mixfix
       area: "ring theory"
+      comments:
+       - "<math><mrow intent='ring-of-formal-power-series($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 [[ $2 ]]"
       urls: 
        - "https://en.wikipedia.org/wiki/Formal_power_series#The_ring_of_formal_power_series"
@@ -9950,6 +10054,8 @@ concepts:
       en: rising factorial $1 $2
       property: mixfix
       area: "combinatorics"
+      comments:
+       - "<math><mrow intent='rising-factorial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msup $1 mover $2 ¯"
       notationa: "msup $1 mrow ( $2 ) /mrow"
       urls: 
@@ -10453,6 +10559,8 @@ concepts:
       en: sobolev space
       property: "indexed symbol"
       area: "fourier analysis"
+      comments:
+       - "<math><mrow intent='sobolev-space($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup W $1 $2"
       urls: 
        - "https://mathworld.wolfram.com/SobolevSpace.html"
@@ -10608,6 +10716,8 @@ concepts:
       en: spherical bessel function of third kind
       property: "indexed function"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='spherical-bessel-function-of-third-kind($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msubsup h $1 (1)"
       notationa: "msubsup h $2 (2"
       urls: 
@@ -10688,6 +10798,8 @@ concepts:
       en: stalk of $1 at $2
       property: msub
       area: "sheaf theory"
+      comments:
+       - "<math><mrow intent='stalk($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub $1 $2"
       urls: 
        - "https://en.wikipedia.org/wiki/Stalk_(sheaf)"
@@ -10722,6 +10834,8 @@ concepts:
       en: stanley reisner ring $1 $2
       property: mixfix
       area: "commutative algebra"
+      comments:
+       - "<math><mrow intent='stanley-reisner-ring($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow $1 [ $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Stanley%E2%80%93Reisner_ring"
@@ -10782,6 +10896,8 @@ concepts:
       en: stiefel manifold $1 $2
       property: mixfix
       area: "differential geometry"
+      comments:
+       - "<math><mrow intent='stiefel-manifold($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow msub V $1 /msub ( $2"
       urls: 
        - "https://mathworld.wolfram.com/StiefelManifold.html"
@@ -10855,6 +10971,8 @@ concepts:
       en: $1 string concatenation $2
       property: infix
       area: "computer science"
+      comments:
+       - "<math><mrow intent='string-concatenation($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mo"
       urls: 
        - "https://mathworld.wolfram.com/Concatenation.html"
@@ -11459,6 +11577,8 @@ concepts:
       en: total derivative $1 with respect to $2
       property: mixfix
       area: "differential calculus"
+      comments:
+       - "<math><mrow intent='total-derivative($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow d msub $1 $2 /msub"
       urls: 
        - "https://mathworld.wolfram.com/TotalDerivative.html"
@@ -11624,6 +11744,8 @@ concepts:
       en: turan graph $1 $2
       property: "function, indexed function"
       area: "graph theory"
+      comments:
+       - "<math><mrow intent='turan-graph($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mi T"
       notationc: "mi D"
       notationb: "msub T $1"
@@ -12055,6 +12177,8 @@ concepts:
       en: wavelet transform $1 $2
       property: "embellished function"
       area: "functional analysis"
+      comments:
+       - "<math><mrow intent='wavelet-transform($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow [ msub W $1 /msub $2 ]"
       urls: 
        - "https://mathworld.wolfram.com/WaveletTransform.html"
@@ -12157,6 +12281,8 @@ concepts:
       en: weighted lehmer mean $1 $2
       property: "indexed function"
       area: "means"
+      comments:
+       - "<math><mrow intent='weighted-lehmer-mean($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub L mrow $1 , $2 /mrow"
       urls: 
        - "https://mathworld.wolfram.com/LehmerMean.html"
@@ -12228,6 +12354,8 @@ concepts:
       en: whittaker function $1 $2
       property: "indexed function"
       area: "special functions"
+      comments:
+       - "<math><mrow intent='whittaker-function($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "msub M mrow $1, $2 /mrow"
       notationa: "msub W mrow $1, $2 /mrow"
       urls: 
@@ -12407,6 +12535,8 @@ concepts:
       en: wronskian of $1, $2
       property: operator
       area: "special functions"
+      comments:
+       - "<math><mrow intent='wronskian($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mrow 𝒲 { $1, $2 }"
       notationa: "mi W"
       urls: 

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -720,7 +720,7 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Bell_numbers"
     
     - concept: bell-polynomial
-      arity: n
+      arity: "*"
       en: $1 th bell polynomial of $2, $3, ...
       property: "indexed function"
       area: "polynomials"
@@ -12700,7 +12700,7 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
     
     - concept: witt-vector
-      arity: n
+      arity: "*"
       en: witt vector of $1
       property: fenced
       area: "ring theory"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4089,10 +4089,8 @@ concepts:
       property: mixfix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='falling-factorial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup $1 mover $2 ¯"
-      notationb: "msup $1 munder $2 ¯"
-      notationa: "msub mrow ( $1 ) /mrow $2"
+        - "<math><msub intent='falling-factorial($a1,$a2)'><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow><mi arg='a2'>n</mi></msub></math>"
+        - "<math><msup intent='falling-factorial($a1,$a2)'><mi arg='a1'>x</mi><munder><mi arg='a2'>n</mi><mo>_</mo></munder></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/FallingFactorial.html"
@@ -10202,13 +10200,12 @@ concepts:
     
     - concept: rising-factorial
       arity: 2
-      en: rising factorial $1 $2
+      en: #2 th rising factorial of  $1
       property: mixfix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='rising-factorial($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msup $1 mover $2 ¯"
-      notationa: "msup $1 mrow ( $2 ) /mrow"
+        - "<math><msup intent='rising-factorial($a1,$a2)'><mi arg='a1'>x</mi><mrow><mo>(</mo><mi arg='a2'>n</mi><mo>)</mo></mrow></msup></math>"
+        - "<math><msup intent='rising-factorial($a1,$a2)'><mi arg='a1'>x</mi><mover><mi arg='a2'>n</mi><mo>¯</mo></mover></msup></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Falling_and_rising_factorials"
        - "https://mathworld.wolfram.com/RisingFactorial.html"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -268,9 +268,8 @@ concepts:
       property: mover/msup
       area: "algebra"
       comments:
-       - "<math><mrow intent='algebraic-closure($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mover ¯"
-      notationa: "msup alg"
+       - "<math><mover intent='algebraic-closure($a1)'><mi arg='a1'>A</mi><mo>¯</mo></mover></math>"
+       - "<math><msup intent='algebraic-closure($a1)'><mi arg='a1'>A</mi><mi>alg</mi></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/AlgebraicClosure.html"
        - "https://en.wikipedia.org/wiki/Algebraic_closure"
@@ -12762,9 +12761,8 @@ concepts:
       property: operator
       area: "special functions"
       comments:
-       - "<math><mrow intent='wronskian($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "mrow 𝒲 { $1, $2 }"
-      notationa: "mi W"
+       - "<math><mrow intent='wronskian($a1,$a2)'><mi>𝒲</mi><mrow><mo></mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a2'>g</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wronskian($a1,$a2)'><mi>W</mi><mrow><mo></mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a2'>g</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Wronskian.html"
        - "https://en.wikipedia.org/wiki/Wronskian"
@@ -12819,13 +12817,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Z-transform"
     
     - concept: zernike-polynomial
-      arity: 1
-      en: zernike polynomial of $1
+      arity: 4
+      en: $1 $2 zernike polynomial of $3, $4
       property: "indexed function"
       area: "orthogonal polynomials"
       comments:
-       - "<math><mrow intent='zernike-polynomial($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msubsup Z"
+       - "<math><mrow intent='zernike-polynomial($a1,$a2,$a3,$a4)'><msubsup><mi>Z</mi><mi arg='a1'>n</mi><mi arg='a2'>m</mi></msubsup><mrow><mo>(</mo><mi arg='a3'>ρ</mi><mo>,</mo><mi arg='a4'>φ</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/ZernikePolynomial.html"
        - "https://en.wikipedia.org/wiki/Zernike_polynomials"
@@ -12853,12 +12850,12 @@ concepts:
        - "https://en.wikipedia.org/wiki/Zero_matrix"
     
     - concept: zero-morphism
-      arity: 1
-      en: zero morphism of $1
+      arity: 2
+      en: zero morphism $1 $2
       property: "indexed symbol"
       area: "category theory"
       comments:
-       - "<math><mrow intent='zero-morphism($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><msub intent='zero-morphism($a1)'><mn>0</mn><mrow><mi arg='a1'>A</mi><mi arg='a2'>B</mi></mrow></msub></math>"
       notation: "msub mn 0 mrow X,Y"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_morphism"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4664,7 +4664,8 @@ concepts:
       en: gateaux derivative of $1 at $2 ; £3
       property: mixfix
       area: "differential calculus"
-      notation: "mrow d$1($2; $3"
+      comments:
+      - "<math><mrow intent='gateaux-derivative($a1,$a2,$a3)'><mi>d</mi><mi arg='a1'>F</mi><mrow><mo>(</mo><mi arg='a2'>u</mi><mo>;</mo><mi arg='a3'>ψ)</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GateauxDerivative.html"
        - "https://en.wikipedia.org/wiki/G%C3%A2teaux_derivative"
@@ -11720,10 +11721,11 @@ concepts:
     
     - concept: ultraproduct
       arity: 3
-      en: ultraproduct of $1, $2 and $3
+      en: ultraproduct of $1, $2 modulo $3
       property: mixfix
       area: "abstract algebra"
-      notation: "mrow ∏ msub $1 $2 /msub / $3"
+      comments:
+      - "<math><mrow intent='ultraproduct($a1,$a2,$a3)'><msub><mo>∏</mo><mrow><mi>i</mi><mo>∈</mo><mi arg='a2'>I</mi></mrow></msub><mi arg='a1'>M</mi><mo>/</mo><mi arg='a3'>𝒰</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Ultraproduct.html"
        - "https://en.wikipedia.org/wiki/Ultraproduct"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -12473,13 +12473,12 @@ concepts:
        - "https://www.encyclopediaofmath.org/index.php/Weight"
     
     - concept: weighted-lehmer-mean
-      arity: 2
-      en: weighted lehmer mean $1 $2
+      arity: "*"
+      en: weighted lehmer mean of $1 $2 ...
       property: "indexed function"
       area: "means"
       comments:
-       - "<math><mrow intent='weighted-lehmer-mean($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>)</mo></mrow></mrow></math>"
-      notation: "msub L mrow $1 , $2 /mrow"
+       - "<math><mrow intent='weighted-lehmer-mean($a1,$a2,$a3)'><msub><mi>L</mi><mi>p</mi></msub><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>,</mo><mi arg='a2'>y</mi><mo>,</mo><mi arg='a3'>z</mi><mo>)</mo></mrow></mrow></math>
       urls: 
        - "https://mathworld.wolfram.com/LehmerMean.html"
        - "https://en.wikipedia.org/wiki/Lehmer_mean"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -688,7 +688,7 @@ concepts:
       property: postfix
       area: "calendar units"
       comments:
-       - "<math><mrow intent='bc($a1)'><mn>2024</mn><mo>&#x2009;</mo><mi>BC</mi></mrow></math>"      
+       - "<math><mrow intent='bc($a1)'><mn ad='a1'>2024</mn><mo>&#x2009;</mo><mi>BC</mi></mrow></math>"      
       urls: 
        - "https://en.wikipedia.org/wiki/Anno_Domini"
     
@@ -3046,7 +3046,7 @@ concepts:
       property: prefix
       area: "category theory"
       comments:
-       - "<math><mrow intent='direct-limit($a1)'><munder><mi>lim</mi><mo>→</mo></munder><mi>A</mi></mrow></math>"
+       - "<math><mrow intent='direct-limit($a1)'><munder><mi>lim</mi><mo>→</mo></munder><mi ad='a1'>A</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectLimit.html"
        - "https://en.wikipedia.org/wiki/Direct_limit"
@@ -3089,9 +3089,9 @@ concepts:
       property: "function, mixfix"
       area: "differential calculus"
       comments:
-       - "<math><msup intent='directional-derivative($a1)'><mi>∇</mi><mi>v</mi></msup><mi>f</mi></math>"
-       - "<math><msup intent='directional-derivative($a1)'><mi>D</mi><mi>v</mi></msup><mi>f</mi></math>"
-       - "<math><mrow intent='directional-derivative($a1)'><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>∇</mi><mi>v</mi></msup><mi ad='a1'>f</mi></math>"
+       - "<math><msup intent='directional-derivative($a1)'><mi>D</mi><mi>v</mi></msup><mi ad='a1'>f</mi></math>"
+       - "<math><mrow intent='directional-derivative($a1)'><mi>v</mi><mo>⋅</mo><mi>∇</mi></mrow><mi ad='a1'>f</mi></math>"
       urls: 
        - "https://mathworld.wolfram.com/DirectionalDerivative.html"
        - "https://en.wikipedia.org/wiki/Directional_derivative"
@@ -3252,8 +3252,8 @@ concepts:
       property: "function, mixfix"
       area: "vector calculus"
       comments:
-       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi>f</mi></mrow></math>"
-       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi>f</mi></mrow></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>div</mi><mi ad='a1'>f</mi></mrow></math>"
+       - "<math><mrow intent='divergence($a1)'><mi>∇</mi><mo>⋅</mo><mi ad='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Divergence.html"
        - "https://en.wikipedia.org/wiki/Divergence_(computer_science)"
@@ -3386,7 +3386,7 @@ concepts:
       property: postfix
       area: "combinatorics"
       comments:
-       - "<math><mrow intent='double-factorial($a1)'><mn>10</mn><mo>&#x203c;</mo></mrow></math>"
+       - "<math><mrow intent='double-factorial($a1)'><mn ad='a1'>10</mn><mo>&#x203c;</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/DoubleFactorial.html"
        - "https://en.wikipedia.org/wiki/Double_factorial"
@@ -3455,8 +3455,8 @@ concepts:
       property: msup
       area: "linear algebra"
       comments:
-       - "<math><msup intent='dual-space($a1)'><mi>V</mi><mo>*</mo></msup></math>"
-       - "<math><msup intent='dual-space($a1)'><mi>V</mi><mo>&#x2032;</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi ad='a1'>V</mi><mo>*</mo></msup></math>"
+       - "<math><msup intent='dual-space($a1)'><mi ad='a1'>V</mi><mo>&#x2032;</mo></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/DualSpace.html"
        - "https://en.wikipedia.org/wiki/Dual_space"
@@ -4345,7 +4345,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='fourier-cosine-transform($a1)'><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi>f</mi></mrow></math>"
+       - "<math><mrow intent='fourier-cosine-transform($a1)'><msub><mi>ℱ</mi><mi arg='a3'>c</mi></msub><mi ad='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierCosineTransform.html"
        - "https://dlmf.nist.gov/1.14#E9"
@@ -4357,7 +4357,7 @@ concepts:
       property: operator
       area: "functional analysis"
       comments:
-       - "<math><mrow intent='fourier-sine-transform($a1)'><msub><mi>ℱ</mi><mi>s</mi></msub><mi>f</mi></mrow></math>"
+       - "<math><mrow intent='fourier-sine-transform($a1)'><msub><mi>ℱ</mi><mi>s</mi></msub><mi ad='a1'>f</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierSineTransform.html"
        - "https://dlmf.nist.gov/1.14#E10"
@@ -4511,7 +4511,7 @@ concepts:
       property: mixfix
       area: "ring theory"
       comments:
-       - "<math><mrow intent='free-algebra($a1,$a2)'><mi>R</mi><mo>⟨</mo><mi arg='a1'>X</mi><mo>⟩</mo></mrow></math>"
+       - "<math><mrow intent='free-algebra($a1,$a2)'><mi ad='a1'>R</mi><mo>⟨</mo><mi arg='a2'>X</mi><mo>⟩</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/FreeAlgebra.html"
        - "https://en.wikipedia.org/wiki/Free_algebra"
@@ -4618,8 +4618,8 @@ concepts:
       property: msup, fenced
       area: "category theory"
       comments:
-       - "<math><msup intent='functor-category($a1,$a2)'><mi arg='a1'>f</mi><mi arg='a1'>g</mi></msup></math>"
-       - "<math><mrow intent='functor-category($a1,$a2)'><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a1'>g</mi><mo>]</mo></mrow></math>"
+       - "<math><msup intent='functor-category($a1,$a2)'><mi arg='a1'>f</mi><mi arg='a2'>g</mi></msup></math>"
+       - "<math><mrow intent='functor-category($a1,$a2)'><mo>[</mo><mi arg='a1'>f</mi><mo>,</mo><mi arg='a2'>g</mi><mo>]</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Functor_category"
        - "https://ncatlab.org/nlab/show/functor+category"
@@ -4706,7 +4706,7 @@ concepts:
       property: function
       area: "abstract algebra"
       comments:
-       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi></mrow></math>"
+       - "<math><mrow intent='galois-group($a1)'><mi>Gal</mi><mi ad='a1'>G</mi></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaloisGroup.html"
        - "https://en.wikipedia.org/wiki/Galois_group"
@@ -6117,7 +6117,7 @@ concepts:
       property: mixfix, 
       area: "set theory"
       comments:
-       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi>f</mi><mo>:</mo><mi arg='a1'>X</mi><mo>↣</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='injection($a1,$a2,$a3)'><mi ad='a1'>f</mi><mo>:</mo><mi arg='a2'>X</mi><mo>↣</mo><mi arg='a3'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Bijection#Definition"
     
@@ -7137,8 +7137,8 @@ concepts:
       property: fenced, fenced stacked
       area: "number theory"
       comments:
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi>p</mi><mo>)</mo></mrow></math>"
-       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi>p</mi></mfrac><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mi arg='a1'>a</mi><mo>|</mo><mi ad='a2'>p</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='legendre-symbol($a1,$a2)'><mo>(</mo><mfrac><mi arg='a1'>a</mi><mi ad='a2'>p</mi></mfrac><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/LegendreSymbol.html"
        - "https://en.wikipedia.org/wiki/Legendre_symbol"
@@ -7690,7 +7690,7 @@ concepts:
       property: mtable, fenced
       area: "algebra"
       comments:
-       - "<math><mrow intent='matrix($a1,$a2)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='matrix($a1)'><mi style='color:red'>!!F</mi><mrow><mo>(</mo><mi arg='a1'>x</mi><mo>)</mo></mrow></mrow></math>"
       notation: "mtable"
       notationb: "<math><mrow intent='matrix($a1)'><mo>[</mo><mi arg='a1'>x</mi><mo>]</mo></mrow></math>"
       notationa: "mrow ( $1"
@@ -8523,7 +8523,7 @@ concepts:
       property: fenced
       area: "euclidean solid geometry"
       comments:
-       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>,</mo><mi>±</mi><mo>)</mo></mrow></math>"
+       - "<math><mrow intent='octant($a1,$a2,$a3)'><mo>(</mo><mi ad='a1'>±</mi><mo>,</mo><mi ad='a2'>±</mi><mo>,</mo><mi ad='a3'>±</mi><mo>)</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/Octant.html"
        - "https://en.wikipedia.org/wiki/Octant_(plane_geometry)"
@@ -8739,7 +8739,7 @@ concepts:
       property: function
       area: "group theory"
       comments:
-       - "<math><mrow intent='p-core($a1)'><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi>G</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='p-core($a1)'><msub><mi>O</mi><mi>p</mi></msub><mrow><mo>(</mo><mi ad='a1'>G</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Core_(group)"
        - "https://en.wikipedia.org/wiki/P-soluble_group"
@@ -8752,7 +8752,7 @@ concepts:
       property: mixfix
       area: "numerical analysis"
       comments:
-       - "<math><msub intent='pade-approximant($a1,$a2,$a3)'><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi>f</mi></msub></math>"
+       - "<math><msub intent='pade-approximant($a1,$a2,$a3)'><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi ad='a3'>f</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/3.11#SS4.p1"
        - "https://mathworld.wolfram.com/PadeApproximant.html"
@@ -8861,7 +8861,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><msub intent='pauli-matrix($a1)'><mi>σ</mi><mi>G</mi></msub></math>"
+       - "<math><msub intent='pauli-matrix($a1)'><mi>σ</mi><mi ad='a1'>G</mi></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/PauliMatrices.html"
        - "https://mathworld.wolfram.com/PauliMatrix.html"
@@ -10189,7 +10189,7 @@ concepts:
       property: operator
       area: "calculus"
       comments:
-       - "<math><msub intent='right-derivative($a1)'><mo>∂</mo><mo>+</mo></msub></math>"
+       - "<math><msub intent='right-derivative($a1)'><mo>∂</mo><mo>+</mo></msub><mi ad='a1'>f</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Left_and_right_derivative"
     
@@ -10261,7 +10261,7 @@ concepts:
       property: mixfix
       area: "category theory"
       comments:
-       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi>Z</mi></mrow></math>"
+       - "<math><mrow intent='roof($a1,$a2,$a3)'><mi arg='a1'>X</mi><mo>&leftarrow;</mo><mi arg='a2'>Y</mi><mo>&rightarrow;</mo><mi ad='a3'>Z</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Span_(category_theory)"
        - "https://ncatlab.org/nlab/show/span"
@@ -11743,7 +11743,7 @@ concepts:
       property: msub
       area: "group theory"
       comments:
-       - "<math><msub intent='torsion-subgroup($a1)'><mi>G</mi><mi>T</mi></msub></math>"
+       - "<math><msub intent='torsion-subgroup($a1)'><mi ad='a1'>G</mi><mi>T</mi></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Torsion_subgroup"
        - "https://ncatlab.org/nlab/show/torsion+subgroup"
@@ -11898,7 +11898,7 @@ concepts:
       property: "indexed symbol"
       area: "topology"
       comments:
-       - "<math><msup intent='triple-torus($a1)'><mi>𝕋</mi><mn>3</mn></msup></math>"
+       - "<math><msup intent='triple-torus'><mi>𝕋</mi><mn>3</mn></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/TripleTorus.html"
        - "https://en.wikipedia.org/wiki/Three-torus"
@@ -12597,7 +12597,7 @@ concepts:
       property: "indexed symbol"
       area: "mathematical physics"
       comments:
-       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi>&delta;</mi></msub><mrow><mo>(</mo><mi>t</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='wiener-sausage($a1,$a2)'><msub><mi>W</mi><mi ad='a1'>&delta;</mi></msub><mrow><mo>(</mo><mi ad='a2'>t</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerSausage.html"
        - "https://en.wikipedia.org/wiki/Wiener_sausage"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -4199,7 +4199,8 @@ concepts:
       en: first isogonic center
       property: symbol
       area: "geometry"
-      notation: "mrow X(13"
+      comments:
+       - "<math><mrow intent='first-isogonic-center'><mi mathvariant='normal'>X</mi><mo>(</mo><mn>13</mn><mo>)</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Fermat_point"
     
@@ -4712,7 +4713,8 @@ concepts:
       en: gaussian integers
       property: constant
       area: "number theory"
-      notation: "mrow ℤ [i]"
+      comments:
+       - "<math><mrow intent='gaussian-integers'><mi>ℤ</mi><mo>[</mo><mi>i</mi>><mo>]</mo></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/GaussianInteger.html"
        - "https://en.wikipedia.org/wiki/Gaussian_integer"
@@ -4756,7 +4758,8 @@ concepts:
       en: gelfond schneider constant
       property: constant
       area: "transcendental constants"
-      notation: "msup 2 msqrt 2"
+      comments:
+       - "<math><msup intent='gelfond-schneider-constant'><mn>2</mn><msqrt><mn>2</mn></msqrt></msup></math>"
       urls: 
        - "https://mathworld.wolfram.com/Gelfond-SchneiderConstant.html"
        - "https://en.wikipedia.org/wiki/Gelfond%E2%80%93Schneider_constant"
@@ -7650,11 +7653,12 @@ concepts:
        - "https://ncatlab.org/nlab/show/meson"
     
     - concept: metaplectic-group
-      arity: 0
+      arity: 1
       en: metaplectic group
       property: symbol
       area: "group theory"
-      notation: "msub Mp 2n"
+      comments:
+       - "<math><mrow intent='metaplectic-group($a1)'><msub><mi>Mp</mi><mrow><mn>2</mn><mi>n</mi></mrow></msub><mrow><mo>(</mo><mi arg='a1'>R</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/MetaplecticGroup.html"
        - "https://en.wikipedia.org/wiki/Metaplectic_group"
@@ -8847,14 +8851,15 @@ concepts:
        - le-nombre-radiant
     
     - concept: playing-card-suit
-      arity: 0
+      arity: 1
       en: playing card suit
       property: unit
       area: "game theory"
-      notation: "mo ♣"
-      notationc: "mo ♠"
-      notationb: "mo ♦"
-      notationa: "mo ♥"
+      comments:
+       - "<math><mrow intent='playing-card-suit($a1)'><mo arg='a1'>♣</mo></mrow></math>"
+       - "<math><mrow intent='playing-card-suit($a1)'><mo arg='a1'>♠</mo></mrow></math>"
+       - "<math><mrow intent='playing-card-suit($a1)'><mo arg='a1'>♦</mo></mrow></math>"
+       - "<math><mrow intent='playing-card-suit($a1)'><mo arg='a1'>♥</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Playing_card_suit"
        - "https://en.wikipedia.org/wiki/Poker_probability"
@@ -10051,7 +10056,8 @@ concepts:
       en: s5 modal logic
       property: constant
       area: "logic"
-      notation: "mi S5"
+      comments:
+       - "<math><mi intent='s5-modal-logic'>S5</mi></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/S5_(modal_logic)"
     
@@ -10737,13 +10743,14 @@ concepts:
       alias:
        - face-ideal
     
-    - concept: star
+    - concept: star-game
       arity: 0
       en: star
       property: constant
       area: "combinatorial game theory"
-      notation: "mo ∗"
-      notationa: "mrow { 0 | 0 }"
+      comments:
+       - "<math><mo intent='star-game'>∗</mo></math>"
+       - "<math><mrow intent='star-game'><mo>{</mo><mn>0</mn><mo>|</mo><mn>0</mn><mo>}</mo></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Star_(game_theory)"
     
@@ -12232,7 +12239,8 @@ concepts:
       en: wiener algebra
       property: symbol
       area: "Fourier analysis"
-      notation: "mrowA(T"
+      comments:
+      - "<math><mrow intent='wiener-algebra'><mi>A</mi><mrow><mo>(</mo><mi>T</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/WienerAlgebra.html"
        - "https://en.wikipedia.org/wiki/Wiener_algebra"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -8076,7 +8076,7 @@ concepts:
       property: "msub, mixfix"
       area: "mathematics"
       comments:
-       - "<math><mrow intent='moment-of-function($a1)'><msub><mi>μ</mi><mi arg='a1'>n</mi></msub></math></math>"
+       - "<math><mrow intent='moment-of-function($a1)'><msub><mi>μ</mi><mi arg='a1'>n</mi></msub></mrow></math>"
       notationa: "mrow E [ msup $1 $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -7674,7 +7674,7 @@ concepts:
     
     - concept: matrix
       arity: 1
-      en: matrix of $1
+      en: matrix $1
       property: mtable, fenced
       area: "algebra"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -11375,7 +11375,7 @@ concepts:
     
     - concept: surjection
       arity: 3
-      en: surjection  $1 $2 $3
+      en: surjection  $1, from $2 to $3
       property: mixfix, infix
       area: "set theory"
       comments:

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1134,7 +1134,7 @@ concepts:
       property: infix
       area: "algebraic topology"
       comments:
-       - "<math><mrow intent='cap-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⌣</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='cap-product($a1,$a2)'><mi arg='a1'>X</mi><mo>⌢</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Cap_product"
        - "https://ncatlab.org/nlab/show/cap+product"

--- a/_data/open.yml
+++ b/_data/open.yml
@@ -1285,7 +1285,7 @@ concepts:
       property: mtable
       area: "group theory"
       comments:
-       - "<math><mtable><mtr><mtd><mo>×</mo></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>1</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>−1</mn></mtd><mtd><mn>−1</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable>"
+       - "<math><mrow intent='cayley-table($a1)'><mtable arg='a1'><mtr><mtd><mo>×</mo></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>1</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>−1</mn></mtd></mtr><mtr><mtd><mn>−1</mn></mtd><mtd><mn>−1</mn></mtd><mtd><mn>1</mn></mtd></mtr></mtable></mrow></math>"
       urls: 
        - "https://mathworld.wolfram.com/CayleyTable.html"
        - "https://en.wikipedia.org/wiki/Cayley_table"
@@ -1532,7 +1532,7 @@ concepts:
       property: "indexed symbol"
       area: "Riemannian geometry"
       comments:
-       - "<math><mmultiscripts><mi>&Gamma;</mi><mrow/><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mrow/><mi arg='a2'>j</mi><mrow/></mmultiscripts></math>"
+       - "<math><mmultiscripts intent='christoffel-symbol-of-second-kind($a1,$a2,$a3)'><mi>&Gamma;</mi><mrow/><mi arg='a3'>k</mi><mi arg='a1'>i</mi><mrow/><mi arg='a2'>j</mi><mrow/></mmultiscripts></math>"
       urls: 
        - "https://mathworld.wolfram.com/ChristoffelSymbol.html"
        - "https://en.wikipedia.org/wiki/Christoffel_symbols"
@@ -2148,7 +2148,7 @@ concepts:
       property: constant
       area: "logic"
       comments:
-       - "<math><mo>⊥</mo></math>"
+       - "<math><mo intent='contradiction'>⊥</mo></math>"
       urls: 
        - "https://mathworld.wolfram.com/Contradiction.html"
        - "https://en.wikipedia.org/wiki/Contradiction"
@@ -2583,13 +2583,13 @@ concepts:
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4705"
     
-    - concept: decrease-tends-to?
+    - concept: decrease-tends-to
       arity: 2
-      en: $1 decrease tends to? $2
+      en: $1 decrease tends to $2
       property: infix
       area: "calculus"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>↘</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='decrease-tends-to($a1,$a2)''><mi arg='a1'>X</mi><mo>↘</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"
@@ -4292,7 +4292,7 @@ concepts:
       property: mover
       area: "fourier analysis"
       comments:
-       - "<math><mover><mi>f</mi><mo>^</mo></mover></math>"
+       - "<math><mover intent='fourier-transform($a1)'><mi arg='a1'>f</mi><mo>^</mo></mover></math>"
       urls: 
        - "https://mathworld.wolfram.com/FourierTransform.html"
        - "https://en.wikipedia.org/wiki/%E2%84%B1"
@@ -5747,7 +5747,7 @@ concepts:
       area: "set theory"
       notation: "$1 [ $2 ]"
       notationc: "msub $1 *"
-      notationb: "<math><msup><mi>X</mi><mo>→</mo></msup></math>"
+      notationb: "<msup><mi>X</mi><mo>→</mo></msup>"
       notationa: "$1 '' $2"
       urls: 
        - "https://mathworld.wolfram.com/Image.html"
@@ -5880,13 +5880,13 @@ concepts:
       urls: 
        - "https://youtu.be/HZ7a9YkF204?t=4606"
     
-    - concept: increase-tends-to?
+    - concept: increase-tends-to
       arity: 2
-      en: $1 increase tends to? $2
+      en: $1 increase tends to $2
       property: infix
       area: "calculus"
       comments:
-       - "<math><mrow><mi arg='a1'>X</mi><mo>↗</mo><mi arg='a2'>Y</mi></mrow></math>"
+       - "<math><mrow intent='increase-tends-to($a1,$a2)'><mi arg='a1'>X</mi><mo>↗</mo><mi arg='a2'>Y</mi></mrow></math>"
       urls: 
        - "https://math.stackexchange.com/questions/1886232/what-does-this-notation-mean-limes-from-left-right"
        - "http://pi.math.cornell.edu/~web6720/MATH%206710%20notes.pdf"
@@ -6139,7 +6139,7 @@ concepts:
       property: symbol
       area: "probability theory"
       comments:
-       - "<math><msubsup><mi>W</mi><mi>p</mi><mn>−1</mn></msubsup></math>"
+       - "<math><msubsup intent='inverse-wishart-distribution'><mi>W</mi><mi>p</mi><mn>−1</mn></msubsup></math>"
       urls: 
        - "https://mathworld.wolfram.com/WishartDistribution.html"
        - "https://en.wikipedia.org/wiki/Wishart_distribution"
@@ -6724,7 +6724,7 @@ concepts:
       property: indexed fenced
       area: "classical mechanics"
       comments:
-       - "<math><msub><mrow><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi><mo>]</mo></mrow><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
+       - "<math><msub intent='lagrange-bracket($1,$2,$3,$4)'><mrow><mo>[</mo><mi>u</mi><mo>,</mo><mi>v</mi><mo>]</mo></mrow><mrow><mi>p</mi><mo>,</mo><mi>q</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/LagrangeBracket.html"
        - "https://en.wikipedia.org/wiki/Lagrange_bracket"
@@ -7009,7 +7009,7 @@ concepts:
       property: "indexed symbol"
       area: "combinatorics"
       comments:
-       - "<math><msub><mi>&#x03f5;</mi><mrow><mi arg='a1'>i</mi><mi arg='a2'>j</mi><mi arg='a3'>k</mi></mrow></msub></math>"
+       - "<math><msub intent='levi-civita-symbol($1,$2,$3)'><mi>&#x03f5;</mi><mrow><mi arg='a1'>i</mi><mi arg='a2'>j</mi><mi arg='a3'>k</mi></mrow></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/Levi-CivitaSymbol.html"
        - "https://en.wikipedia.org/wiki/Levi-Civita_symbol"
@@ -7851,12 +7851,12 @@ concepts:
        - "https://en.wikipedia.org/wiki/M%C3%B6bius_function"
     
     - concept: moment-of-function
-      arity: 2
-      en: moment of function $1 $2
+      arity: 
+      en: $1 th moment 
       property: "msub, mixfix"
       area: "mathematics"
       comments:
-       - "<math><msub><mi>μ</mi><mi arg='a1'>x</mi></msub></math>"
+       - "<math><mrow intent='moment-of-function($a1)'><msub><mi>μ</mi><mi arg='a1'>n</mi></msub></math></math>"
       notationa: "mrow E [ msup $1 $2 ]"
       urls: 
        - "https://en.wikipedia.org/wiki/Moment_(mathematics)"
@@ -8165,7 +8165,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mover><mi>h</mi><mo>^</mo></mover></math>"
+       - "<math><mover intent='neron-tate-height'><mi>h</mi><mo>^</mo></mover></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/N%C3%A9ron%E2%80%93Tate_height"
       alias:
@@ -8521,7 +8521,7 @@ concepts:
       property: mixfix
       area: "numerical analysis"
       comments:
-       - "<math><msub><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi>f</mi></msub></math>"
+       - "<math><msub intent='pade-approximant($a1,$a2,$a3)'><mrow><mo>[</mo><mi arg='a1'>X</mi><mo>/</mo><mi arg='a2'>Y</mi><mo>]</mo></mrow><mi>f</mi></msub></math>"
       urls: 
        - "https://dlmf.nist.gov/3.11#SS4.p1"
        - "https://mathworld.wolfram.com/PadeApproximant.html"
@@ -8568,7 +8568,7 @@ concepts:
       property: embellished infix
       area: "category theory"
       notation: "<munderover>"
-      notationd: "<math><mrow/>"
+      notationd: "<mrow/>"
       notationc: "<munder><mo>⟶</mo> $1</munder>"
       notationb: "<mover><mo>⟶</mo> $2</mover>"
       notationa: "</munderover>"
@@ -9287,7 +9287,7 @@ concepts:
       property: constant
       area: "geometry"
       comments:
-       - "<math><msqrt><mn>2</mn></msqrt></math>"
+       - "<math><msqrt intent='pythagoras-constant'><mn>2</mn></msqrt></math>"
       urls: 
        - "https://mathworld.wolfram.com/PythagorassConstant.html"
        - "https://en.wikipedia.org/wiki/Sqrt(2)"
@@ -9322,8 +9322,8 @@ concepts:
       property: symbol
       area: "mathematical symbols"
       comments:
-       - "<math><mo>□</mo></math>"
-       - "<math><mo>∎</mo></math>"
+       - "<math><mo intent='qed'>□</mo></math>"
+       - "<math><mo intent='qed'>∎</mo></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Tombstone_(typography)"
       alias:
@@ -9450,7 +9450,7 @@ concepts:
       property: symbol
       area: "geometry"
       comments:
-       - "<math><mi arg='a1'>x</mi></math>"
+       - "<math><mi intent='radius-vector'>x</mi></math>"
        - "<math><mi intent='radius-vector'>r</mi></math>"
        - "<math><mi intent='radius-vector'>s</mi></math>"
       urls: 
@@ -9810,14 +9810,14 @@ concepts:
     
     
     - concept: riemann-sphere
-      arity: 1
-      en: riemann sphere of $1
+      arity: 0
+      en: riemann sphere
       property: scripted symbol
       area: "projective geometry"
       comments:
-       - "<math><mover><mi>ℂ</mi><mo>^</mo></mover></math>"
-       - "<math><mover><mi>ℂ</mi><mo>¯</mo></mover></math>"
-       - "<math><msub intent='riemann-sphere($a1)'><mi>ℂ</mi><mo>∞</mo></msub></math>"
+       - "<math><mover intent='riemann-sphere'><mi>ℂ</mi><mo>^</mo></mover></math>"
+       - "<math><mover intent='riemann-sphere'><mi>ℂ</mi><mo>¯</mo></mover></math>"
+       - "<math><msub intent='riemann-sphere'><mi>ℂ</mi><mo>∞</mo></msub></math>"
       urls: 
        - "https://mathworld.wolfram.com/RiemannSphere.html"
        - "https://en.wikipedia.org/wiki/Riemann_sphere"
@@ -9953,7 +9953,7 @@ concepts:
       property: symbol
       area: "number theory"
       comments:
-       - "<math><mi mathvariant='normal'>i</mi></math>"
+       - "<math><mi intent='roman-numeral' mathvariant='normal'>i</mi></math>"
        - "<math><mi intent='roman-numeral'>ii</mi></math>"
        - "<math><mi intent='roman-numeral'>iii</mi></math>"
        - "<math><mi intent='roman-numeral'>iv</mi></math>"
@@ -10197,7 +10197,7 @@ concepts:
       property: "indexed function"
       area: "relational algebra"
       comments:
-       - "<math><msub><mi>&sigma;</mi><mrow><mi arg='a1'>a</mi><mi arg='a2'>&theta;</mi><mi arg='a3'>b</mi></mrow></msub></math>"
+       - "<math><msub intent='selection($a1,$a2,$a3)'><mi>&sigma;</mi><mrow><mi arg='a1'>a</mi><mi arg='a2'>&theta;</mi><mi arg='a3'>b</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Selection_(relational_algebra)"
     
@@ -12331,7 +12331,7 @@ concepts:
       property: fenced
       area: "ring theory"
       comments:
-       - "<math><mrow><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='witt-vector($a1)'><mi>W</mi><mrow><mo>(</mo><mi arg='a1'>X</mi><mo>)</mo></mrow></mrow></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Witt_vector"
        - "https://www.encyclopediaofmath.org/index.php/Witt_vector"
@@ -12468,7 +12468,7 @@ concepts:
       property: "indexed symbol"
       area: "linear algebra"
       comments:
-       - "<math><msub><mn>0</mn><mrow><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></math>"
+       - "<math><msub intent='zero-matrix($a1,$a2)'><mn>0</mn><mrow><mi arg='a1'>i</mi><mi arg='a2'>j</mi></mrow></msub></math>"
       urls: 
        - "https://en.wikipedia.org/wiki/Zero_matrix"
     

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -1,6 +1,17 @@
 ---
 title: Open Concept List
 ---
+<script>
+  function showmath (){
+      const ml =document.querySelectorAll("math");
+      for(const m of ml) {
+	  const md =  document.createElement("div");
+	  md.className="mmlshow";
+	  md.textContent=m.outerHTML.replaceAll("><",">\n<");
+	  m.parentNode.replaceChild(md, m);
+      }
+  }
+</script>
 <style>
 p.langs {margin:1em; padding:1em;background-color: #EEE}
 tr:target >td:first-child {border-left:solid thick black}
@@ -25,6 +36,7 @@ a.self {color: black; font-weight:500}
 math:not(:has(*[intent])) {
     color: red;
     }
+div.mmlshow {display:inline-block;padding:1em;margin:.5em;border-radius:1em;font-family:monospace;background-color:#EEE;white-space:pre;}
 </style>
 
 <style id="langcss">
@@ -60,6 +72,7 @@ order might not be clear from the standard notation, the speech hint
 or comments should make clear what is the intended order of arguments.
 
 
+
 ----
 
 ### Sources
@@ -69,6 +82,10 @@ Additional contributions are welcome:
 
 ----
 
+<p><button onclick="showmath()">Show MathML Source</button></p>
+
+
+----
 
 <details>
 <summary>Available Template Languages</summary>

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -7,7 +7,7 @@ title: Open Concept List
       for(const m of ml) {
 	  const md =  document.createElement("div");
 	  md.className="mmlshow";
-	  md.textContent=m.outerHTML.replaceAll("><",">\n<");
+	  md.textContent=m.outerHTML.replaceAll("<mrow></mrow>","<mrow/>").replaceAll("><",">\n<");
 	  m.parentNode.replaceChild(md, m);
       }
   }

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -20,7 +20,7 @@ a.self {color: black; font-weight:500}
 math:not(:has(*[intent])) {
     color: red;
     }
-}</style>
+</style>
 
 <style id="langcss">
 {% for language in site.data.languages offset:1-%}

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -17,6 +17,11 @@ a.self {color: black; font-weight:500}
      [arg="a2"]:hover::after { content: " $2" ; }
      [arg="a3"]:hover::after { content: " $3" ; }
      [arg="a4"]:hover::after { content: " $4" ; }
+     [arg="a5"]:hover::after { content: " $5" ; }
+     [arg="a6"]:hover::after { content: " $6" ; }
+     [arg="a7"]:hover::after { content: " $7" ; }
+     [arg="a8"]:hover::after { content: " $8" ; }
+     [arg="a9"]:hover::after { content: " $9" ; }
 math:not(:has(*[intent])) {
     color: red;
     }

--- a/intent-open-concepts/index.md
+++ b/intent-open-concepts/index.md
@@ -17,7 +17,10 @@ a.self {color: black; font-weight:500}
      [arg="a2"]:hover::after { content: " $2" ; }
      [arg="a3"]:hover::after { content: " $3" ; }
      [arg="a4"]:hover::after { content: " $4" ; }
-</style>
+math:not(:has(*[intent])) {
+    color: red;
+    }
+}</style>
 
 <style id="langcss">
 {% for language in site.data.languages offset:1-%}


### PR DESCRIPTION
This adds `arg` attributes to most MathML examples (and a single test `intent` attribute) and has some styling using @dginev 's version of the css for arg.

It's work in progress but I'd like to merge anyway to avoid getting too far ahead on a branch, and give time to bring the core list to the same format.

The html/css rendering of the arg attributes is visible by hovering over them at

https://davidcarlisle.github.io/mathml-docs/intent-open-concepts/