### PR TITLE
add equation-label for w3c/mathml#525

### DIFF
--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -195,8 +195,7 @@
   applicability: mtd
   effect: indicates that the cell does not hold a label.
           This may be used if a table column is being used solely to hold labels
-	  to highlight empty cells for unlabeled rows.
-	  
+          to highlight empty cells for unlabeled rows.
 
 - property: number-set
   type: mathematical-category

--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -184,6 +184,19 @@
   applicability: mtable
   effect: indicates that the table should be read column by column
 
+- property: equation-label
+  type: table
+  applicability: mtd
+  effect: indicates that the cell holds an equation label.
+          This may influence the way the surrounding `mtr` is announced.
+
+- property: no-equation-label
+  type: table
+  applicability: mtd
+  effect: indicates that the cell does not hold a label.
+          This may be used if a table column is being used solely to hold labels
+	  to highlight empty cells for unlabeled rows.
+	  
 
 - property: number-set
   type: mathematical-category


### PR DESCRIPTION
As discussed in w3c/mathml#525 this adds `equation-label` (and `no-equation-label`) properties to identify equation labels in `mtable`.

These properties have been tested with test implementation in LaTeX (for generation) and MathCAT (reading) and greatly improve the reading of aligned math displays.  

Following discussion in the issue, and in WG zoom meetings, the text added by this PR is quite general, it does not constrain the label to be in the first column, or mandate any particular behaviour, it just standardises the property to be available as a way to mark those cells which are labels.

