### PR TITLE
largeop properties

### DIFF
--- a/_data/core.yml
+++ b/_data/core.yml
@@ -674,7 +674,7 @@ concepts:
       property: function
       en: "sum over $1 of $2"
       mathml:
-       - "<math><mrow intent='sum($a1,$a2)'><munder><mo>∑</mo><mrow arg='$a1'><mi>i</mi><mo>∈</mo><mi>X</mi></mrow></munder><mrow arg='a2'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sum($a1,$a2)'><munder><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>∈</mo><mi>X</mi></mrow></munder><mrow arg='a2'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munder>` or `<msub>`
 
@@ -683,7 +683,7 @@ concepts:
       property: function
       en: "sum from $1 to $2 of $3"
       mathml:
-       - "<math><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='$a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munderover>` or `<msubsup>`
 

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -219,12 +219,27 @@ largeop:
     characters: [⋃]
   - concept: intersection
     characters: [⋂]
+  - concept: logical-and
+    characters: [⋀]
+  - concept: logical-or
+    characters: [⋁]
   - concept: integral
     characters: [∫]
   - concept: double-integral
     characters: [∬]
+  - concept: triple-integral
+    characters: [∭]
   - concept: contour-integral
     characters: [∮]
+  - concept: surface-integral
+    characters: [∯]
+  - concept: clockwise-integral
+    characters: [∱]
+  - concept: clockwise-contor-integral
+    characters: [∲]
+  - concept: anticlockwise-contor-integral
+    characters: [∳]
+
 
 concepts:
 
@@ -467,16 +482,16 @@ concepts:
   - title: calculus
     intents:
     - concept: definite-integral
-      arity: 1
-      property: ???
-      en: "integral over $1"
+      arity: 2
+      property: largeop
+      en: "integral over $1 of $2"
       comments:
       - "integral sign is not an argument"
 
     - concept: definite-integral
-      arity: 2
-      property: ???
-      en: "integral from $1 to $2"
+      arity: 3
+      property: largeop
+      en: "integral from $1 to $2 of $3"
       comments:
       - "integral sign is not an argument"
     
@@ -662,7 +677,7 @@ concepts:
     intents:
     - concept: sum
       arity: 1
-      property: function
+      property: largeop
       en: "sum of $1"
       mathml:
        - "<math display='block'><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
@@ -689,7 +704,7 @@ concepts:
 
     - concept: product
       arity: 1
-      property: function
+      property: largeop
       en: "product of $1"
       comments:
       - usually on `<mrow>`

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -219,6 +219,12 @@ largeop:
     characters: [⋃]
   - concept: intersection
     characters: [⋂]
+  - concept: integral
+    characters: [∫]
+  - concept: double-integral
+    characters: [∬]
+  - concept: contour-integral
+    characters: [∮]
 
 concepts:
 

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -309,9 +309,9 @@ concepts:
       en: $1 evaluated-at $2
       comments:
       - "Two common notations are
-        <math><mrow><msub><mrow><mrow><mrow><msup><mi>x</mi><mn>2</mn></msup></mrow><mo>|</mo></mrow></mrow><mn>3</mn></msub></mrow></math>
+        <math display='block'><mrow><msub><mrow><mrow><mrow><msup><mi>x</mi><mn>2</mn></msup></mrow><mo>|</mo></mrow></mrow><mn>3</mn></msub></mrow></math>
         and
-        <math>
+        <math display='block'>
           <msub>
               <mrow>
                   <msup><mi>x</mi><mn>2</mn></msup>
@@ -413,7 +413,7 @@ concepts:
       en: "polar coordinate $1 comma $2"
       comment:
       - "The first argument is the radius, the second argument is the polar angle, the third arguments is the azimuthal angle."
-      - "Example: <math><mo>(</mo><mi>r</mi><mo>,</mo><mo>&#xA0;</mo><mi>&#x3B8;</mi><mo>)</mo></math>"
+      - "Example: <math display='block'><mo>(</mo><mi>r</mi><mo>,</mo><mo>&#xA0;</mo><mi>&#x3B8;</mi><mo>)</mo></math>"
 
     - concept: spherical-coordinate
       arity: 3
@@ -421,14 +421,14 @@ concepts:
       en: "spherical coordinate $1 comma $2, comma $3"
       comment:
       - "The first argument is the radius, the second argument is the angle."
-      - "Example: <math><mo>(</mo><mi>r</mi><mo>,</mo><mi>&#x3A6;</mi><mo>,</mo><mi>&#x3B8;</mi><mo>)</mo></math>"
+      - "Example: <math display='block'><mo>(</mo><mi>r</mi><mo>,</mo><mi>&#x3A6;</mi><mo>,</mo><mi>&#x3B8;</mi><mo>)</mo></math>"
 
     - concept: cartesian-coordinate
       arity: ">=2"
       property: function
       en: "cartesian coordinate $1 comma $2 ..."
       comment:
-      - "Example: <math><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>)</mo></math>"
+      - "Example: <math display='block'><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>)</mo></math>"
 
     - concept: coordinate
       arity: ">=2"
@@ -436,7 +436,7 @@ concepts:
       en: "coordinate $1 comma $2 ..."
       comment:
       - "This a generic coordinate that doesn't specify the coordinate system. It takes 2 or more arguments."
-      - "Example: <math><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>)</mo></math>"
+      - "Example: <math display='block'><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>)</mo></math>"
 
     - concept: floor
       arity: 1
@@ -454,9 +454,9 @@ concepts:
       en: rounded-value of $1
       comments:
       - "This sometimes uses the notation
-        <math><mo>&#x230A;</mo><mi>x</mi><mo>&#x2309;</mo></math>
+        <math display='block'><mo>&#x230A;</mo><mi>x</mi><mo>&#x2309;</mo></math>
         or
-        <math><mo>[</mo><mi>x</mi><mo>]</mo></math>"
+        <math display='block'><mo>[</mo><mi>x</mi><mo>]</mo></math>"
 
     - concept: fractional-part
       arity: 1
@@ -489,11 +489,11 @@ concepts:
       - "(terse) d <$3 if $3 != 1> $1 by d $2 <$3 if $3 != 1>"
       comments:
       - "the terse reading only makes sense for Leibniz notation such as 
-          <math><mfrac><mrow><msup><mi>d</mi><mn>2</mn></msup><mi>y</mi></mrow><mrow><mi>d</mi><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></math>
+          <math display='block'><mfrac><mrow><msup><mi>d</mi><mn>2</mn></msup><mi>y</mi></mrow><mrow><mi>d</mi><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac></math>
           or
-          <math><mfrac><msup><mi>d</mi><mn>2</mn></msup><mrow><mi>d</mi><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac><mi>f</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>.
+          <math display='block'><mfrac><msup><mi>d</mi><mn>2</mn></msup><mrow><mi>d</mi><msup><mi>x</mi><mn>2</mn></msup></mrow></mfrac><mi>f</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>.
           It does not make sense for other notations such as 
-          <math><msup><mi>f</mi><mo>''</mo></msup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>
+          <math display='block'><msup><mi>f</mi><mo>''</mo></msup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></math>
           "
       - "The first of these examples might be marked up as"
       - |
@@ -538,7 +538,7 @@ concepts:
       comments:
       - "limit is not an argument, but intent should be on `msub` or `munder`"
       - "There are several arrows used for limits. "
-      - "Example: <math>
+      - "Example: <math display='block'>
               <munder intent='limit($lim)'>
                   <mi>lim</mi>
                   <mrow arg='lim' intent='tends-to-from-below($x, $val)'><mi arg='x'>x</mi><mo>↗</mo><mn arg='val'>0</mn></mrow>
@@ -557,7 +557,7 @@ concepts:
         </munder>
         ```
       - "Another notation that might be spoken similarly is
-        <math><munder><mrow><mi>l</mi><mi>i</mi><mi>m</mi></mrow><mrow><mi>x</mi><mo>→</mo><msup><mn>0</mn><mo>-</mo></msup></mrow></munder></math>
+        <math display='block'><munder><mrow><mi>l</mi><mi>i</mi><mi>m</mi></mrow><mrow><mi>x</mi><mo>→</mo><msup><mn>0</mn><mo>-</mo></msup></mrow></munder></math>
         "
     
     - concept: tends-to
@@ -593,7 +593,7 @@ concepts:
                the argument to `set` is typically an `mrow`. For example:
 
                ```
-               <math>
+               <math display='block'>
                 <mrow intent='set($members)'>
                  <mo>{</mo>
                  <mrow arg='members'>
@@ -617,7 +617,7 @@ concepts:
       comments:
       - "This can be spoken in many ways. See other entry for infix speech."
       - "There are several notations that are used and their order of appearance differs:
-        <math><mi>A</mi><mo>-</mo><mi>B</mi></math>, <math><mi>A</mi><mo>\\</mo><mi>B</mi></math>"
+        <math display='block'><mi>A</mi><mo>-</mo><mi>B</mi></math>, <math display='block'><mi>A</mi><mo>\\</mo><mi>B</mi></math>"
 
     - concept: set-difference
       arity: 2
@@ -634,7 +634,7 @@ concepts:
       comments:
       - "This can be spoken in many ways. See other entry for functional speech."
       - "Two notations used for complement are: 
-        <math><msup><mi>A</mi><mi>C</mi></msup></math>, <math><msup><mi>A</mi><mo>'</mo></msup></math>"
+        <math display='block'><msup><mi>A</mi><mi>C</mi></msup></math>, <math display='block'><msup><mi>A</mi><mo>'</mo></msup></math>"
 
     - concept: empty-set
       arity: 0
@@ -665,7 +665,7 @@ concepts:
       property: function
       en: "sum of $1"
       mathml:
-       - "<math><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math display='block'><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<mrow>`
 
@@ -674,7 +674,7 @@ concepts:
       property: function
       en: "sum over $1 of $2"
       mathml:
-       - "<math><mrow intent='sum($a1,$a2)'><munder><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>∈</mo><mi>X</mi></mrow></munder><mrow arg='a2'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math display='block'><mrow intent='sum($a1,$a2)'><munder><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>∈</mo><mi>X</mi></mrow></munder><mrow arg='a2'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munder>` or `<msub>`
 
@@ -683,7 +683,7 @@ concepts:
       property: function
       en: "sum from $1 to $2 of $3"
       mathml:
-       - "<math><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math display='block'><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munderover>` or `<msubsup>`
 
@@ -772,7 +772,7 @@ concepts:
       - "(verbose) arcsine $1"
       comments:
       - "used as 'arcsin', 'arc sin'"
-      - "this is distinct from sin inverse (<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math>)"
+      - "this is distinct from sin inverse (<math display='block'><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup></math>)"
 
     - concept: arccosine
       arity: 1
@@ -978,7 +978,7 @@ concepts:
       property: function
       en: "mean of $1"
       comments:
-      - "This might be display as <math><mover><mi>x</mi><mo>&#xAF;</mo></mover></math>"
+      - "This might be display as <math display='block'><mover><mi>x</mi><mo>&#xAF;</mo></mover></math>"
 
     - concept: standard-deviation
       arity: 1
@@ -1011,7 +1011,7 @@ concepts:
                 The intent should be on the `mrow` that includes the "P"
       
                  ```
-                 <math>
+                 <math display='block'>
                   <mrow intent='conditional-probability($arg1, $arg2)'>
                    <mi>P</mi>
                    <mo>(</mo>
@@ -1072,7 +1072,7 @@ concepts:
       arity: 1
       property: prefix
       comments:
-      - "Example: <math><mover><mi>x</mi><mo>^</mo></mover></math>"
+      - "Example: <math display='block'><mover><mi>x</mi><mo>^</mo></mover></math>"
       en: "unit vector x"
 
     - concept: identity-matrix
@@ -1101,7 +1101,7 @@ concepts:
       en: "$1 by $2 ..."
       comments:
       - "This is typically used with the `×` operator and can be placed on that character as a 0-arity concept name.
-                A common use would be describe the size of a matrix. For example <math><mi>m</mi><mo>×</mo><mi>n</mi></math>."
+                A common use would be describe the size of a matrix. For example <math display='block'><mi>m</mi><mo>×</mo><mi>n</mi></math>."
 
 
     ## ====================== 4.4.10 Constants and Sets ======================
@@ -1178,7 +1178,7 @@ concepts:
         en:
         - "line segment $1 $2"
         comments:
-        - "Example: (`mover`): <math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>_</mo></mover></math>"
+        - "Example: (`mover`): <math display='block'><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>_</mo></mover></math>"
 
       - concept: directed-line-segment
         arity: 2
@@ -1186,7 +1186,7 @@ concepts:
         en:
         - "directed line segment $1 $2"
         comments:
-        - "Example: (`mover`): <math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>→</mo></mover></math>"
+        - "Example: (`mover`): <math display='block'><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>→</mo></mover></math>"
 
       - concept: line
         arity: 2
@@ -1194,7 +1194,7 @@ concepts:
         en:
         - "line $1 $2"
         comments:
-        - "Example: (`mover`): <math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>↔</mo></mover></math>"
+        - "Example: (`mover`): <math display='block'><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>↔</mo></mover></math>"
 
       - concept: ray
         arity: 2
@@ -1202,7 +1202,7 @@ concepts:
         en:
         - "ray $1 $2"
         comments:
-        - "Example: (`mover`): <math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>→</mo></mover></math>"
+        - "Example: (`mover`): <math display='block'><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>→</mo></mover></math>"
 
       - concept: arc
         arity: 2
@@ -1210,7 +1210,7 @@ concepts:
         en:
         - "arc $1 $2"
         comments:
-        - "Example: (`mover`): <math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>⌒</mo></mover></math>"
+        - "Example: (`mover`): <math display='block'><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>⌒</mo></mover></math>"
 
       - concept: length
         arity: 1
@@ -1219,7 +1219,7 @@ concepts:
         - "length of $1"
         comments:
         - "It may be necessary to 'nest' the intent as shown here for the example:
-          <math><mrow intent='length(line-segment($start, $end))'>
+          <math display='block'><mrow intent='length(line-segment($start, $end))'>
                  <mi arg='start' mathvariant='normal'>A</mi>
                  <mi arg='end' mathvariant='normal'>B</mi>
               </mrow></math>"
@@ -1239,7 +1239,7 @@ concepts:
         - "area of $1"
         comments:
         - "There are many notations. Here's one: 
-            <math><mrow intent='area($a,$b,$c,$d)'><mo>[</mo><mi arg='a' mathvariant='normal'>A</mi><mi arg='b' mathvariant='normal'>B</mi><mi arg='c' mathvariant='normal'>C</mi><mi arg='d'  mathvariant='normal'>D</mi><mo>]</mo></mrow></math>"
+            <math display='block'><mrow intent='area($a,$b,$c,$d)'><mo>[</mo><mi arg='a' mathvariant='normal'>A</mi><mi arg='b' mathvariant='normal'>B</mi><mi arg='c' mathvariant='normal'>C</mi><mi arg='d'  mathvariant='normal'>D</mi><mo>]</mo></mrow></math>"
         - "The markup for this is:"
         - |
           ```
@@ -1261,7 +1261,7 @@ concepts:
         en:
         - "point $1 [comma $2 ...]"
         comment:
-        - "Example: <math><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>,</mo><mn>3</mn><mo>)</mo></math>"
+        - "Example: <math display='block'><mo>(</mo><mn>1</mn><mo>,</mo><mn>2</mn><mo>,</mo><mn>3</mn><mo>)</mo></math>"
 
       - concept: volume
         arity: 1
@@ -1343,14 +1343,14 @@ concepts:
         property: function
         en: "translation by $1 comma $2"
         comments:
-        - "Example: <math><msub><mi>T</mi><mrow><mo>(</mo><mn>1</mn><mo>,</mo><mn>3</mn><mo>)</mo></mrow></msub></math>"
+        - "Example: <math display='block'><msub><mi>T</mi><mrow><mo>(</mo><mn>1</mn><mo>,</mo><mn>3</mn><mo>)</mo></mrow></msub></math>"
         
       - concept: constraint
         arity: 2
         property: infix
         en: "fraction 2 over x minus 1 with constraint x not equal to 1"
         comments:
-        - "Example: <math><mfrac><mn>2</mn><mrow><mi>x</mi><mo>-</mo><mn>1</mn></mrow></mfrac><mo>,</mo><mo>&#xA0;</mo><mi>x</mi><mo>&#x2260;</mo><mn>1</mn></math>"
+        - "Example: <math display='block'><mfrac><mn>2</mn><mrow><mi>x</mi><mo>-</mo><mn>1</mn></mrow></mfrac><mo>,</mo><mo>&#xA0;</mo><mi>x</mi><mo>&#x2260;</mo><mn>1</mn></math>"
         
       - concept: binomial-coefficient
         arity: 2
@@ -1358,7 +1358,7 @@ concepts:
         en: "$1 choose $2"
         comments:
         - "There are many notations used for the binomial coefficient. Here are some of them: 
-          <math><mrow intent='binomial-coefficent($power, $term)'>
+          <math display='block'><mrow intent='binomial-coefficent($power, $term)'>
             <mo>(</mo>
             <mfrac linethickness='0'>
                 <mi arg='power'>n</mi>
@@ -1366,14 +1366,14 @@ concepts:
             </mfrac>
             <mo>)</mo>
           </mrow></math>, 
-          <math>
+          <math display='block'>
             <msubsup intent='binomial-coefficent($power, $term>)'>
               <mi>C</mi>
               <mi arg='term'>k</mi>
               <mi arg='power'>n</mi>
             </msubsup>
           </math>, 
-          <math>
+          <math display='block'>
             <mmultiscripts intent='binomial-coefficent($power, $term)'>
               <mi>C</mi>
               <mi arg='term'>k</mi> <none/>
@@ -1388,7 +1388,7 @@ concepts:
         en: "$2 permutation of $1"
         comments:
         - "There are many notations for this: some of them are 
-            <math>
+            <math display='block'>
               <msubsup><mi>P</mi><mi>k</mi><mi>n</mi></msubsup>
               <mo>,</mo><mo>&#xA0;</mo>
               <mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts>
@@ -1416,7 +1416,7 @@ concepts:
         property: function
         en: "permutation cycle of $1 $2 ..."
         comments:
-        - "A common notation for a permutation cycle is <math><mo>(</mo>
+        - "A common notation for a permutation cycle is <math display='block'><mo>(</mo>
                 <mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>3</mn></mtd><mtd><mn>2</mn></mtd></mtr></mtable>
                 <mo>)</mo></math>"
         - "This would be marked up as:"
@@ -1455,7 +1455,7 @@ concepts:
         en: "$1 which is $2"
         comments:
         - "used with `mover` or `munder`"
-        - "Example: <math><munder><munder><mrow><msub><mi mathvariant='normal'>H</mi><mn>2</mn></msub><mi mathvariant='normal'>O</mi></mrow><mo>&#x23DF;</mo></munder><mtext>water</mtext></munder></math>"
+        - "Example: <math display='block'><munder><munder><mrow><msub><mi mathvariant='normal'>H</mi><mn>2</mn></msub><mi mathvariant='normal'>O</mi></mrow><mo>&#x23DF;</mo></munder><mtext>water</mtext></munder></math>"
 
       - concept: braced-group
         arity: 1
@@ -1463,7 +1463,7 @@ concepts:
         en: "grouped $1 end-grouped"
         comments:
         - "used with `mover` or `munder`"
-        - "Example: <math><munder><mrow><mfrac><mn>1</mn><mn>3</mn></mfrac><mo>-</mo><mfrac><mn>1</mn><mn>6</mn></mfrac></mrow><mo>&#x23DF;</mo></munder></math>"
+        - "Example: <math display='block'><munder><mrow><mfrac><mn>1</mn><mn>3</mn></mfrac><mo>-</mo><mfrac><mn>1</mn><mn>6</mn></mfrac></mrow><mo>&#x23DF;</mo></munder></math>"
 
       - concept: repeating-decimal
         arity: 1
@@ -1471,7 +1471,7 @@ concepts:
         en: "repeating decimal $1"
         comments:
         - "typically used in when there is a bar over the repeating part of a decimal or dots over the first and last digits."
-        - "Example: <math><mfrac><mn>1</mn><mn>22</mn></mfrac><mo>=</mo><mn>0</mn><mo>.</mo><mn>0</mn><mover><mn>45</mn><mo>_</mo></mover></math>"
+        - "Example: <math display='block'><mfrac><mn>1</mn><mn>22</mn></mfrac><mo>=</mo><mn>0</mn><mo>.</mo><mn>0</mn><mover><mn>45</mn><mo>_</mo></mover></math>"
         - "This right hand side of this might be might be marked up as:"
         - |
           ```

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -664,6 +664,7 @@ concepts:
       arity: 1
       property: function
       en: "sum of $1"
+       - "<math><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='$a1'><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<mrow>`
 
@@ -671,6 +672,8 @@ concepts:
       arity: 2
       property: function
       en: "sum over $1 of $2"
+      mathml:
+       - "<math><mrow intent='sum($a1,$a2)'><munder><mo>∑</mo><mrow arg='$a1'><mi>i</mi><mo>∈</mo><mi>X</mi></mrow></munder><mrow arg='a2'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munder>` or `<msub>`
 
@@ -678,6 +681,7 @@ concepts:
       arity: 3
       property: function
       en: "sum from $1 to $2 of $3"
+       - "<math><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='$a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munderover>` or `<msubsup>`
 

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -664,6 +664,7 @@ concepts:
       arity: 1
       property: function
       en: "sum of $1"
+      mathml:
        - "<math><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='$a1'><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<mrow>`
@@ -681,6 +682,7 @@ concepts:
       arity: 3
       property: function
       en: "sum from $1 to $2 of $3"
+      mathml:
        - "<math><mrow intent='sum($a1,$a2,$a3)'><munderover><mo>∑</mo><mrow arg='$a1'><mi>i</mi><mo>=</mo><mi>a</mi></mrow><mi arg='a2'>b</mi></munderover><mrow arg='a3'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<munderover>` or `<msubsup>`

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -665,7 +665,7 @@ concepts:
       property: function
       en: "sum of $1"
       mathml:
-       - "<math><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='$a1'><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
+       - "<math><mrow intent='sum($a1)'><mo>∑</mo><mrow arg='a1'><mi>f</mi><mo>(</mo><mi>i</mi><mo>)</mo></mrow></mrow></math>"
       comments:
       - usually on `<mrow>`
 

--- a/_data/core.yml
+++ b/_data/core.yml
@@ -210,6 +210,16 @@ defaultfixity:
          characters: [⁢U+2062]
 
 
+largeop:
+  - concept: sum
+    characters: [∑,⅀]  
+  - concept: product
+    characters: [∏,⨉]
+  - concept: union
+    characters: [⋃]
+  - concept: intersection
+    characters: [⋂]
+
 concepts:
 
   ## From chapter 4 of MathML3

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -152,8 +152,7 @@ presentation.
 </tr>
 </thead>
 <tbody>
-{%- for c in site.data.core.concepts.intents -%}
-{%- if c.concept == "sum" %-}
+{%- for c in site.data.core.concepts[3].intents | where: "concept", "sum" -%}
 {%- assign arityr = c.arity | replace: ">=", "⩾" -%}
 {%- assign arityu = c.arity | replace: ">=", "GEQ" -%}
 {%- assign propertyu = c.property | replace: "?", "Q" -%}
@@ -186,8 +185,8 @@ presentation.
 {% endfor %}
 </td>
 </tr>
-{%- endif -%}
 {%- endfor -}
+</table>
 
 
 

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -132,7 +132,7 @@ if c.link
 
 ----
 
-## Core Concept Default Large Operatorss
+## Default Large Operator Concepts
 
 Speech templates for "large" operators follow a similar pattern
 and are often strongly associated with particular characters.

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -152,7 +152,8 @@ presentation.
 </tr>
 </thead>
 <tbody>
-{%- for c in site.data.core.concepts[3].intents | where: "concept", "sum" -%}
+{%- for c in site.data.core.concepts[3].intents -%}
+{%- if c.concept == "sum" -%}
 {%- assign arityr = c.arity | replace: ">=", "⩾" -%}
 {%- assign arityu = c.arity | replace: ">=", "GEQ" -%}
 {%- assign propertyu = c.property | replace: "?", "Q" -%}
@@ -185,6 +186,7 @@ presentation.
 {% endfor %}
 </td>
 </tr>
+%- endif -%}
 {%- endfor -%}
 </tbody>
 </table>

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -154,9 +154,10 @@ presentation.
 <tbody>
 {%- for c in site.data.core.concepts[3].intents | where: "concept", "sum" -%}
 <tr>
-<td>sum</td>
+<td>sum</td><td>a: {{c.arity}}}</td><td>p: {{c.property}}</td>
 </tr>
 {%- endfor -%}
+</tbody>
 </table>
 
 

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -186,7 +186,7 @@ presentation.
 {% endfor %}
 </td>
 </tr>
-%- endif -%}
+{%- endif -%}
 {%- endfor -%}
 </tbody>
 </table>

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -126,7 +126,7 @@ but do have default fixity properties other than `function`.
 
 {%- for fix in site.data.core.defaultfixity -%}
 
-<dt id="{{fix.fixity}}"><b><a href="../intent-core-properties/#{{fix.fixity}}">{{fix.fixity}}</a></b>
+<dt id="{{fix.fixity}}"><b><a href="../intent-core-properties/#prop-{{fix.fixity}}">{{fix.fixity}}</a></b>
 {%- for c in fix.concepts -%}
 <span id="{{c.concept}}"></span> 
 {%- endfor %}
@@ -220,7 +220,7 @@ presentation.
 
 
 <dl>
-<dt id="largeoplist"><a href="../intent-core-properties/#largeop"><b>largeop</b></dt>
+<dt id="largeoplist"><b><a href="../intent-core-properties/#prop-largeop">largeop</a></b></dt>
 <dd>
 {%- for c in site.data.core.largeop -%}
 <a

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -32,14 +32,31 @@ title: Core Concept List
 p.langs {margin:1em; padding:1em;background-color: #EEE}
 tr:target >td:first-child {border-left:solid thick black}
 span.cb {margin-right: 2em; white-space:nowrap}
+.markdown-body table {font-size:85%}
 .markdown-body table tr.row0, .markdown-body table th.row0 {background-color:#F6F8FA}
 .markdown-body table tr.row1 {background-color:#FEFFFE}
 a.link {font-weight:500}
 a.self {color: black; font-weight:500}
+     [arg] { background-color: #ddfafa;}
+     [arg]:hover {display:inline;background-color: #add8e6;}
+     [arg]:hover::after {display:inline;vertical-align: sub; font-size: 0.7em; }
+     [arg="a1"]:hover::after { content: " $1" ; }
+     [arg="a2"]:hover::after { content: " $2" ; }
+     [arg="a3"]:hover::after { content: " $3" ; }
+     [arg="a4"]:hover::after { content: " $4" ; }
+     [arg="a5"]:hover::after { content: " $5" ; }
+     [arg="a6"]:hover::after { content: " $6" ; }
+     [arg="a7"]:hover::after { content: " $7" ; }
+     [arg="a8"]:hover::after { content: " $8" ; }
+     [arg="a9"]:hover::after { content: " $9" ; }
+math:not(:has(*[intent])) {
+    color: red;
+    }
+div.mmlshow {display:inline-block;padding:1em;margin:.5em;border-radius:1em;font-family:monospace;background-color:#EEE;white-space:pre;}
 </style>
 
 <style id="langcss">
-{% for language in site.data.languages offset:2-%}
+{% for language in site.data.languages offset:1-%}
   {%- unless forloop.first %},{% endunless%} *.{{language.language-code}}
 {%- endfor -%}
  {display:none}
@@ -84,6 +101,14 @@ Any concept that does not have a speech template in the specifed language will s
 
 Localised texts can be added to the YAML file:
 [core.yml](https://github.com/w3c/mathml-docs/blob/main/_data/core.yml)
+
+----
+
+<p>
+<button id="b1" type="button" onclick="showmathml()">Show MathML Source</button>
+<button id="b2" type="button" onclick="displaymath()">Display typeset math</button>
+</p>
+
 
 ----
 
@@ -245,7 +270,7 @@ if c.link
  <input
 	onchange="updatelang(this)"
 	type="checkbox"
-	{% if lang == "en" or lang == "fr" %} checked {% endif %}
+	{% if lang == "en" or lang == "Xfr" %} checked {% endif %}
       id="cb-{{lang}}"
       name="language"
       value="{{lang}}" />

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -135,12 +135,66 @@ if c.link
 ## Core Concept Default Large Operatorss
 
 Speech templates for "large" operators follow a similar pattern
-and are often strongly associated with particur characters.
+and are often strongly associated with particular characters.
 They are collected here to give a more convenient and compact
 presentation.
 
-<p>
+<table style="width:100%">
+<thead>
+<tr class="row0">
+<th>Concept</th>
+<th>Arity</th>
+<th>Property</th>
+{%- for language in site.data.languages -%}
+<th class="{{language.language-code}}">Speech Template ({{language.language-code}})</th> 
+{%- endfor -%}
+<th style="width:auto">Comments</th>
+</tr>
+</thead>
+<tbody>
+{%- for c in site.data.core.concepts.intents -%}
+{%- if c.concept == "sum" %-}
+{%- assign arityr = c.arity | replace: ">=", "⩾" -%}
+{%- assign arityu = c.arity | replace: ">=", "GEQ" -%}
+{%- assign propertyu = c.property | replace: "?", "Q" -%}
+<tr id="{{c.concept}}{{arityu}}{{propertyu}}" class="row{{ clss }}">
+<td><a class="self" href="#{{c.concept}}{{arityu}}{{propertyu}}">{{c.concept}}</a></td>
+<td>{{arityr}}</td>
+<td>{{c.property}}{%- unless c.default == false or c.arity == 0-%}*{%- endunless -%}</td>
+{%- for language in site.data.languages -%}
+<td class="{{language.language-code}}">
+{%- if c[language.language-code] -%}
+{%- for l in c[language.language-code] -%}
+{{l}} {%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+{%- else -%}
+{%- for l in c.en -%}
+{{l}} ({{language.language-code}}){%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %} 
+{% endif %}
+</td>
+{%- endfor -%}
+<td style="width:auto">
+{%- for com in c.comments -%}
+{{com | markdownify | replace: "<p>", "<span>" | replace: "</p>", "</span>" }}
+{%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+{%- if c.comments and c.mathml -%}<br>{%- endif -%}
+{%- for mml in c.mathml -%}
+{{mml}}
+{%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+</td>
+</tr>
+{%- endif -%}
+{%- endfor -}
 
+
+
+
+<dl>
+<dt id="largeoplist"><b>Operators</b></dt>
+<dd>
 {%- for c in site.data.core.largeop -%}
 <a
 {%
@@ -159,7 +213,8 @@ if c.link
 )
 {% unless forloop.last -%}, {% endunless -%}
 {%- endfor %}
-</p>
+</dd>
+</dl>
 
 
 

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -126,7 +126,7 @@ but do have default fixity properties other than `function`.
 
 {%- for fix in site.data.core.defaultfixity -%}
 
-<dt id="{{fix.fixity}}"><b>{{fix.fixity}}</b>
+<dt id="{{fix.fixity}}"><b><a href="core-properties#{{fix.fixity}}">{{fix.fixity}}</a></b>
 {%- for c in fix.concepts -%}
 <span id="{{c.concept}}"></span> 
 {%- endfor %}
@@ -220,7 +220,7 @@ presentation.
 
 
 <dl>
-<dt id="largeoplist"><b>Operators</b></dt>
+<dt id="largeoplist"><a href="core-properties#largeop"><b>largeop</b></dt>
 <dd>
 {%- for c in site.data.core.largeop -%}
 <a

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -153,8 +153,37 @@ presentation.
 </thead>
 <tbody>
 {%- for c in site.data.core.concepts[3].intents | where: "concept", "sum" -%}
+{%- assign arityr = c.arity | replace: ">=", "⩾" -%}
+{%- assign arityu = c.arity | replace: ">=", "GEQ" -%}
+{%- assign propertyu = c.property | replace: "?", "Q" -%}
 <tr>
-<td>sum</td><td>a: {{c.arity}}}</td><td>p: {{c.property}}</td>
+<td>{{c.concept}}</td>
+<td>{{c.arityu}}}</td>
+<td>{{c.property}}{%- unless c.default == false or c.arity == 0-%}*{%- endunless -%}</td>
+{%- for language in site.data.languages -%}
+<td class="{{language.language-code}}">
+{%- if c[language.language-code] -%}
+{%- for l in c[language.language-code] -%}
+{{l}} {%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+{%- else -%}
+{%- for l in c.en -%}
+{{l}} ({{language.language-code}}){%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %} 
+{% endif %}
+</td>
+{%- endfor -%}
+<td style="width:auto">
+{%- for com in c.comments -%}
+{{com | markdownify | replace: "<p>", "<span>" | replace: "</p>", "</span>" }}
+{%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+{%- if c.comments and c.mathml -%}<br>{%- endif -%}
+{%- for mml in c.mathml -%}
+{{mml}}
+{%- unless forloop.last -%}<br>{% endunless -%}
+{% endfor %}
+</td>
 </tr>
 {%- endfor -%}
 </tbody>

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -153,39 +153,10 @@ presentation.
 </thead>
 <tbody>
 {%- for c in site.data.core.concepts[3].intents | where: "concept", "sum" -%}
-{%- assign arityr = c.arity | replace: ">=", "⩾" -%}
-{%- assign arityu = c.arity | replace: ">=", "GEQ" -%}
-{%- assign propertyu = c.property | replace: "?", "Q" -%}
-<tr id="{{c.concept}}{{arityu}}{{propertyu}}" class="row{{ clss }}">
-<td><a class="self" href="#{{c.concept}}{{arityu}}{{propertyu}}">{{c.concept}}</a></td>
-<td>{{arityr}}</td>
-<td>{{c.property}}{%- unless c.default == false or c.arity == 0-%}*{%- endunless -%}</td>
-{%- for language in site.data.languages -%}
-<td class="{{language.language-code}}">
-{%- if c[language.language-code] -%}
-{%- for l in c[language.language-code] -%}
-{{l}} {%- unless forloop.last -%}<br>{% endunless -%}
-{% endfor %}
-{%- else -%}
-{%- for l in c.en -%}
-{{l}} ({{language.language-code}}){%- unless forloop.last -%}<br>{% endunless -%}
-{% endfor %} 
-{% endif %}
-</td>
-{%- endfor -%}
-<td style="width:auto">
-{%- for com in c.comments -%}
-{{com | markdownify | replace: "<p>", "<span>" | replace: "</p>", "</span>" }}
-{%- unless forloop.last -%}<br>{% endunless -%}
-{% endfor %}
-{%- if c.comments and c.mathml -%}<br>{%- endif -%}
-{%- for mml in c.mathml -%}
-{{mml}}
-{%- unless forloop.last -%}<br>{% endunless -%}
-{% endfor %}
-</td>
+<tr>
+<td>sum</td>
 </tr>
-{%- endfor -}
+{%- endfor -%}
 </table>
 
 

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -126,7 +126,7 @@ but do have default fixity properties other than `function`.
 
 {%- for fix in site.data.core.defaultfixity -%}
 
-<dt id="{{fix.fixity}}"><b><a href="core-properties#{{fix.fixity}}">{{fix.fixity}}</a></b>
+<dt id="{{fix.fixity}}"><b><a href="../core-properties/#{{fix.fixity}}">{{fix.fixity}}</a></b>
 {%- for c in fix.concepts -%}
 <span id="{{c.concept}}"></span> 
 {%- endfor %}
@@ -220,7 +220,7 @@ presentation.
 
 
 <dl>
-<dt id="largeoplist"><a href="core-properties#largeop"><b>largeop</b></dt>
+<dt id="largeoplist"><a href="../core-properties/#largeop"><b>largeop</b></dt>
 <dd>
 {%- for c in site.data.core.largeop -%}
 <a

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -132,6 +132,39 @@ if c.link
 
 ----
 
+## Core Concept Default Large Operatorss
+
+Speech templates for "large" operators follow a similar pattern
+and are often strongly associated with particur characters.
+They are collected here to give a more convenient and compact
+presentation.
+
+<p>
+
+{%- for c in site.data.core.largeop -%}
+<a
+{%
+if c.link
+-%}
+ href="#{{c.link}}" class="link"
+{%- else -%}
+ href="#{{c.concept}}" class="self"
+{%- endif -%}
+>{{c.concept}}</a> 
+(
+{%- for ch in c.characters -%}
+{{ch}}
+{%- unless forloop.last -%}, {% endunless -%}
+{%- endfor -%}
+)
+{% unless forloop.last -%}, {% endunless -%}
+{%- endfor %}
+</p>
+
+
+
+----
+
 ## Core Concept Templates
 
 

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -159,7 +159,7 @@ presentation.
 {%- assign propertyu = c.property | replace: "?", "Q" -%}
 <tr>
 <td>{{c.concept}}</td>
-<td>{{c.arityu}}}</td>
+<td>{{c.arityu}}</td>
 <td>{{c.property}}{%- unless c.default == false or c.arity == 0-%}*{%- endunless -%}</td>
 {%- for language in site.data.languages -%}
 <td class="{{language.language-code}}">

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -159,7 +159,7 @@ presentation.
 {%- assign propertyu = c.property | replace: "?", "Q" -%}
 <tr>
 <td>{{c.concept}}</td>
-<td>{{c.arityu}}</td>
+<td>{{arityr}}</td>
 <td>{{c.property}}{%- unless c.default == false or c.arity == 0-%}*{%- endunless -%}</td>
 {%- for language in site.data.languages -%}
 <td class="{{language.language-code}}">

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -126,7 +126,7 @@ but do have default fixity properties other than `function`.
 
 {%- for fix in site.data.core.defaultfixity -%}
 
-<dt id="{{fix.fixity}}"><b><a href="../core-properties/#{{fix.fixity}}">{{fix.fixity}}</a></b>
+<dt id="{{fix.fixity}}"><b><a href="../intent-core-properties/#{{fix.fixity}}">{{fix.fixity}}</a></b>
 {%- for c in fix.concepts -%}
 <span id="{{c.concept}}"></span> 
 {%- endfor %}
@@ -220,7 +220,7 @@ presentation.
 
 
 <dl>
-<dt id="largeoplist"><a href="../core-properties/#largeop"><b>largeop</b></dt>
+<dt id="largeoplist"><a href="../intent-core-properties/#largeop"><b>largeop</b></dt>
 <dd>
 {%- for c in site.data.core.largeop -%}
 <a

--- a/intent-core-concepts/index.md
+++ b/intent-core-concepts/index.md
@@ -251,13 +251,6 @@ if c.link
 
 
 
-<p>
-<button id="b1" type="button" onclick="showmathml()">Show MathML Source</button>
-<button id="b2" type="button" onclick="displaymath()">Display typeset math</button>
-</p>
-
-
-
 ----
 
 <details>


### PR DESCRIPTION
This PR addresses issue  https://github.com/w3c/mathml/issues/482

It groups the more common largeop (Unicode n-ary or integral characters) in a style similar to the default fixity list. and now explicitly references `largeop` from the core property list.

Currently it is a separate section although an alternative more compressed layout could be achieved by simply adding `largeop`
to the default fixity section and dropping teh extra wording around it, relying on the link to `largeop` in the core property list for the speech templates.

largeop and the fixity properties are now all links to the core property list.  this highlights the fact that `nofix` as cuuent lused eg for `diameter` https://davidcarlisle.github.io/mathml-docs/intent-core-concepts/#diameter  has no definition.

I'm not sure if `nofix` was intended to be a meta-property implying there is no property applied or if it is intended to be a real property that can be explicitly used (in which case it should be added to core property list).  Currently it makes a broken link.

In order to fit integrals in this `largeop` list I had to increase the arity  so `integral:largeop{f)` is $\int f$ which means the arity one form can't be used for $\int_C$ perhaps we need two properties one that does not expect the summand/integrand so can be used on the munderover and just refer to the "embellished operator"?