### PR TITLE
add plus and full width plus to unicode-speech

### DIFF
--- a/_data/unicode-speech.yml
+++ b/_data/unicode-speech.yml
@@ -1,5 +1,9 @@
 ---
 -
+    - char: +
+    - u: "002B"
+    - t: plus
+-
     - char: ¡
     - u: "00A1"
     - t: inverted exclamation mark
@@ -8014,7 +8018,7 @@
 -
     - char: ＋
     - u: "FF0B"
-    - t: equals sign
+    - t: full width plus
 -
     - char: ＜
     - u: "FF1C"


### PR DESCRIPTION
I spotted a mistake with FF0B, hence the PR.

I am also wondering what the intended coverage of unicode-speech.yml ought to be - I didn't succeed in finding the usual plus sign (002B), and I think there are a number of other missing entries of that nature. Is that by design?