### PR TITLE
add literal  property

### DIFF
--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -72,7 +72,7 @@
   type: inference
   applicability: all presentation elements
   effect: |
-    Assistive technology should use it's system specified defaults.
+    Assistive technology should use its system specified defaults.
     This is the default behavior if neither the
     [literal property](../literal-common-properties#literal-property)
     nor

--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -68,7 +68,17 @@
     Assistive technology should use the specified `common` defaults.  
     See [common property](../literal-common-properties#common-property)
 
-
+- property: legacy
+  type: inference
+  applicability: all presentation elements
+  effect: |
+    Assistive technology should use it's system specified defaults.
+    This is the default behavior if neither the
+    [literal property](../literal-common-properties#literal-property)
+    nor
+    [common property](../literal-common-properties#common-property)
+    is in effect.
+    See [legacy property](../literal-common-properties#legacy-property)
 
 - property: array
   type: table

--- a/literal-common-properties.md
+++ b/literal-common-properties.md
@@ -31,6 +31,10 @@ The exact words may depend upon both the audience and the children of node. Some
 
 For someone who is blind, it may be important to indicate the start and end of fractions, roots, etc., but for someone with dyslexia, the extra words might be "verbal noise."
 
+If neither `:literal` nor `:common` property is in scope, the default
+behavior, which may be explicitly specified by using the `:legacy`
+property, is system dependent.
+
 
 ## `literal` property
 
@@ -130,3 +134,8 @@ As noted above, a trig function raised to a "-1" power should have special speec
 These are spoken in a special way, although maybe that is just the default way to speak those Unicode characters.
 
 However, adding subscripts and superscripts of various types (e.g., $\mathbb {Z}^2$,  $\mathbb {Z}^+$, and $\mathbb {Z}_2$) often have specialized speech such as "Z 2".
+
+
+## `legacy` property
+
+The behavior of readings when the `:legacy` property is in effect is system dependent. Links to documentation of some known systems may be added here as the information becomes available.


### PR DESCRIPTION
As discussed on the last call, this adds `:legacy` alongside `:common` and `:literal` properties.

Not changed in this PR but the file with the expanded definitions of these properties,

https://w3c.github.io/mathml-docs/literal-common-properties

has lots of TeX such as `$x^2$` which is probably intended to be rendered by MathJax as here $x^2$  but that is only automatic in issues and direct github markdown rendering, as we are using gh-pages and Jekyll we'd need to load it in the page template, or just show the tex as source with backtick markup, or we could use mathml. (mentioning this now as it may come up in review, but can be fixed editorially after this PR is handled)

