### PR TITLE
use-argname property

### DIFF
--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -425,3 +425,18 @@
   examples:
     - mathml: '<math><mi>a</mi><mspace intent=":pause-xlong" width="4cm"/><mi>b</mi></math>'
       en: "a [pause....] b"
+
+- property: use-argname
+  type: argname
+  applicability: all
+  effect: "Used an an element with `arg`, causes the specified `argname` to be used to introduce the argument in speech.
+           May be translated to the current language, or used literally if translation is not known."
+  examples:
+     - mathml: '<mi arg="numerator" intent=":use-argname">x</mi>'
+       en: numerator
+       fr: numérateur
+       de: Zähler
+     - mathml: '<mi arg="denominator" intent=":use-argname">x</mi>'
+       en: denominator
+       fr: dénominateur
+       de: Nenner

--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -440,3 +440,7 @@
        en: denominator
        fr: dénominateur
        de: Nenner
+     - mathml: '<mn arg="base" intent=":use-argname">2</mn>'
+       en: base
+       fr: base
+       de: Basis

--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -429,7 +429,7 @@
 - property: use-argname
   type: argname
   applicability: all
-  effect: "Used as a _self-property_ on an element with `arg`, causes the specified `argname` to be used to introduce the argument in speech.
+  effect: "Used as a _self-property_ on an element with `arg`, causes the value of the `arg` attribute to be used as the name to introduce the argument in speech.
            May be translated to the current language, or used literally if translation is not known."
   examples:
      - mathml: '<mi arg="numerator" intent=":use-argname">x</mi>'

--- a/_data/core-properties.yml
+++ b/_data/core-properties.yml
@@ -429,7 +429,7 @@
 - property: use-argname
   type: argname
   applicability: all
-  effect: "Used an an element with `arg`, causes the specified `argname` to be used to introduce the argument in speech.
+  effect: "Used as a _self-property_ on an element with `arg`, causes the specified `argname` to be used to introduce the argument in speech.
            May be translated to the current language, or used literally if translation is not known."
   examples:
      - mathml: '<mi arg="numerator" intent=":use-argname">x</mi>'
@@ -444,3 +444,11 @@
        en: base
        fr: base
        de: Basis
+     - mathml: '<mrow arg="lower-limit" intent=":use-argname"><mi>i</mi><mo>=</mo><mn>0</mn></mrow>'
+       en: lower-limit
+       fr: "limite à gauche"
+       de: Untergrenze
+     - mathml: '<mi arg="upper-limit" intent=":use-argname">n</mi>'
+       en: upper-limit
+       fr: "limite à droite"
+       de: Obergrenze


### PR DESCRIPTION
This PR addresses issue w3c/mathml#524 if accepted a small change to the main spec to list `use-argname` in the abbreviated list of properties would follow.

This adds `use-argname` to the properties YAML file, with translations of the main core arg names handled by the existing show available languages form at the top of the page, resulting in a display like

<img width="904" height="841" alt="image showing use-argname property definition" src="https://github.com/user-attachments/assets/02349e15-d341-4387-8093-d892b34b675b" />


The page is online at my fork as

https://davidcarlisle.github.io/mathml-docs/intent-core-properties/#prop-use-argname

